### PR TITLE
Feature/improved tabs

### DIFF
--- a/app/assets/javascripts/routers/management/PagesRouter.js
+++ b/app/assets/javascripts/routers/management/PagesRouter.js
@@ -16,6 +16,18 @@
       new App.View.SiteSwitcherView({
         el: $('.js-site-switcher')
       });
+
+      // We initialize the tabs
+      new App.View.TabView({
+        el: $('.js-tabs'),
+        redirect: true,
+        currentTab: 1,
+        tabs: [
+          { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
+          { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+        ]
+      });
     }
 
   });

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -17,6 +17,18 @@
         el: $('.js-site-switcher'),
         urlFormat: '/management/sites/:slug/structure'
       });
+
+      // We initialize the tabs
+      new App.View.TabView({
+        el: $('.js-tabs'),
+        redirect: true,
+        currentTab: 0,
+        tabs: [
+          { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
+          { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+        ]
+      });
     }
 
   });

--- a/app/assets/javascripts/routers/management/WidgetsRouter.js
+++ b/app/assets/javascripts/routers/management/WidgetsRouter.js
@@ -17,6 +17,18 @@
         el: $('.js-site-switcher'),
         urlFormat: '/management/sites/:slug/widgets'
       });
+
+      // We initialize the tabs
+      new App.View.TabView({
+        el: $('.js-tabs'),
+        redirect: true,
+        currentTab: 2,
+        tabs: [
+          { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
+          { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+        ]
+      });
     }
 
   });

--- a/app/assets/javascripts/templates/shared/tabs.hbs
+++ b/app/assets/javascripts/templates/shared/tabs.hbs
@@ -1,3 +1,5 @@
-{{#each tabs}}
-  <li class="tab" role="tab" aria-controls="{{id}}">{{name}}</li>
-{{/each}}
+<ul class="c-tabs">
+  {{#each tabs}}
+    <li class="tab" role="tab" {{#if id}}aria-controls="{{id}}"{{/if}}>{{name}}</li>
+  {{/each}}
+</ul>

--- a/app/assets/stylesheets/components/shared/c-tabs.scss
+++ b/app/assets/stylesheets/components/shared/c-tabs.scss
@@ -3,8 +3,17 @@
   justify-content: center;
   height: 50px;
   margin: 0;
+  padding: 0 $wrapper-mobile-padding;
   background-color: $color-1;
   list-style: none;
+
+  @media #{$mq-mobile} {
+    padding: 0 $wrapper-tablet-padding;
+  }
+
+  @media #{$mq-tablet} {
+    padding: 0 $wrapper-padding;
+  }
 
   > .tab {
     width: 200px;

--- a/app/views/management/_header.html.erb
+++ b/app/views/management/_header.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-dark bg-inverse" style="margin-bottom: 20px;">
+<nav class="navbar navbar-dark bg-inverse">
   <button class="navbar-toggler hidden-sm-up" type="button" data-toggle="collapse" data-target="#exCollapsingNavbar2">
     &#9776;
   </button>

--- a/app/views/management/site_pages/index.html.erb
+++ b/app/views/management/site_pages/index.html.erb
@@ -1,3 +1,4 @@
+<div class="js-tabs"></div>
 <div class="wrapper">
   <h1>Pages</h1>
 

--- a/app/views/management/sites/structure.html.erb
+++ b/app/views/management/sites/structure.html.erb
@@ -1,29 +1,32 @@
-<h1>Structure</h1>
+<div class="js-tabs"></div>
+<div class="wrapper">
+  <h1>Structure</h1>
 
-<table class="table table-bordered">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Site</th>
-    <th>URL</th>
-    <th colspan="3"></th>
-  </tr>
-  </thead>
+  <table class="table table-bordered">
+    <thead>
+    <tr>
+      <th>Name</th>
+      <th>Site</th>
+      <th>URL</th>
+      <th colspan="3"></th>
+    </tr>
+    </thead>
 
-  <tbody>
-  <% @pages.each do |site_page| %>
-      <tr>
-        <td><%= site_page.name %></td>
-        <td><%= site_page.site.name %></td>
-        <td><%= site_page.url %></td>
-        <td><%= link_to 'Show', management_site_page_path(site_page) %></td>
-        <td><%= link_to 'Edit', edit_management_site_page_path(site_page) %></td>
-        <td><%= link_to 'Destroy', management_site_page_path(site_page), method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-  <% end %>
-  </tbody>
-</table>
+    <tbody>
+    <% @pages.each do |site_page| %>
+        <tr>
+          <td><%= site_page.name %></td>
+          <td><%= site_page.site.name %></td>
+          <td><%= site_page.url %></td>
+          <td><%= link_to 'Show', management_site_page_path(site_page) %></td>
+          <td><%= link_to 'Edit', edit_management_site_page_path(site_page) %></td>
+          <td><%= link_to 'Destroy', management_site_page_path(site_page), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        </tr>
+    <% end %>
+    </tbody>
+  </table>
 
-<br>
+  <br>
 
-<%= link_to 'New Page', management_site_site_pages_path, class: 'btn btn-primary' %>
+  <%= link_to 'New Page', management_site_site_pages_path, class: 'btn btn-primary' %>
+</div>


### PR DESCRIPTION
**This PR should be merged after #31** (because it's based on it).

It modifies the tabs so they can handle links towards other pages. The tabs can now handle two types of data:
* if the parameters `tabs` is an array of objects containing HTML ids *and* the parameter `redirect` is let to `false`, then the component triggers an event each time the active tab is changed
* if the array contains urls *and* the parameter `redirect` is set to `true`, then when switching from a tab to another, the user will be redirected to said url of the active tab (using [Turbolinks](https://github.com/turbolinks/turbolinks))

When the component is used with URLs, the tabs aren't HTML links because of accessibility features letting the user know the component is a tab switcher and letting the user use their keyboard to switch the active tab.