### PR TITLE
Feature/admin header improvements

### DIFF
--- a/app/assets/stylesheets/components/shared/c-header-admin.scss
+++ b/app/assets/stylesheets/components/shared/c-header-admin.scss
@@ -41,6 +41,20 @@
     }
   }
 
+  &.-bright {
+    background-color: $color-1;
+    color: $color-3;
+
+    a {
+      color: $color-3;
+      &.-highlight { color: $color-3; }
+    }
+
+    .breadcrumbs {
+      color: rgba($color-3, .5);
+    }
+  }
+
   .menu {
     > li {
       margin-right: 20px;

--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -26,6 +26,13 @@ class Admin::SiteStepsController < AdminController
   end
 
   def show
+    @breadcrumbs = ['CMS']
+    if current_site.id
+      @breadcrumbs << 'Site edition'
+    else
+      @breadcrumbs << 'Site creation'
+    end
+
     if step == 'name'
       @site = current_site
       gon.global.url_controller_id = URL_CONTROLLER_ID

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -17,6 +17,8 @@ class Admin::SitesController < AdminController
       }
     end
 
+    @breadcrumbs = ['CMS']
+
     respond_to do |format|
       format.html { render :index }
       format.json { render json: @sites }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,6 +15,8 @@ class Admin::UsersController < AdminController
       }
     end
 
+    @breadcrumbs = ['CMS']
+
     respond_to do |format|
       format.html { render :index }
       format.json { render json: @users }

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="c-header-admin">
+<div class="c-header-admin -bright">
   <div class="wrapper">
     <div>
       <% unless @breadcrumbs.blank? %>


### PR DESCRIPTION
This PR makes a visual difference between the admin and management section by changing the background of the first with the green color. In addition, a breadcrumbs has been added on the admin.

This task is a first step towards what the real design looks like: we still need to embed the admin/management link into the "site switcher" which needs an overhaul ([Pivotal task](https://www.pivotaltracker.com/story/show/133997235)).