### PR TITLE
Bug/shared instance properties

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -16,6 +16,7 @@
 //= require underscore
 //= require backbone
 //= require handlebars
+//= require object-assign-polyfill
 
 //= require_self
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require vega
 //= require leaflet
 //= require handlebars
+//= require object-assign-polyfill
 
 //= require_self
 

--- a/app/assets/javascripts/management.js
+++ b/app/assets/javascripts/management.js
@@ -22,6 +22,7 @@
 //= require jquery-ui
 //= require jquery-nested-sortable
 //= require sir-trevor
+//= require object-assign-polyfill
 
 //= require_self
 

--- a/app/assets/javascripts/views/admin/flagColorsView.js
+++ b/app/assets/javascripts/views/admin/flagColorsView.js
@@ -21,7 +21,7 @@
     },
 
     initialize: function (settings) {
-      this.options = _.extend(this.defaults, settings);
+      this.options = Object.assign({}, this.defaults, settings);
       this.render();
     },
 

--- a/app/assets/javascripts/views/management/siteSwitcherView.js
+++ b/app/assets/javascripts/views/management/siteSwitcherView.js
@@ -32,7 +32,7 @@
     },
 
     initialize: function (settings) {
-      this.options = _.extend(this.defaults, settings);
+      this.options = Object.assign({}, this.defaults, settings);
 
       this.collection.fetch()
         .done(this.render.bind(this))

--- a/app/assets/javascripts/views/management/treeStructureView.js
+++ b/app/assets/javascripts/views/management/treeStructureView.js
@@ -12,7 +12,7 @@
     },
 
     initialize: function (settings) {
-      this.options = _.extend(this.defaults, settings);
+      this.options = Object.assign({}, this.defaults, settings);
 
       this.render();
       // this.collection.fetch()

--- a/app/assets/javascripts/views/management/wysiwygView.js.erb
+++ b/app/assets/javascripts/views/management/wysiwygView.js.erb
@@ -17,7 +17,7 @@
     },
 
     initialize: function (settings) {
-      this.options = _.extend(this.defaults, settings);
+      this.options = Object.assign({}, this.defaults, settings);
 
       this.JSONContainer = document.querySelector('.js-content-json');
       this.HTMLContainer = document.querySelector('.js-content');

--- a/app/assets/javascripts/views/shared/notificationView.js
+++ b/app/assets/javascripts/views/shared/notificationView.js
@@ -29,7 +29,7 @@
     template: HandlebarsTemplates['shared/notification'],
 
     initialize: function (settings) {
-      this.options = _.extend(this.defaults, settings);
+      this.options = Object.assign({}, this.defaults, settings);
 
       this._createEl();
 

--- a/app/assets/javascripts/views/shared/tabView.js
+++ b/app/assets/javascripts/views/shared/tabView.js
@@ -29,7 +29,7 @@
     template: HandlebarsTemplates['shared/tabs'],
 
     initialize: function (settings) {
-      this.options = _.extend(this.defaults, settings);
+      this.options = Object.assign({}, this.defaults, settings);
       this.render();
     },
 

--- a/vendor/assets/javascripts/object-assign-polyfill.js
+++ b/vendor/assets/javascripts/object-assign-polyfill.js
@@ -1,0 +1,25 @@
+// Polyfill borrowed from here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+if (typeof Object.assign != 'function') {
+  (function () {
+    Object.assign = function (target) {
+      'use strict';
+      // We must check against these specific cases.
+      if (target === undefined || target === null) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var output = Object(target);
+      for (var index = 1; index < arguments.length; index++) {
+        var source = arguments[index];
+        if (source !== undefined && source !== null) {
+          for (var nextKey in source) {
+            if (source.hasOwnProperty(nextKey)) {
+              output[nextKey] = source[nextKey];
+            }
+          }
+        }
+      }
+      return output;
+    };
+  })();
+}


### PR DESCRIPTION
This PR solves an issue where instance properties could leak into another view.

The default properties of the views are defined in their prototype. To customise them, the previous solution would mutate them (i.e. mutate the prototype) which would affect any other instantiated view. Instead of that, the new solution copies the prototype into the instances and mutate this copy. It uses `Object.assign` to do so, which needs a polyfill for [older browsers](http://kangax.github.io/compat-table/es6/#test-Object_static_methods_Object.assign), that's why a new script has been added.