### PR TITLE
Prevents the search field to be duplicated

### DIFF
--- a/app/assets/javascripts/views/shared/tableView.js
+++ b/app/assets/javascripts/views/shared/tableView.js
@@ -217,6 +217,7 @@
       }.bind(this));
 
       // We bind the elements to the DOM
+      this.options.searchFieldContainer.innerHTML = ''; // We make sure the container is empty
       this.options.searchFieldContainer.appendChild(searchField);
       this.options.searchFieldContainer.appendChild(searchButton);
 


### PR DESCRIPTION
This PR prevents the table's search field to be duplicated when the user push the browser's back button.

The issue is caused by [Turbolinks](https://github.com/turbolinks/turbolinks) caching the page and can be solved by making sure to empty the container of the search field before adding a new one.

[Pivotal task](https://www.pivotaltracker.com/story/show/133613407)