### PR TITLE
Bug fix: pages layout doesn't render admin layout when logged in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def layout_by_resource
-    if @current_user
+    if @current_user && !self.is_a?(SitePageController)
       "admin"
     else
       "application"


### PR DESCRIPTION
There was a bug when rendering the layout for the site's pages when the user was logged in.
Please check if this fix is correct.