### PR TITLE
Improve authorization on management interface

### DIFF
--- a/app/controllers/management/site_pages_controller.rb
+++ b/app/controllers/management/site_pages_controller.rb
@@ -1,13 +1,13 @@
 class Management::SitePagesController < ManagementController
   before_action :set_page, only: [:show, :edit, :update, :destroy, :toggle_enable]
   before_action :set_site, only: [:index, :new, :create]
+  before_action :authenticate_user_for_site!, only: [:index, :new, :create]
   before_action :set_content_type_variables, only: [:new, :edit]
 
   # GET /management/:site_slug
   # GET /management/:site_slug.json
   def index
-    @pages = SitePage.joins(:users)
-               .where(users: {id: current_user.id})
+    @pages = SitePage.joins(:site)
                .where(sites: {slug: params[:site_slug]})
                .paginate(:page => params[:page], :per_page => params[:per_page])
                .order(params[:order] || 'created_at ASC')

--- a/app/controllers/management/static_page_controller.rb
+++ b/app/controllers/management/static_page_controller.rb
@@ -2,9 +2,13 @@ class Management::StaticPageController < ManagementController
 
   # GET /management
   def dashboard
-    @sites = Site.joins(:users)
-               .where(users: {id: current_user.id})
-               .paginate(:page => params[:page], :per_page => params[:per_page])
+    if (current_user.admin?)
+      @sites = Site
+    else
+      @sites = Site.joins(:users).where(users: {id: current_user.id})
+    end
+
+    @sites = @sites.paginate(:page => params[:page], :per_page => params[:per_page])
                .order(params[:order] || 'created_at ASC')
 
     @breadcrumbs = ['Dashboard']

--- a/app/controllers/management_controller.rb
+++ b/app/controllers/management_controller.rb
@@ -1,4 +1,11 @@
 class ManagementController < ActionController::Base
   before_action :authenticate_user!
   layout 'management'
+
+  def authenticate_user_for_site!
+    return true if current_user.admin?
+    raise ScriptError, 'Expected site to be defined to validate authorization, but none found' if @site.nil?
+
+    raise Exception, 'User not authorized to access this site' unless @site.users.exists?(current_user)
+  end
 end


### PR DESCRIPTION
Admin users can now access all sites on the management interface, even if they are not explicitly associated to them