### PR TITLE
Adds Airbnb's ES5 configuration for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,12 @@
 {
-  "extends": "eslint:recommended",
+  "extends": "airbnb-base/legacy",
   "rules": {
     "arrow-body-style": 1,
-    "func-names": 0
+    "func-names": 0,
+    "no-new": 0,
+    "no-param-reassign": [2, { "props": false }],
+    "max-len": [2, { "ignoreComments": true }],
+    "vars-on-top": 0
   },
   "globals": {
     "vg": true,

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -23,8 +23,7 @@
 // = require_tree ./views/admin
 // = require dispatcher
 
-(function() {
-
+(function () {
   'use strict';
 
   this.App = {
@@ -34,5 +33,4 @@
     Router: {},
     Helper: {}
   };
-
 }).call(this);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,8 +27,7 @@
 // = require_tree ./views/home
 // = require dispatcher
 
-(function() {
-
+(function () {
   'use strict';
 
   this.App = {
@@ -38,5 +37,4 @@
     Router: {},
     Helper: {}
   };
-
 }).call(this);

--- a/app/assets/javascripts/dispatcher.js
+++ b/app/assets/javascripts/dispatcher.js
@@ -1,5 +1,4 @@
-(function(App) {
-
+(function (App) {
   'use strict';
 
   var Dispatcher = Backbone.Router.extend({
@@ -13,18 +12,17 @@
 
   var dispatcher = new Dispatcher();
 
-  dispatcher.on('route', function(routeName) {
+  dispatcher.on('route', function (routeName) {
     Backbone.history.stop();
     var Router = App.Router[routeName];
 
     if (Router) {
       new Router();
 
-      Backbone.history.start({pushState: false});
+      Backbone.history.start({ pushState: false });
     }
   });
 
   // We need this to detect router pathname
   Backbone.history.start({ pushState: true });
-
 }).call(this, this.App);

--- a/app/assets/javascripts/management.js
+++ b/app/assets/javascripts/management.js
@@ -24,8 +24,7 @@
 // = require_tree ./views/management
 // = require dispatcher
 
-(function() {
-
+(function () {
   'use strict';
 
   this.App = {
@@ -35,5 +34,4 @@
     Router: {},
     Helper: {}
   };
-
 }).call(this);

--- a/app/assets/javascripts/routers/AdminRouter.js
+++ b/app/assets/javascripts/routers/AdminRouter.js
@@ -1,6 +1,4 @@
-
-(function(App) {
-
+((function (App) {
   'use strict';
 
   App.Router.Admin = Backbone.Router.extend({
@@ -9,12 +7,11 @@
       '(/)': 'index'
     },
 
-    index: function() {
+    index: function () {
       console.info('You are at admin page');
 
       new App.View.AdminView();
     }
 
   });
-
-})(this.App);
+})(this.App));

--- a/app/assets/javascripts/routers/ManagementRouter.js
+++ b/app/assets/javascripts/routers/ManagementRouter.js
@@ -1,6 +1,4 @@
-
-(function(App) {
-
+((function (App) {
   'use strict';
 
   App.Router.Management = Backbone.Router.extend({
@@ -9,12 +7,11 @@
       '(/)': 'index'
     },
 
-    index: function() {
+    index: function () {
       console.info('You are at management page (index)');
 
       new App.View.ManagementView();
     }
 
   });
-
-})(this.App);
+})(this.App));

--- a/app/assets/javascripts/views/admin/adminView.js
+++ b/app/assets/javascripts/views/admin/adminView.js
@@ -1,14 +1,11 @@
-
-(function(App) {
-
+((function (App) {
   'use strict';
 
   App.View.AdminView = Backbone.View.extend({
 
-    initialize: function() {
+    initialize: function () {
       console.info('adminview initialized');
     }
 
   });
-
-})(this.App);
+})(this.App));

--- a/app/assets/javascripts/views/home/homeView.js
+++ b/app/assets/javascripts/views/home/homeView.js
@@ -1,16 +1,13 @@
-
-(function(App) {
-
+((function (App) {
   'use strict';
 
   App.View.HomeView = Backbone.View.extend({
 
-    initialize: function() {
+    initialize: function () {
       console.info('homeview initialized');
     }
 
   });
 
   new App.View.HomeView();
-
-})(this.App);
+})(this.App));

--- a/app/assets/javascripts/views/management/managementView.js
+++ b/app/assets/javascripts/views/management/managementView.js
@@ -1,14 +1,11 @@
-
-(function(App) {
-
+((function (App) {
   'use strict';
 
   App.View.ManagementView = Backbone.View.extend({
 
-    initialize: function() {
+    initialize: function () {
       console.info('managementview initialized');
     }
 
   });
-
-})(this.App);
+})(this.App));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "forest-atlas-landscape-cms",
+  "version": "1.0.0",
+  "description": "[![Build Status](https://travis-ci.org/Vizzuality/forest-atlas-landscape-cms.svg?branch=master)](https://travis-ci.org/Vizzuality/forest-atlas-landscape-cms)",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Vizzuality/forest-atlas-landscape-cms.git"
+  },
+  "author": "Vizzuality <hello@vizzuality.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Vizzuality/forest-atlas-landscape-cms/issues"
+  },
+  "homepage": "https://github.com/Vizzuality/forest-atlas-landscape-cms#readme",
+  "devDependencies": {
+    "eslint": "^3.3.1",
+    "eslint-config-airbnb-base": "^5.0.3",
+    "eslint-plugin-import": "^1.14.0"
+  }
+}


### PR DESCRIPTION
At first, I was unable to configure eslint to use [Airbnb's ES5 configuration](https://www.npmjs.com/package/eslint-config-airbnb-base) but I finally managed to add it. The main reason of this PR is that the eslint's recommended configuration is too permissive and doesn't check much.

I've updated the current code so only warnings are left due to the `console.log` statements which will be removed in the future.