### PR TITLE
Feature/analysis dashboard bookmarks

### DIFF
--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -42,6 +42,7 @@
       this._initMap();
       this._initBookmarks();
       this._setListeners();
+      this._renderCharts();
     },
 
     /**
@@ -105,7 +106,7 @@
       new App.View.DashboardBookmarksView({
         el: document.querySelector('.js-bookmarks'),
         getState: function () { return this.state; }.bind(this),
-        setState: function (state) { console.log(state); }
+        setState: this._restoreState.bind(this)
       });
     },
 
@@ -130,6 +131,40 @@
 
         default:
       }
+    },
+
+    /**
+     * Restore the state of the dashboard
+     * @param {object} state
+     */
+    _restoreState: function (state) {
+      // We restore the first chart
+      var chart1State = {
+        chart: state.config.charts[0].type,
+        columnX: state.config.charts[0].x,
+        columnY: state.config.charts[0].y
+      };
+      this.chart1.options = Object.assign({}, this.chart1.options, chart1State);
+      this.chart1.renderChart();
+
+      // We restore the second chart
+      var chart2State = {
+        chart: state.config.charts[1].type,
+        columnX: state.config.charts[1].x,
+        columnY: state.config.charts[1].y
+      };
+      this.chart2.options = Object.assign({}, this.chart2.options, chart2State);
+      this.chart2.renderChart();
+
+      // TODO do the same for the map
+    },
+
+    /**
+     * Render the charts
+     */
+    _renderCharts: function () {
+      this.chart1.render();
+      this.chart2.render();
     },
 
     index: function () {

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -3,6 +3,30 @@
 
   App.Router.FrontDashboard = Backbone.Router.extend({
 
+    // Global state of the dashboard
+    state: {
+      name: 'New bookmark',
+      config: {
+        map: {
+          lat: null,
+          lng: null,
+          zoom: null
+        },
+        charts: [
+          {
+            type: null,
+            x: null,
+            y: null
+          },
+          {
+            type: null,
+            x: null,
+            y: null
+          }
+        ]
+      }
+    },
+
     routes: {
       '(/)': 'index'
     },
@@ -16,13 +40,32 @@
 
       this._initCharts();
       this._initMap();
+      this._initBookmarks();
+      this._setListeners();
     },
 
+    /**
+     * Set the listeners that don't depend on a DOM element
+     */
+    _setListeners: function () {
+      this.listenTo(this.chart1, 'state:change', function (state) {
+        this._saveState('chart1', state);
+      });
+      this.listenTo(this.chart2, 'state:change', function (state) {
+        this._saveState('chart2', state);
+      });
+
+      // We would do the same for the map
+    },
+
+    /**
+     * Init the charts
+     */
     _initCharts: function () {
       var dataset = (window.gon && gon.analysisData.data) || [];
       var charts = (window.gon && gon.analysisGraphs) || [{}, {}];
 
-      new App.View.ChartWidgetView({
+      this.chart1 = new App.View.ChartWidgetView({
         el: document.querySelector('.js-chart-1'),
         data: dataset,
         chartConfig: App.Helper.ChartConfig,
@@ -31,7 +74,7 @@
         columnY: charts[0].y || null
       });
 
-      new App.View.ChartWidgetView({
+      this.chart2 = new App.View.ChartWidgetView({
         el: document.querySelector('.js-chart-2'),
         data: dataset,
         chartConfig: App.Helper.ChartConfig,
@@ -41,6 +84,9 @@
       });
     },
 
+    /**
+     * Init the map
+     */
     _initMap: function () {
       // This JS will probably be moved to independent views once the architecture will be refined
       var map = L.map(document.querySelector('.js-map'), {
@@ -50,6 +96,40 @@
       L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png', {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attributions">CARTO</a>'
       }).addTo(map);
+    },
+
+    /**
+     * Init the bookmarks
+     */
+    _initBookmarks: function () {
+      new App.View.DashboardBookmarksView({
+        el: document.querySelector('.js-bookmarks'),
+        getState: function () { return this.state; }.bind(this),
+        setState: function (state) { console.log(state); }
+      });
+    },
+
+    /**
+     * Save the state of the specified component into a global state object
+     * @param {string} component - "chart1", "chart2" or "map"
+     * @param {object} state - state to save
+     */
+    _saveState: function (component, state) {
+      switch (component) {
+        case 'map':
+          this.state.config.map = Object.assign({}, this.state.config.map, state);
+          break;
+
+        case 'chart1':
+          this.state.config.charts[0] = Object.assign({}, this.state.config.charts[0], state);
+          break;
+
+        case 'chart2':
+          this.state.config.charts[1] = Object.assign({}, this.state.config.charts[1], state);
+          break;
+
+        default:
+      }
     },
 
     index: function () {

--- a/app/assets/javascripts/templates/front/dashboard-bookmarks.hbs
+++ b/app/assets/javascripts/templates/front/dashboard-bookmarks.hbs
@@ -1,0 +1,15 @@
+<header>
+  <h3>Bookmarks</h3>
+  <button type="button" class="c-button -outline -dark-text -normal-weight js-add-state">Add state</button>
+</header>
+<ul class="bookmarks">
+  {{#each bookmarks}}
+    <li>
+      <span title="Click to edit the name" contenteditable="true" class="js-name" data-id="{{@index}}">{{name}}</span>
+      <div class="buttons">
+        <button type="button" class="-apply js-apply" data-id="{{@index}}" title="Apply state">Apply state<svg width="16" height="11" viewBox="0 0 16 11" xmlns="http://www.w3.org/2000/svg"><path d="M5.895 5.5a2.106 2.106 0 1 0 4.21 0 2.106 2.106 0 1 0-4.21 0zM16 5.5C14.467 2.768 11.461 0 8 0 4.547 0 1.533 2.768 0 5.5 1.533 8.232 4.547 11 8 11c3.461 0 6.467-2.768 8-5.5zM8 1.692c2.09 0 3.79 1.705 3.79 3.808 0 2.103-1.7 3.808-3.79 3.808S4.21 7.603 4.21 5.5c0-2.103 1.7-3.808 3.79-3.808z" fill="#555" fill-rule="evenodd"/></svg></button>
+        <button type="button" class="-delete js-delete" data-id="{{@index}}" title="Delete bookmark">Delete bookmark<svg width="10" height="14" viewBox="0 0 10 14" xmlns="http://www.w3.org/2000/svg"><path d="M7 1V0H3v1H0v2h10V1H7zM1 14h8V4H1v10z" fill="#555" fill-rule="evenodd"/></svg></button>
+      </div>
+    </li>
+  {{/each}}
+</ul>

--- a/app/assets/javascripts/templates/front/dashboard-bookmarks.hbs
+++ b/app/assets/javascripts/templates/front/dashboard-bookmarks.hbs
@@ -3,6 +3,9 @@
   <button type="button" class="c-button -outline -dark-text -normal-weight js-add-state">Add state</button>
 </header>
 <ul class="bookmarks">
+  {{#unless bookmarks.length}}
+    <li class="no-bookmark">You haven't saved any bookmark yet</li>
+  {{/unless}}
   {{#each bookmarks}}
     <li>
       <span title="Click to edit the name" contenteditable="true" class="js-name" data-id="{{@index}}">{{name}}</span>

--- a/app/assets/javascripts/views/front/dashboardBookmarksView.js
+++ b/app/assets/javascripts/views/front/dashboardBookmarksView.js
@@ -41,9 +41,9 @@
     _onKeydownName: function (e) {
       if (e.keyCode !== 13) return; // enter key
       e.preventDefault();
-      var id = +e.target.dataset.id;
-      this._editBookmark(id, { name: e.target.textContent });
-      e.target.blur();
+      var id = +e.currentTarget.dataset.id;
+      this._editBookmark(id, { name: e.currentTarget.textContent });
+      e.currentTarget.blur();
     },
 
     /**
@@ -51,7 +51,7 @@
      * @param {object} e - event object
      */
     _onClickApply: function (e) {
-      var id = +e.target.dataset.id;
+      var id = +e.currentTarget.dataset.id;
       var bookmark = this._getBookmark(id);
       this.options.setState(bookmark);
     },
@@ -61,7 +61,7 @@
      * @param {object} e - event object
      */
     _onClickDelete: function (e) {
-      var id = +e.target.dataset.id;
+      var id = +e.currentTarget.dataset.id;
       this._deleteBookmark(id);
       this.render();
     },

--- a/app/assets/javascripts/views/front/dashboardBookmarksView.js
+++ b/app/assets/javascripts/views/front/dashboardBookmarksView.js
@@ -1,0 +1,182 @@
+((function (App) {
+  'use strict';
+
+  App.View.DashboardBookmarksView = Backbone.View.extend({
+
+    className: 'c-dashboard-bookmarks',
+    template: HandlebarsTemplates['front/dashboard-bookmarks'],
+
+    defaults: {
+      // Callback to retrieve the global state of the dashboard
+      getState: function () { },
+      // Callback to set the global state of the dashboard
+      setState: function () { },
+      // Name of the key in the local storage
+      storageID: 'bookmarks'
+    },
+
+    events: {
+      'click .js-add-state': '_onClickAddState',
+      'keydown .js-name': '_onKeydownName',
+      'click .js-apply': '_onClickApply',
+      'click .js-delete': '_onClickDelete'
+    },
+
+    initialize: function (settings) {
+      this.options = Object.assign({}, this.defaults, settings);
+      this.render();
+    },
+
+    /**
+     * Event handler for the click on the "add state" button
+     */
+    _onClickAddState: function () {
+      this._saveBookmark(this.options.getState());
+      this.render();
+    },
+
+    /**
+     * Event handler for when editing the name of a bookmark
+     */
+    _onKeydownName: function (e) {
+      if (e.keyCode !== 13) return; // enter key
+      e.preventDefault();
+      var id = +e.target.dataset.id;
+      this._editBookmark(id, { name: e.target.textContent });
+      e.target.blur();
+    },
+
+    /**
+     * Event handler for the click on the "apply state" buttons
+     * @param {object} e - event object
+     */
+    _onClickApply: function (e) {
+      var id = +e.target.dataset.id;
+      var bookmark = this._getBookmark(id);
+      this.options.setState(bookmark);
+    },
+
+    /**
+     * Event handler for the click on the "delete bookmark" buttons
+     * @param {object} e - event object
+     */
+    _onClickDelete: function (e) {
+      var id = +e.target.dataset.id;
+      this._deleteBookmark(id);
+      this.render();
+    },
+
+    /**
+     * Retrieve the bookmarks from the local storage and return them
+     * @returns {object[]} bookmarks
+     */
+    _getBookmarks: function () {
+      var bookmarks;
+
+      try {
+        bookmarks = JSON.parse(localStorage.getItem(this.options.storageID)) || [];
+      } catch (err) {
+        // We delete what's in the local storage so we can move forward
+        localStorage.removeItem(this.options.storageID);
+
+        // We display an error
+        new App.View.NotificationView({
+          visible: true,
+          type: 'error',
+          content: 'The bookmarks have been corrupted and can\'t be retrieved'
+        });
+      }
+
+      return bookmarks || [];
+    },
+
+    /**
+     * Retrieve a specific bookmark from the local storage
+     * @param {number} id - index of the bookmark
+     */
+    _getBookmark: function (id) {
+      var bookmarks = this._getBookmarks();
+      return bookmarks[id];
+    },
+
+    /**
+     * Create a new bookmark and store the state within
+     * @param {object} state
+     */
+    _saveBookmark: function (state) {
+      var bookmarks = this._getBookmarks();
+      bookmarks.push(state);
+
+      try {
+        localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
+      } catch (err) {
+        // We display an error
+        new App.View.NotificationView({
+          visible: true,
+          type: 'error',
+          content: 'The bookmark couldn\'t be saved properly'
+        });
+      }
+    },
+
+    /**
+     * Edit a bookmark and stores its new copy in the local storage
+     * @param {number} id - index of the bookmark
+     * @param {object} changes - object containing the modifications
+     */
+    _editBookmark: function (id, changes) {
+      var bookmarks = this._getBookmarks();
+      bookmarks[id] = Object.assign({}, bookmarks[id], changes);
+
+      try {
+        localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
+      } catch (err) {
+        // We display an error
+        new App.View.NotificationView({
+          visible: true,
+          type: 'error',
+          content: 'The name of the bookmark couldn\'t be updated'
+        });
+      }
+    },
+
+    /**
+     * Delete a bookmark from the local storage
+     * @param {number} id - index of the bookmark
+     */
+    _deleteBookmark: function (id) {
+      var bookmarks = this._getBookmarks();
+      bookmarks.splice(id, 1);
+
+      var couldSave = false;
+      try {
+        localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
+        couldSave = true;
+      } catch (err) {
+        // We display an error
+        new App.View.NotificationView({
+          visible: true,
+          type: 'error',
+          content: 'The bookmark couldn\'t be deleted'
+        });
+      }
+
+      if (couldSave) {
+        new App.View.NotificationView({
+          visible: true,
+          autoCloseTimer: 5,
+          content: 'The bookmark has been successfully deleted!'
+        });
+      }
+    },
+
+    render: function () {
+      this.el.classList.add(this.className);
+      this.el.innerHTML = this.template({
+        bookmarks: this._getBookmarks()
+      });
+      this.setElement(this.el);
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/views/front/dashboardBookmarksView.js
+++ b/app/assets/javascripts/views/front/dashboardBookmarksView.js
@@ -18,12 +18,20 @@
     events: {
       'click .js-add-state': '_onClickAddState',
       'keydown .js-name': '_onKeydownName',
+      'blur .js-name': '_onKeydownName',
       'click .js-apply': '_onClickApply',
       'click .js-delete': '_onClickDelete'
     },
 
     initialize: function (settings) {
       this.options = Object.assign({}, this.defaults, settings);
+
+      // These notifications are later used to display feedback
+      // By creating them now, we avoid to layer them on top of another if several notifications
+      // need to be displayed at once
+      this.successNotification = new App.View.NotificationView({ autoCloseTimer: 5 });
+      this.errorNotification = new App.View.NotificationView({ type: 'error' });
+
       this.render();
     },
 
@@ -39,7 +47,7 @@
      * Event handler for when editing the name of a bookmark
      */
     _onKeydownName: function (e) {
-      if (e.keyCode !== 13) return; // enter key
+      if (e.keyCode && e.keyCode !== 13) return; // enter key
       e.preventDefault();
       var id = +e.currentTarget.dataset.id;
       this._editBookmark(id, { name: e.currentTarget.textContent });
@@ -80,11 +88,8 @@
         localStorage.removeItem(this.options.storageID);
 
         // We display an error
-        new App.View.NotificationView({
-          visible: true,
-          type: 'error',
-          content: 'The bookmarks have been corrupted and can\'t be retrieved'
-        });
+        this.errorNotification.options.content = 'The bookmarks have been corrupted and can\'t be retrieved';
+        this.errorNotification.show();
       }
 
       return bookmarks || [];
@@ -111,11 +116,8 @@
         localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
       } catch (err) {
         // We display an error
-        new App.View.NotificationView({
-          visible: true,
-          type: 'error',
-          content: 'The bookmark couldn\'t be saved properly'
-        });
+        this.errorNotification.options.content = 'The bookmark couldn\'t be saved properly';
+        this.errorNotification.show();
       }
     },
 
@@ -132,11 +134,8 @@
         localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
       } catch (err) {
         // We display an error
-        new App.View.NotificationView({
-          visible: true,
-          type: 'error',
-          content: 'The name of the bookmark couldn\'t be updated'
-        });
+        this.errorNotification.options.content = 'The name of the bookmark couldn\'t be updated';
+        this.errorNotification.show();
       }
     },
 
@@ -154,19 +153,13 @@
         couldSave = true;
       } catch (err) {
         // We display an error
-        new App.View.NotificationView({
-          visible: true,
-          type: 'error',
-          content: 'The bookmark couldn\'t be deleted'
-        });
+        this.errorNotification.options.content = 'The bookmark couldn\'t be deleted';
+        this.errorNotification.show();
       }
 
       if (couldSave) {
-        new App.View.NotificationView({
-          visible: true,
-          autoCloseTimer: 5,
-          content: 'The bookmark has been successfully deleted!'
-        });
+        this.successNotification.options.content = 'The bookmark has been successfully deleted!';
+        this.successNotification.show();
       }
     },
 

--- a/app/assets/stylesheets/components/front/c-dashboard-bookmarks.scss
+++ b/app/assets/stylesheets/components/front/c-dashboard-bookmarks.scss
@@ -1,0 +1,79 @@
+.c-dashboard-bookmarks {
+  > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 10px 0;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: $font-size-x-normal;
+    font-weight: $font-weight-light;
+    line-height: 1.7;
+  }
+
+  > .bookmarks {
+    display: block;
+    width: 100%;
+
+    > li {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 15px;
+      border-bottom: 1px solid rgba($color-4, .1);
+    }
+  }
+
+  .buttons {
+    flex-shrink: 0;
+
+    button {
+      display: inline-block;
+      position: relative;
+      margin: 0;
+      margin-left: 15px;
+      padding: 0;
+      transition: opacity .3s;
+      border: 0;
+      background-color: transparent;
+      text-indent: -10000px; // We keep the text for accessibility matter
+      cursor: pointer;
+      opacity: .3;
+
+      &:hover {
+        opacity: 1;
+
+        @if $theme == 1 {
+          path {
+            fill: $color-1;
+          }
+        }
+      }
+
+      &.-apply {
+        width: 16px;
+        height: 11px;
+      }
+
+      &.-delete {
+        width: 10px;
+        height: 14px;
+      }
+
+      > svg {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+
+        path {
+          transition: fill .3s;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/components/front/c-dashboard-bookmarks.scss
+++ b/app/assets/stylesheets/components/front/c-dashboard-bookmarks.scss
@@ -23,6 +23,14 @@
       justify-content: space-between;
       padding: 12px 15px;
       border-bottom: 1px solid rgba($color-4, .1);
+
+      &.no-bookmark {
+        display: block;
+        width: 100%;
+        border-bottom-color: transparent;
+        text-align: center;
+        opacity: .5;
+      }
     }
   }
 

--- a/app/assets/stylesheets/components/shared/c-button.scss
+++ b/app/assets/stylesheets/components/shared/c-button.scss
@@ -18,6 +18,10 @@
     color: $color-4;
   }
 
+  &.-normal-weight {
+    font-weight: $font-weight-normal;
+  }
+
   &.-disabled {
     cursor: default;
     opacity: .3;

--- a/app/assets/stylesheets/front/_settings-theme-fa.scss
+++ b/app/assets/stylesheets/front/_settings-theme-fa.scss
@@ -44,9 +44,9 @@ $color-6:  #333;
 $color-7:  #3b3b3b;
 $color-8:  #f5f4f4;
 $color-9:  #eceaea;
-$color-10: transparent; // Fake color, to be replaced
-$color-11: transparent; // Fake color, to be replaced
-$color-12: transparent; // Fake color, to be replaced
+$color-10: darken(saturate($color-1, 10%), 5%);
+$color-11: #fff00e;
+$color-12: #dd3e21;
 
 // General layout
 $body-max-width:         1280px;

--- a/app/assets/stylesheets/front/_settings-theme-lsa.scss
+++ b/app/assets/stylesheets/front/_settings-theme-lsa.scss
@@ -61,9 +61,9 @@ $color-6:  #333;
 $color-7:  #3b3b3b;
 $color-8:  #f5f4f4;
 $color-9:  #eceaea;
-$color-10: transparent; // Fake color, to be replaced
-$color-11: transparent; // Fake color, to be replaced
-$color-12: transparent; // Fake color, to be replaced
+$color-10: darken(saturate($color-1, 10%), 5%);
+$color-11: #fff00e;
+$color-12: #dd3e21;
 
 // General layout
 $body-max-width:         1280px;

--- a/app/views/site_page/analysis_dashboard.html.erb
+++ b/app/views/site_page/analysis_dashboard.html.erb
@@ -18,8 +18,7 @@
   <div class="secondary-container">
     <div class="graph js-chart-1"></div>
     <div class="graph js-chart-2"></div>
-    <div class="bookmarks">
-      Bookmarks
+    <div class="bookmarks js-bookmarks">
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR implements the bookmark feature for the analysis dashboard.

It enables the user to save the state of the application (*) via bookmarks in the browser’s local storage. Once a bookmark is saved, it can be renamed by clicking on it, restored or deleted.

In case of failure (typically on Safari with the private browsing active), a notification is displayed. If the bookmarks are corrupted, the user is informed about it and they are deleted from the local storage in order to move forward and let the user create others.

If the manager updates the configuration of the dashboard, some bookmarks could be no longer valid. This case hasn’t been addressed yet and needs discussion on how we should handle it.

(*) Only the state of the charts are currently saved as the map isn’t implemented yet.