### PR TITLE
Doesn't force the width anymore

### DIFF
--- a/app/assets/javascripts/templates/management/site-switcher.hbs
+++ b/app/assets/javascripts/templates/management/site-switcher.hbs
@@ -1,4 +1,4 @@
-<select class="c-site-switcher" {{#if slug}}style="width: {{width}};"{{/if}}>
+<select class="c-site-switcher">
   <option value="" disabled {{#unless slug}}selected{{/unless}}>Change site</option>
   {{#each sites}}
     <option value="{{slug}}" {{#if active}}selected{{/if}}>{{name}}</option>

--- a/app/assets/javascripts/views/management/siteSwitcherView.js
+++ b/app/assets/javascripts/views/management/siteSwitcherView.js
@@ -72,14 +72,7 @@
             site.active = site.slug === this.options.slug;
             return site;
           }, this),
-        slug: this.options.slug,
-        // Basically, we want the width of the select input to be the width of its content
-        // Because it's not possible with CSS, we base the width of the input on the length of
-        // the content and then use it with the "ch" unit (which is roughly the width of the
-        // character "0")
-        // There's an offset of 2ch to compensate the left padding for the arrow and as an error
-        // margin
-        width: (this.options.slug.length + 2) + 'ch'
+        slug: this.options.slug
       }));
     }
 


### PR DESCRIPTION
This PR makes the site switcher more resilient but less compliant with the design.

In the design, the site switcher's width is equal to it's content i.e. the length of the selected site name.

Nevertheless, as it's impossible to do so in pure CSS, the previous solution was setting the width of the input to a fixed size (the length of its content) using the [`ch` CSS unit](https://www.w3.org/TR/css3-values/#ch) (1 ch is fairly equivalent at the size of a character).

The solution was tricky due to the fairness of the equivalence and caused an issue on Chromium on Linux where the input wouldn't be wide enough to show its full content. As a consequence, this PR rolls back the code to let the input's width be the size of the longer option.