### PR TITLE
Brings modifications to the public sites

### DIFF
--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -9,6 +9,10 @@
     var routerName = 'Front' + window.route;
 
     if (App.Router[routerName]) {
+      // Because turbolinks doesn't fully reload the page, we need to stop the
+      // history before anything else
+      Backbone.history.stop();
+
       new App.Router[routerName]();
 
       // We can still use the hash to store the state

--- a/app/assets/stylesheets/components/front/c-content.scss
+++ b/app/assets/stylesheets/components/front/c-content.scss
@@ -80,12 +80,14 @@
   }
 
   .image {
+    display: block;
     width: 100%;
     height: auto;
     margin: 35px 0 50px;
+    max-width: $media-max-width;
 
     @media #{$mq-mobile} {
-      margin: 65px 0 80px;
+      margin: 65px auto 80px;
     }
   }
 }

--- a/app/assets/stylesheets/components/front/c-cover.scss
+++ b/app/assets/stylesheets/components/front/c-cover.scss
@@ -4,7 +4,7 @@
   position: relative;
   align-items: center;
   justify-content: center;
-  padding: 30px 0;
+  padding: 50px 0 30px 0;
   // image sample. This property should be injected through javascript
   background-image: asset-url('cover.jpg');
   background-repeat: no-repeat;

--- a/app/assets/stylesheets/front/_base-theme-2.scss
+++ b/app/assets/stylesheets/front/_base-theme-2.scss
@@ -40,7 +40,7 @@ ul {
 }
 
 a {
-  display: inline-block;
+  // Do not set inline-block here otherwise the links will be forced to be on online line
   padding: 0 3px;
   color: currentColor;
   text-decoration: none;

--- a/app/assets/stylesheets/front/_settings-theme-1.scss
+++ b/app/assets/stylesheets/front/_settings-theme-1.scss
@@ -65,7 +65,8 @@ $color-9:  #eceaea;
 // General layout
 $body-max-width:         1280px;
 $content-max-width:       750px;
-$wrapper-padding:          80px;
+$media-max-width:        1060px;
+$wrapper-padding:          30px;
 $wrapper-tablet-padding:   30px;
 $wrapper-mobile-padding:   15px;
 

--- a/app/assets/stylesheets/front/_settings-theme-2.scss
+++ b/app/assets/stylesheets/front/_settings-theme-2.scss
@@ -48,7 +48,8 @@ $color-9:  #eceaea;
 // General layout
 $body-max-width:         1280px;
 $content-max-width:       750px;
-$wrapper-padding:          80px;
+$media-max-width:        1060px;
+$wrapper-padding:          30px;
 $wrapper-tablet-padding:   30px;
 $wrapper-mobile-padding:   15px;
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <title><%= ForestAtlasLandscapeCms::Application.config.site_name %></title>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <%= stylesheet_link_tag 'front/application-theme-1', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= stylesheet_link_tag 'front/application-theme-2', media: 'all', 'data-turbolinks-track': 'reload' %>
 
 </head>
 


### PR DESCRIPTION
The PR makes some changes to the public websites due to design changes or visual/functional issues.

Here's the full list of changes:
* Reduces the padding of the wrapper on desktop (according to the new visuals)
* Reduces the max-size of the images (to match the design)
* Removes the `display: inline-block;` property on the links of theme 2 because it would prevent them to break on a new line
* On mobile, increases the top padding of the cover component to have more space with the breadcrumbs
* Fixes an issue with the routers where the JS wouldn't execute due to another running instance of `Backbone.History`