### PR TITLE
Feature/env

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,5 @@
 {
-  "extends": "airbnb",
-  "parserOptions": {
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true
-    }
-  },
-  "plugins": [],
+  "extends": "eslint:recommended",
   "rules": {
     "arrow-body-style": 1,
     "func-names": 0
@@ -14,6 +8,12 @@
     "vg": true,
     "d3": true,
     "$": true,
-    "L": true
+    "L": true,
+    "Backbone": true,
+    "handlebars": true,
+    "_": true
   },
+  "env": {
+    "browser": true
+  }
 }

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,15 @@
+rules:
+  property-sort-order:
+    - 2
+  force-element-nesting:
+    - 0
+  no-color-literals:
+    - 2
+    -
+      allow-rgba: true
+  no-url-protocols:
+    - 0
+  nesting-depth:
+    - 2
+    -
+      max-depth: 3

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'active_model_serializers', '~> 0.10.0'
 gem 'handlebars_assets'
 
 # Assets Pipeline
+gem 'autoprefixer-rails'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-d3', '~> 3.5.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   ancestry
   annotate
+  autoprefixer-rails
   bootstrap (~> 4.0.0.alpha3)
   byebug
   ckeditor

--- a/app/assets/stylesheets/browserslist
+++ b/app/assets/stylesheets/browserslist
@@ -1,0 +1,4 @@
+> 1%
+last 2 versions
+Firefox ESR
+Safari >= 8


### PR DESCRIPTION
This PR sets up autoprefixer, sass-lint and eslint. I've added the recommended configuration of eslint and not Airbnb's one because it doesn't support ES5 anymore.

Expect the current (small) code base to have linting errors. You may need to install globally sass-lint and eslint in order to have your text editor detecting it:
> npm install -g sass-lint eslint