### PR TITLE
Fixes a 500 error when creating/editing a page

### DIFF
--- a/app/views/management/site_pages/forms/_open_content.html.erb
+++ b/app/views/management/site_pages/forms/_open_content.html.erb
@@ -48,7 +48,7 @@
         <div class="c-wysiwyg">
           <%= f.fields_for :content, OpenStruct.new(site_page.content) do |ff| %>
               <%= ff.hidden_field :body, class: 'js-content' %>
-              <%= ff.cktext_area :json, class: 'js-content-json' %>
+              <%= ff.text_area :json, class: 'js-content-json' %>
           <% end %>
         </div>
       </div>

--- a/app/views/management/site_pages/forms/_static_content.html.erb
+++ b/app/views/management/site_pages/forms/_static_content.html.erb
@@ -48,7 +48,7 @@
         <div class="c-wysiwyg">
           <%= f.fields_for :content, OpenStruct.new(site_page.content) do |ff| %>
               <%= ff.hidden_field :body, class: 'js-content' %>
-              <%= ff.cktext_area :json, class: 'js-content-json' %>
+              <%= ff.text_area :json, class: 'js-content-json' %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
PR #69 has been merged quickly without testing (my fault). Some references to `ckeditor` were still present which would raise internal errors when the user would create or edit pages that contain a `textarea` (Open Content page for example).