### PR TITLE
Feature/wysiwyg improvements

### DIFF
--- a/app/assets/javascripts/blocks/imageBlock.js
+++ b/app/assets/javascripts/blocks/imageBlock.js
@@ -1,0 +1,84 @@
+((function () {
+  'use strict';
+
+  SirTrevor.Blocks.Image = SirTrevor.Block.extend({
+
+    type: 'image',
+    icon_name: 'image',
+    droppable: true,
+    uploadable: true,
+
+    validFileTypes: ['jpg', 'jpeg', 'png', 'gif'],
+
+    /**
+     * Return true if the type is valid
+     * @param {string} type
+     * @returns {boolean}
+     */
+    isValidFileType: function (type) {
+      var extension = type.match(/image\/(.+)$/);
+      return extension && extension.length && this.validFileTypes.indexOf(extension[1]) !== -1;
+    },
+
+    getContent: function () {
+      return this.inner.querySelector('.js-content');
+    },
+
+    /**
+     * Hide the interface to upload an image, and display the image passed as argument
+     * @param {string} base64 base64 string representing the image
+     */
+    displayImage: function (base64) {
+      this.editor.innerHTML = '<img src="' + base64 + '" class="image" />';
+      this.inputs.style.display = 'none';
+      this.editor.style.display = 'block';
+    },
+
+    onDrop: function (input) {
+      var file = input.files[0];
+
+      if (!file) return;
+
+      if (!this.isValidFileType(file.type)) {
+        // eslint-disable-next-line no-alert
+        this.addMessage('Only the following file types are accepted: ' + this.validFileTypes.join(', '));
+        return;
+      }
+
+      this.loading();
+
+      var reader = new FileReader();
+
+      reader.addEventListener('load', function () {
+        this.displayImage(reader.result);
+        this.ready();
+      }.bind(this));
+
+      reader.addEventListener('error', function () {
+        this.addMessage('Unable to load the image');
+      }.bind(this));
+
+      reader.readAsDataURL(file);
+    },
+
+    loadData: function (data) {
+      this.editor.innerHTML = data.text;
+    },
+
+    _serializeData: function () {
+      return {
+        format: 'html',
+        text: this.editor.innerHTML
+      };
+    },
+
+    toggleEmptyClass: function () {
+      this.getContent().classList.toggle('-empty', this.isEmpty());
+    },
+
+    isEmpty: function () {
+      return true;
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/blocks/introductionBlock.js
+++ b/app/assets/javascripts/blocks/introductionBlock.js
@@ -129,7 +129,7 @@
 
     type: 'introduction',
     icon_name: 'text',
-    template: '<p class="st-text-block paragrapg -intro -empty js-content" contenteditable="true"></p>',
+    template: '<p class="st-text-block paragraph -intro -empty js-content" contenteditable="true"></p>',
     // By making the block textable, we can navigate to the one below by pressing the bottom key
     textable: true,
 

--- a/app/assets/javascripts/blocks/introductionBlock.js
+++ b/app/assets/javascripts/blocks/introductionBlock.js
@@ -1,0 +1,181 @@
+((function () {
+  'use strict';
+
+  // Definitions of the key codes
+  var BACKSPACE_KEY = 8;
+  var ENTER_KEY = 13;
+  var LEFT_ARROW_KEY = 37;
+  var TOP_ARROW_KEY = 38;
+  var RIGHT_ARROW_KEY = 39;
+  var BOTTOM_ARROW_KEY = 40;
+
+  var ScribePlugin = function (block) {
+    return function (scribe) {
+      // Mostly borrowed there: https://github.com/madebymany/sir-trevor-js/blob/b28af9e608b736ed495944df94ad54eec55c9d06/src/blocks/scribe-plugins/scribe-text-block-plugin.js
+      var isAtStart = false;
+
+      var getTotalLength = function () {
+        var selection = new scribe.api.Selection();
+        var range = selection.range.cloneRange();
+        range.selectNodeContents(scribe.el);
+
+        return range.toString().length;
+      };
+
+      // Remove any empty elements at the start of the range.
+      var stripFirstEmptyElement = function (div) {
+        if (div.firstChild === null) { return; }
+
+        var firstChild = div.firstChild.childNodes[0];
+        if (firstChild && firstChild.nodeName !== '#text') {
+          if (firstChild.innerText === '') {
+            div.firstChild.removeChild(firstChild);
+          }
+        }
+      };
+
+      var rangeToHTML = function (range, extract) {
+        var div = document.createElement('div');
+        if (extract) {
+          div.appendChild(range.extractContents());
+        } else {
+          div.appendChild(range.cloneContents());
+        }
+
+        stripFirstEmptyElement(div);
+
+        // Sometimes you'll get an empty tag at the start of the block.
+        if (div.firstChild && div.firstChild.nodeName !== '#text') {
+          div = div.lastChild;
+        }
+
+        return div.innerHTML.trim();
+      };
+
+      var isAtStartOfBlock = function () {
+        if (scribe.getTextContent() === '') { return true; }
+
+        var selection = new scribe.api.Selection();
+        var range = selection.range.cloneRange();
+
+        range.setStartBefore(scribe.el.firstChild, 0);
+
+        return rangeToHTML(range, false) === '';
+      };
+
+      var isAtEndOfBlock = function () {
+        var currentRange = {};
+
+        // This bit comes from here: https://github.com/bmcmahen/selection-range/blob/master/index.js
+        var selection = window.getSelection();
+        var range = selection.getRangeAt(0);
+        var clone = range.cloneRange();
+        clone.selectNodeContents(scribe.el);
+        clone.setEnd(range.endContainer, range.endOffset);
+        currentRange.end = clone.toString().length;
+        clone.setStart(range.startContainer, range.startOffset);
+        currentRange.start = currentRange.end - clone.toString().length;
+
+        return (getTotalLength() === currentRange.end) && (currentRange.start === currentRange.end);
+      };
+
+      scribe.el.addEventListener('keydown', function (e) {
+        if (block.supressKeyListeners) {
+          return;
+        }
+
+        if (e.keyCode === ENTER_KEY && !e.shiftKey) {
+          e.preventDefault();
+
+          if (isAtEndOfBlock()) {
+            block.mediator.trigger('block:create', 'Text', null, block.el);
+
+            // We remove the extra <br> appended to the end of the element
+            var content = scribe.getHTML();
+            content = scribe.getHTML().replace(/(<br>)+$/, '');
+            scribe.setContent(content);
+          }
+        } else if ((e.keyCode === LEFT_ARROW_KEY || e.keyCode === TOP_ARROW_KEY) && isAtStartOfBlock()) {
+          e.preventDefault();
+          block.mediator.trigger('block:focusPrevious', block.blockID);
+        } else if (e.keyCode === BACKSPACE_KEY && isAtStartOfBlock()) {
+          e.preventDefault();
+          isAtStart = true;
+        } else if ((e.keyCode === RIGHT_ARROW_KEY || e.keyCode === BOTTOM_ARROW_KEY) && isAtEndOfBlock()) {
+          e.preventDefault();
+          block.mediator.trigger('block:focusNext', block.blockID);
+        }
+      });
+
+      scribe.el.addEventListener('keyup', function (e) {
+        if (block.supressKeyListeners) {
+          return;
+        }
+
+        if (e.keyCode === BACKSPACE_KEY && isAtStart) {
+          e.preventDefault();
+
+          block.mediator.trigger('block:remove', block.blockID, {
+            transposeContent: true
+          });
+
+          isAtStart = false;
+        }
+      });
+    };
+  };
+
+  SirTrevor.Blocks.Introduction = SirTrevor.Block.extend({
+
+    type: 'introduction',
+    icon_name: 'text',
+    template: '<p class="st-text-block paragrapg -intro -empty js-content" contenteditable="true"></p>',
+    // By making the block textable, we can navigate to the one below by pressing the bottom key
+    textable: true,
+
+    scribeOptions: {
+      // When the user press the enter key, we don't want to create a new div but insert a
+      // <br> tag instead
+      allowBlockElements: false
+    },
+
+    configureScribe: function (scribe) {
+      scribe.use(new ScribePlugin(this));
+
+      scribe.on('content-changed', this.toggleEmptyClass.bind(this));
+    },
+
+
+    editorHTML: function () {
+      return this.template;
+    },
+
+    getContent: function () {
+      return this.inner.querySelector('.js-content');
+    },
+
+    loadData: function (data) {
+      this.getContent().innerHTML = SirTrevor.toHTML(data.text, this.type);
+    },
+
+    _serializeData: function () {
+      return {
+        format: 'html',
+        text: '<p class="paragraph -intro">' + this.getContent().innerHTML + '</p>'
+      };
+    },
+
+    onBlockRender: function () {
+      this.getContent().focus();
+    },
+
+    toggleEmptyClass: function () {
+      this.getContent().classList.toggle('-empty', this.isEmpty());
+    },
+
+    isEmpty: function () {
+      return this._scribe.getTextContent() === '';
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/blocks/quoteBlock.js
+++ b/app/assets/javascripts/blocks/quoteBlock.js
@@ -1,0 +1,181 @@
+((function () {
+  'use strict';
+
+  // Definitions of the key codes
+  var BACKSPACE_KEY = 8;
+  var ENTER_KEY = 13;
+  var LEFT_ARROW_KEY = 37;
+  var TOP_ARROW_KEY = 38;
+  var RIGHT_ARROW_KEY = 39;
+  var BOTTOM_ARROW_KEY = 40;
+
+  var ScribePlugin = function (block) {
+    return function (scribe) {
+      // Mostly borrowed there: https://github.com/madebymany/sir-trevor-js/blob/b28af9e608b736ed495944df94ad54eec55c9d06/src/blocks/scribe-plugins/scribe-text-block-plugin.js
+      var isAtStart = false;
+
+      var getTotalLength = function () {
+        var selection = new scribe.api.Selection();
+        var range = selection.range.cloneRange();
+        range.selectNodeContents(scribe.el);
+
+        return range.toString().length;
+      };
+
+      // Remove any empty elements at the start of the range.
+      var stripFirstEmptyElement = function (div) {
+        if (div.firstChild === null) { return; }
+
+        var firstChild = div.firstChild.childNodes[0];
+        if (firstChild && firstChild.nodeName !== '#text') {
+          if (firstChild.innerText === '') {
+            div.firstChild.removeChild(firstChild);
+          }
+        }
+      };
+
+      var rangeToHTML = function (range, extract) {
+        var div = document.createElement('div');
+        if (extract) {
+          div.appendChild(range.extractContents());
+        } else {
+          div.appendChild(range.cloneContents());
+        }
+
+        stripFirstEmptyElement(div);
+
+        // Sometimes you'll get an empty tag at the start of the block.
+        if (div.firstChild && div.firstChild.nodeName !== '#text') {
+          div = div.lastChild;
+        }
+
+        return div.innerHTML.trim();
+      };
+
+      var isAtStartOfBlock = function () {
+        if (scribe.getTextContent() === '') { return true; }
+
+        var selection = new scribe.api.Selection();
+        var range = selection.range.cloneRange();
+
+        range.setStartBefore(scribe.el.firstChild, 0);
+
+        return rangeToHTML(range, false) === '';
+      };
+
+      var isAtEndOfBlock = function () {
+        var currentRange = {};
+
+        // This bit comes from here: https://github.com/bmcmahen/selection-range/blob/master/index.js
+        var selection = window.getSelection();
+        var range = selection.getRangeAt(0);
+        var clone = range.cloneRange();
+        clone.selectNodeContents(scribe.el);
+        clone.setEnd(range.endContainer, range.endOffset);
+        currentRange.end = clone.toString().length;
+        clone.setStart(range.startContainer, range.startOffset);
+        currentRange.start = currentRange.end - clone.toString().length;
+
+        return (getTotalLength() === currentRange.end) && (currentRange.start === currentRange.end);
+      };
+
+      scribe.el.addEventListener('keydown', function (e) {
+        if (block.supressKeyListeners) {
+          return;
+        }
+
+        if (e.keyCode === ENTER_KEY && !e.shiftKey) {
+          e.preventDefault();
+
+          if (isAtEndOfBlock()) {
+            block.mediator.trigger('block:create', 'Text', null, block.el);
+
+            // We remove the extra <br> appended to the end of the element
+            var content = scribe.getHTML();
+            content = scribe.getHTML().replace(/(<br>)+$/, '');
+            scribe.setContent(content);
+          }
+        } else if ((e.keyCode === LEFT_ARROW_KEY || e.keyCode === TOP_ARROW_KEY) && isAtStartOfBlock()) {
+          e.preventDefault();
+          block.mediator.trigger('block:focusPrevious', block.blockID);
+        } else if (e.keyCode === BACKSPACE_KEY && isAtStartOfBlock()) {
+          e.preventDefault();
+          isAtStart = true;
+        } else if ((e.keyCode === RIGHT_ARROW_KEY || e.keyCode === BOTTOM_ARROW_KEY) && isAtEndOfBlock()) {
+          e.preventDefault();
+          block.mediator.trigger('block:focusNext', block.blockID);
+        }
+      });
+
+      scribe.el.addEventListener('keyup', function (e) {
+        if (block.supressKeyListeners) {
+          return;
+        }
+
+        if (e.keyCode === BACKSPACE_KEY && isAtStart) {
+          e.preventDefault();
+
+          block.mediator.trigger('block:remove', block.blockID, {
+            transposeContent: true
+          });
+
+          isAtStart = false;
+        }
+      });
+    };
+  };
+
+  SirTrevor.Blocks.Quote = SirTrevor.Block.extend({
+
+    type: 'quote',
+    icon_name: 'quote',
+    template: '<blockquote class="st-text-block quote -empty js-content" contenteditable="true"></blockquote>',
+    // By making the block textable, we can navigate to the one below by pressing the bottom key
+    textable: true,
+
+    scribeOptions: {
+      // When the user press the enter key, we don't want to create a new div but insert a
+      // <br> tag instead
+      allowBlockElements: false
+    },
+
+    configureScribe: function (scribe) {
+      scribe.use(new ScribePlugin(this));
+
+      scribe.on('content-changed', this.toggleEmptyClass.bind(this));
+    },
+
+
+    editorHTML: function () {
+      return this.template;
+    },
+
+    getContent: function () {
+      return this.inner.querySelector('.js-content');
+    },
+
+    loadData: function (data) {
+      this.getContent().innerHTML = SirTrevor.toHTML(data.text, this.type);
+    },
+
+    _serializeData: function () {
+      return {
+        format: 'html',
+        text: '<blockquote class="quote">' + this._scribe.getContent() + '</blockquote>'
+      };
+    },
+
+    onBlockRender: function () {
+      this.getContent().focus();
+    },
+
+    toggleEmptyClass: function () {
+      this.getContent().classList.toggle('-empty', this.isEmpty());
+    },
+
+    isEmpty: function () {
+      return this._scribe.getTextContent() === '';
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/blocks/titleBlock.js
+++ b/app/assets/javascripts/blocks/titleBlock.js
@@ -1,0 +1,181 @@
+((function () {
+  'use strict';
+
+  // Definitions of the key codes
+  var BACKSPACE_KEY = 8;
+  var ENTER_KEY = 13;
+  var LEFT_ARROW_KEY = 37;
+  var TOP_ARROW_KEY = 38;
+  var RIGHT_ARROW_KEY = 39;
+  var BOTTOM_ARROW_KEY = 40;
+
+  var ScribePlugin = function (block) {
+    return function (scribe) {
+      // Mostly borrowed there: https://github.com/madebymany/sir-trevor-js/blob/b28af9e608b736ed495944df94ad54eec55c9d06/src/blocks/scribe-plugins/scribe-text-block-plugin.js
+      var isAtStart = false;
+
+      var getTotalLength = function () {
+        var selection = new scribe.api.Selection();
+        var range = selection.range.cloneRange();
+        range.selectNodeContents(scribe.el);
+
+        return range.toString().length;
+      };
+
+      // Remove any empty elements at the start of the range.
+      var stripFirstEmptyElement = function (div) {
+        if (div.firstChild === null) { return; }
+
+        var firstChild = div.firstChild.childNodes[0];
+        if (firstChild && firstChild.nodeName !== '#text') {
+          if (firstChild.innerText === '') {
+            div.firstChild.removeChild(firstChild);
+          }
+        }
+      };
+
+      var rangeToHTML = function (range, extract) {
+        var div = document.createElement('div');
+        if (extract) {
+          div.appendChild(range.extractContents());
+        } else {
+          div.appendChild(range.cloneContents());
+        }
+
+        stripFirstEmptyElement(div);
+
+        // Sometimes you'll get an empty tag at the start of the block.
+        if (div.firstChild && div.firstChild.nodeName !== '#text') {
+          div = div.lastChild;
+        }
+
+        return div.innerHTML.trim();
+      };
+
+      var isAtStartOfBlock = function () {
+        if (scribe.getTextContent() === '') { return true; }
+
+        var selection = new scribe.api.Selection();
+        var range = selection.range.cloneRange();
+
+        range.setStartBefore(scribe.el.firstChild, 0);
+
+        return rangeToHTML(range, false) === '';
+      };
+
+      var isAtEndOfBlock = function () {
+        var currentRange = {};
+
+        // This bit comes from here: https://github.com/bmcmahen/selection-range/blob/master/index.js
+        var selection = window.getSelection();
+        var range = selection.getRangeAt(0);
+        var clone = range.cloneRange();
+        clone.selectNodeContents(scribe.el);
+        clone.setEnd(range.endContainer, range.endOffset);
+        currentRange.end = clone.toString().length;
+        clone.setStart(range.startContainer, range.startOffset);
+        currentRange.start = currentRange.end - clone.toString().length;
+
+        return (getTotalLength() === currentRange.end) && (currentRange.start === currentRange.end);
+      };
+
+      scribe.el.addEventListener('keydown', function (e) {
+        if (block.supressKeyListeners) {
+          return;
+        }
+
+        if (e.keyCode === ENTER_KEY && !e.shiftKey) {
+          e.preventDefault();
+
+          if (isAtEndOfBlock()) {
+            block.mediator.trigger('block:create', 'Text', null, block.el);
+
+            // We remove the extra <br> appended to the end of the element
+            var content = scribe.getHTML();
+            content = scribe.getHTML().replace(/(<br>)+$/, '');
+            scribe.setContent(content);
+          }
+        } else if ((e.keyCode === LEFT_ARROW_KEY || e.keyCode === TOP_ARROW_KEY) && isAtStartOfBlock()) {
+          e.preventDefault();
+          block.mediator.trigger('block:focusPrevious', block.blockID);
+        } else if (e.keyCode === BACKSPACE_KEY && isAtStartOfBlock()) {
+          e.preventDefault();
+          isAtStart = true;
+        } else if ((e.keyCode === RIGHT_ARROW_KEY || e.keyCode === BOTTOM_ARROW_KEY) && isAtEndOfBlock()) {
+          e.preventDefault();
+          block.mediator.trigger('block:focusNext', block.blockID);
+        }
+      });
+
+      scribe.el.addEventListener('keyup', function (e) {
+        if (block.supressKeyListeners) {
+          return;
+        }
+
+        if (e.keyCode === BACKSPACE_KEY && isAtStart) {
+          e.preventDefault();
+
+          block.mediator.trigger('block:remove', block.blockID, {
+            transposeContent: true
+          });
+
+          isAtStart = false;
+        }
+      });
+    };
+  };
+
+  SirTrevor.Blocks.Title = SirTrevor.Block.extend({
+
+    type: 'title',
+    icon_name: 'heading',
+    template: '<h3 class="st-text-block content-title -empty js-content" contenteditable="true"></h3>',
+    // By making the block textable, we can navigate to the one below by pressing the bottom key
+    textable: true,
+
+    scribeOptions: {
+      // When the user press the enter key, we don't want to create a new div but insert a
+      // <br> tag instead
+      allowBlockElements: false
+    },
+
+    configureScribe: function (scribe) {
+      scribe.use(new ScribePlugin(this));
+
+      scribe.on('content-changed', this.toggleEmptyClass.bind(this));
+    },
+
+
+    editorHTML: function () {
+      return this.template;
+    },
+
+    getContent: function () {
+      return this.inner.querySelector('.js-content');
+    },
+
+    loadData: function (data) {
+      this.getContent().innerHTML = SirTrevor.toHTML(data.text, this.type);
+    },
+
+    _serializeData: function () {
+      return {
+        format: 'html',
+        text: '<h3 class="content-title">' + this.getContent().innerHTML + '</h3>'
+      };
+    },
+
+    onBlockRender: function () {
+      this.getContent().focus();
+    },
+
+    toggleEmptyClass: function () {
+      this.getContent().classList.toggle('-empty', this.isEmpty());
+    },
+
+    isEmpty: function () {
+      return this._scribe.getTextContent() === '';
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/management.js
+++ b/app/assets/javascripts/management.js
@@ -27,6 +27,7 @@
 
 // = require_tree ./routers/management
 // = require_tree ./templates
+// = require_tree ./blocks
 // = require_tree ./views/shared
 // = require_tree ./views/management
 // = require dispatchers/managementDispatcher

--- a/app/assets/javascripts/views/management/wysiwygView.js.erb
+++ b/app/assets/javascripts/views/management/wysiwygView.js.erb
@@ -23,7 +23,7 @@
       // Some configuration for Sir Trevor
       SirTrevor.setDefaults({
         iconUrl: "<%= asset_path('icons/sir-trevor.svg') %>",
-        blockTypes: ['Text', 'Heading', 'Quote'],
+        blockTypes: ['Text', 'Heading', 'Quote', 'Title'],
         formatBar: {
           // We only display the commands specified in the defaults object
           commands: _.reject(SirTrevor.config.defaults.formatBar.commands, function (command) {

--- a/app/assets/javascripts/views/management/wysiwygView.js.erb
+++ b/app/assets/javascripts/views/management/wysiwygView.js.erb
@@ -23,7 +23,7 @@
       // Some configuration for Sir Trevor
       SirTrevor.setDefaults({
         iconUrl: "<%= asset_path('icons/sir-trevor.svg') %>",
-        blockTypes: ['Text', 'Heading', 'Quote', 'Title'],
+        blockTypes: ['Text', 'Heading', 'Quote', 'Title', 'Introduction'],
         formatBar: {
           // We only display the commands specified in the defaults object
           commands: _.reject(SirTrevor.config.defaults.formatBar.commands, function (command) {

--- a/app/assets/javascripts/views/management/wysiwygView.js.erb
+++ b/app/assets/javascripts/views/management/wysiwygView.js.erb
@@ -23,7 +23,7 @@
       // Some configuration for Sir Trevor
       SirTrevor.setDefaults({
         iconUrl: "<%= asset_path('icons/sir-trevor.svg') %>",
-        blockTypes: ['Text', 'Heading', 'Quote', 'Title', 'Introduction'],
+        blockTypes: ['Text', 'Heading', 'Title', 'Introduction', 'Quote'],
         formatBar: {
           // We only display the commands specified in the defaults object
           commands: _.reject(SirTrevor.config.defaults.formatBar.commands, function (command) {

--- a/app/assets/javascripts/views/management/wysiwygView.js.erb
+++ b/app/assets/javascripts/views/management/wysiwygView.js.erb
@@ -36,6 +36,15 @@
     },
 
     /**
+     * Return true if the param is a standard html paragraph
+     * @param {string} html
+     * @return {boolean}
+     */
+    _isParagraph: function (html) {
+      return html.indexOf('<p>') === 0;
+    },
+
+    /**
      * Save the HTML output into the HTML container so the server can display the content easily
      */
     saveHTML: function () {
@@ -50,8 +59,20 @@
             return res;
           }
 
+          // By default, the block created by Sir Trevor is a standard paragraph. Nevertheless,
+          // we want this paragraph to have a special class to be styled.
+          if (this._isParagraph(block.data.text)) {
+            // When the user creates a new line by pressing Shift + Enter on his keyboard,
+            // Sir Trevor concatenate a new paragraph at the end of the main one. Instead, we
+            // just want a new line.
+            block.data.text = block.data.text.replace(/<\/p><p>/g, '<br/>');
+            // At this stage, we should only have one opening paragraph tag so we just modify
+            // it to have a class
+            block.data.text = block.data.text.replace('<p>', '<p class="paragraph">');
+          }
+
           return res + block.data.text;
-        }, '');
+        }.bind(this), '');
     },
 
     render: function () {

--- a/app/assets/javascripts/views/management/wysiwygView.js.erb
+++ b/app/assets/javascripts/views/management/wysiwygView.js.erb
@@ -23,7 +23,7 @@
       // Some configuration for Sir Trevor
       SirTrevor.setDefaults({
         iconUrl: "<%= asset_path('icons/sir-trevor.svg') %>",
-        blockTypes: ['Text', 'Heading', 'Title', 'Introduction', 'Quote'],
+        blockTypes: ['Text', 'Heading', 'Title', 'Introduction', 'Quote', 'Image'],
         formatBar: {
           // We only display the commands specified in the defaults object
           commands: _.reject(SirTrevor.config.defaults.formatBar.commands, function (command) {
@@ -54,7 +54,7 @@
         .data
         .reduce(function (res, block) {
           if (block.data.format !== 'html') {
-            // eslint-disable-line no-console
+            // eslint-disable-next-line no-console
             console.warn('Sir Trevor\'s blocks should return an HTML content to be easily used by Rails\' views.');
             return res;
           }

--- a/app/assets/stylesheets/admin/_settings.scss
+++ b/app/assets/stylesheets/admin/_settings.scss
@@ -22,6 +22,7 @@ $font-family-1: 'Fira Sans', sans-serif;
 // Font sizes
 $font-size-small:    12px;
 $font-size-normal:   14px;
+$font-size-s-normal: 15px;
 $font-size-x-normal: 19px;
 $font-size-medium:   21px;
 $font-size-big:      35px;

--- a/app/assets/stylesheets/components/front/c-content.scss
+++ b/app/assets/stylesheets/components/front/c-content.scss
@@ -58,6 +58,14 @@
     font-size: $font-size-medium;
     font-weight: $font-weight-light;
 
+    &::before {
+      content: '“';
+    }
+
+    &::after {
+      content: '”';
+    }
+
     @media #{$mq-mobile} {
       margin: 60px auto;
       font-size: $font-size-big;

--- a/app/assets/stylesheets/components/front/c-content.scss
+++ b/app/assets/stylesheets/components/front/c-content.scss
@@ -89,13 +89,15 @@
 
   .image {
     display: block;
-    width: 100%;
-    height: auto;
+    max-width: 100%;
     margin: 35px 0 50px;
-    max-width: $media-max-width;
 
     @media #{$mq-mobile} {
       margin: 65px auto 80px;
+    }
+
+    @media #{$mq-laptop} {
+      max-width: $media-max-width;
     }
   }
 }

--- a/app/assets/stylesheets/components/management/c-wysiwyg.scss
+++ b/app/assets/stylesheets/components/management/c-wysiwyg.scss
@@ -1,0 +1,23 @@
+.c-wysiwyg {
+
+
+  .content-title {
+    color: $color-4;
+    font-size: $font-size-big;
+    font-weight: $font-weight-bold;
+
+    &.-empty {
+      position: relative;
+
+      &::after {
+        display: inline-block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        color: rgba($color-4, .3);
+        content: 'Title';
+      }
+    }
+  }
+
+}

--- a/app/assets/stylesheets/components/management/c-wysiwyg.scss
+++ b/app/assets/stylesheets/components/management/c-wysiwyg.scss
@@ -1,5 +1,42 @@
 .c-wysiwyg {
 
+  p {
+    margin: 0;
+    font-size: $font-size-s-normal;
+
+    &.-intro {
+      font-size: $font-size-x-normal;
+      font-weight: $font-weight-light;
+
+      &.-empty {
+        position: relative;
+
+        &::after {
+          display: inline-block;
+          position: absolute;
+          top: 0;
+          left: 0;
+          color: rgba($color-4, .3);
+          content: 'Introduction';
+        }
+      }
+    }
+  }
+
+  .st-block {
+    &[data-type='title'] {
+      margin: 40px 0 15px;
+    }
+
+    &[data-type='introduction'] {
+      margin: 15px 0;
+    }
+
+    &[data-type='text'] {
+      margin: 10px 0;
+    }
+  }
+
 
   .content-title {
     color: $color-4;

--- a/app/assets/stylesheets/components/management/c-wysiwyg.scss
+++ b/app/assets/stylesheets/components/management/c-wysiwyg.scss
@@ -23,21 +23,6 @@
     }
   }
 
-  .st-block {
-    &[data-type='title'] {
-      margin: 40px 0 15px;
-    }
-
-    &[data-type='introduction'] {
-      margin: 15px 0;
-    }
-
-    &[data-type='text'] {
-      margin: 10px 0;
-    }
-  }
-
-
   .content-title {
     color: $color-4;
     font-size: $font-size-big;
@@ -54,6 +39,57 @@
         color: rgba($color-4, .3);
         content: 'Title';
       }
+    }
+  }
+
+  .quote {
+    font-size: $font-size-x-normal;
+    font-style: italic;
+
+    &::before {
+      content: '“';
+    }
+
+    &::after {
+      content: '”';
+    }
+
+    &.-empty {
+      position: relative;
+
+      &::before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        color: rgba($color-4, .3);
+        content: '“Citation”';
+      }
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  .st-block {
+    &[data-type='title'] {
+      margin: 40px 0 15px;
+    }
+
+    &[data-type='introduction'] {
+      margin: 15px 0;
+    }
+
+    &[data-type='quote'] {
+      margin: 15px 0;
+
+      > .st-block__inner {
+        margin: 0 110px;
+      }
+    }
+
+    &[data-type='text'] {
+      margin: 10px 0;
     }
   }
 

--- a/app/assets/stylesheets/management/_settings.scss
+++ b/app/assets/stylesheets/management/_settings.scss
@@ -22,6 +22,7 @@ $font-family-1: 'Fira Sans', sans-serif;
 // Font sizes
 $font-size-small:    12px;
 $font-size-normal:   14px;
+$font-size-s-normal: 15px;
 $font-size-x-normal: 19px;
 $font-size-medium:   21px;
 $font-size-big:      35px;

--- a/app/views/management/site_pages/forms/_open_content.html.erb
+++ b/app/views/management/site_pages/forms/_open_content.html.erb
@@ -31,7 +31,7 @@
     <fieldset class="form-group row">
       <%= f.label :content, class: 'col-sm-2 form-control-label' %>
       <div class="col-sm-10">
-        <div class="c-content">
+        <div class="c-wysiwyg">
           <%= f.fields_for :content, OpenStruct.new(site_page.content) do |ff| %>
               <%= ff.hidden_field :body, class: 'js-content' %>
               <%= ff.cktext_area :json, class: 'js-content-json' %>

--- a/app/views/site_page/homepage.html.erb
+++ b/app/views/site_page/homepage.html.erb
@@ -28,8 +28,8 @@
     </p>
 
     <blockquote class="quote">
-      “A key data challenge by integrating forest management classes with forest
-      cover extent and change data from GFW’s near-real-time monitoring system”
+      A key data challenge by integrating forest management classes with forest
+      cover extent and change data from GFW’s near-real-time monitoring system
     </blockquote>
 
     <p class="paragraph">Unless otherwise noted, Atlas data are licensed under a

--- a/app/views/site_page/open_content.html.erb
+++ b/app/views/site_page/open_content.html.erb
@@ -1,7 +1,9 @@
 <%= render 'front/cover'%>
 
 <div class="c-content">
-  <%= @site_page.content['body'].html_safe unless @site_page.content['body'].blank? %>
+  <div class="wrapper">
+    <%= @site_page.content['body'].html_safe unless @site_page.content['body'].blank? %>
+  </div>
 </div>
 
 <%= render 'front/footer'%>

--- a/app/views/site_page/open_content.html.erb
+++ b/app/views/site_page/open_content.html.erb
@@ -1,6 +1,8 @@
 <%= render 'front/cover'%>
 
-<%= @site_page.content['body'].html_safe unless @site_page.content['body'].blank? %>
+<div class="c-content">
+  <%= @site_page.content['body'].html_safe unless @site_page.content['body'].blank? %>
+</div>
 
 <%= render 'front/footer'%>
 

--- a/vendor/assets/javascripts/sir-trevor.js
+++ b/vendor/assets/javascripts/sir-trevor.js
@@ -17055,7 +17055,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (this._scribe.getTextContent() !== '') {
 	      var fakeContent = document.createElement('div');
 	      fakeContent.innerHTML = this.getTextBlockHTML();
-	      content = fakeContent.firstChild.innerHTML || fakeContent.innerHTML;
+        content = fakeContent.children &&
+          Array.prototype.slice.call(fakeContent.children).reduce(function (res, child) {
+            return res + child.innerHTML;
+          }, '') || fakeContent.innerHTML;
 	      return content.replace(/^[\s\uFEFF\xA0]+|$/g, '');
 	    }
 	    return content;
@@ -19764,6 +19767,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var range = selection.range.cloneRange();
 
 	      range.setStartBefore(scribe.el.firstChild, 0);
+
+        var node = range.endContainer.nodeType === 3 ? range.endContainer.parentNode : range.endContainer;
+
+        if (scribe.el.firstChild !== node) {
+          return false;
+        }
 
 	      return rangeToHTML(range, false) === '';
 	    };

--- a/vendor/assets/javascripts/sir-trevor.js
+++ b/vendor/assets/javascripts/sir-trevor.js
@@ -4106,7 +4106,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	if (window.i18n === undefined) {
+	if (window.i18n === undefined || window.i18n.init === undefined) {
 	  // Minimal i18n stub that only reads the English strings
 	  utils.log("Using i18n stub");
 	  window.i18n = {
@@ -4143,6 +4143,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  };
 	} else {
+    debugger;
 	  utils.log("Using i18next");
 	  // Only use i18next when the library has been loaded by the user, keeps
 	  // dependencies slim


### PR DESCRIPTION
This PR enhances the basic wysiwyg with the possibility to add:
* a title
* an introduction
* a quote
* an image (*)

Additionally, it fixes issues where the editor would have a weird behaviour and removes an error related to `i18n` which would appear in the console.

**This PR shouldn't be merged before #56 because it removes `bootstrap` in order to avoid conflict with the library's styles.**

(*) When the user inserts an image, it's not uploaded to the server but inlined as a base64 string in the database. This is a quick solution to have it working and without having to deal with the upload of the image. If this solution gives us issues or if you think it's wrong, we can change it afterwards.