### PR TITLE
Feature/dashboard state validation

### DIFF
--- a/app/assets/javascripts/helpers/widgetToolbox.js
+++ b/app/assets/javascripts/helpers/widgetToolbox.js
@@ -1,0 +1,92 @@
+((function (App) {
+  'use strict';
+
+  // This helper is key to help identify which widgets can be rendered
+  // depending on the data we have
+  // It's also used to validate states
+
+  /**
+   * Constructor of the WidgetToolbox helper
+   * @param {object[]} dataset
+   */
+  App.Helper.WidgetToolbox = function (dataset) {
+    if (!dataset) {
+      throw new Error('The widget toolbox needs to be constructed with a dataset');
+    }
+    this.dataset = dataset;
+    this.jiminy = this._getJiminyInstance();
+  };
+
+  /* eslint-disable no-underscore-dangle */
+
+  /**
+   * Return an instance of Jiminy
+   * @returns {object} instance
+   */
+  App.Helper.WidgetToolbox.prototype._getJiminyInstance = function () {
+    return new Jiminy(this.dataset, App.Helper.ChartConfig);
+  };
+
+  /**
+   * Return the list of charts that can be generated with the dataset
+   * @returns {string[]}
+   */
+  App.Helper.WidgetToolbox.prototype.getAvailableCharts = function () {
+    return this.jiminy.recommendation();
+  };
+
+  /**
+   * Return the available x columns for the selected chart
+   * @param {string} chart - check the available columns for this specific chart
+   * @returns {string[]}
+   */
+  App.Helper.WidgetToolbox.prototype.getAvailableXColumns = function (chart) {
+    return this.jiminy.columns(chart);
+  };
+
+  /**
+   * Return the available y columns for the selected chart
+   * @param {string} chart - check the available columns for this specific chart
+   * @param {string} xColumn - x column name
+   * @returns {string[]}
+   */
+  App.Helper.WidgetToolbox.prototype.getAvailableYColumns = function (chart, xColumn) {
+    return this.jiminy.columns(chart, xColumn);
+  };
+
+  /**
+   * Return two random columns that can be used to generate the chart (x and y)
+   * The y column can be null depending on the chart
+   * @param {string} chart
+   * @return {{ x: string, y: string }}
+   */
+  App.Helper.WidgetToolbox.prototype.getChartRandomColumns = function (chart) {
+    var xColumns = this.getAvailableXColumns(chart);
+    var xColumn;
+    if (!xColumns.length) {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to generate a ' + chart + ' chart out of the current dataset');
+      return { x: null, y: null };
+    }
+
+    xColumn = xColumns[0];
+
+    var yColumns = this.getAvailableYColumns(chart, xColumn);
+    var yColumn = yColumns.length ? yColumns[0] : null;
+
+    return {
+      x: xColumn,
+      y: yColumn
+    };
+  };
+
+  /**
+   * Return the charts configuration object
+   * @return {object} chart config
+   */
+  App.Helper.WidgetToolbox.prototype.getChartConfig = function () {
+    return App.Helper.ChartConfig;
+  };
+
+  /* eslint-enable no-underscore-dangle */
+})(this.App));

--- a/app/assets/javascripts/helpers/widgetToolbox.js
+++ b/app/assets/javascripts/helpers/widgetToolbox.js
@@ -88,5 +88,36 @@
     return App.Helper.ChartConfig;
   };
 
+  /**
+   * Check the validity of a chart regarding the data provided to the constructor
+   * @param {{ type: string, x: string, y: string | null}} chart
+   * @returns {boolean} validity - true if valid
+   */
+  App.Helper.WidgetToolbox.prototype.checkChartValidity = function (chart) {
+    // If the chart hasn't a type, we consider it as valid
+    if (!chart.type) return true;
+    // If the chart can't be rendered with the current dataset
+    if (this.getAvailableCharts().indexOf(chart.type) === -1) return false;
+    // If the x column can be chosen to render the chart
+    if (this.getAvailableXColumns(chart.type).indexOf(chart.x) === -1) return false;
+    // If the y column can be chosen to render the chart with the x column
+    // NOTE: not all the charts have two columns
+    if (this.getAvailableYColumns(chart.type, chart.x).length && (!chart.y || this.getAvailableYColumns(chart.type, chart.x).indexOf(chart.y) === -1)) return false;
+    // If we reach this point, this particular chart is valid
+    return true;
+  };
+
+  /**
+   * Check the validity of a state regarding the data provided to the constructor
+   * For now, only the charts are checked
+   * @param {object} state
+   * @returns {boolean} validity - true if valid
+   */
+  App.Helper.WidgetToolbox.prototype.checkStateValidity = function (state) {
+    return state.config.charts.reduce(function (isValid, chart) {
+      return isValid && this.checkChartValidity(chart);
+    }.bind(this), true);
+  };
+
   /* eslint-enable no-underscore-dangle */
 })(this.App));

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -6,6 +6,7 @@
     // Global state of the dashboard
     state: {
       name: 'New bookmark',
+      version: null,
       config: {
         map: {
           lat: null,
@@ -38,6 +39,11 @@
         el: document.querySelector('.js-header')
       });
 
+      // We create instances of the notifications so we reuse them to avoid duplicates
+      // of the exact same one layered on top one of another
+      this.warningNotification = new App.View.NotificationView({ type: 'warning' });
+      this.errorNotification = new App.View.NotificationView({ type: 'error' });
+
       this._initCharts();
       this._initMap();
       this._initBookmarks();
@@ -60,11 +66,35 @@
     },
 
     /**
+     * Retrieve the dataset provided by the dashboard
+     * @returns {object[]} dataset
+     */
+    _getDataset: function () {
+      return (window.gon && gon.analysisData.data) || [];
+    },
+
+    /**
+     * Retrieve the dashboard's version
+     * @returns {string} version
+     */
+    _getDashboardVersion: function () {
+      return (window.gon && gon.analysisTimestamp) || null;
+    },
+
+    /**
+     * Retrieve the dashboard's charts
+     * @returns {object[]} charts
+     */
+    _getDashboardCharts: function () {
+      return (window.gon && gon.analysisGraphs) || [{}, {}];
+    },
+
+    /**
      * Init the charts
      */
     _initCharts: function () {
-      var dataset = (window.gon && gon.analysisData.data) || [];
-      var charts = (window.gon && gon.analysisGraphs) || [{}, {}];
+      var dataset = this._getDataset();
+      var charts = this._getDashboardCharts();
 
       this.chart1 = new App.View.ChartWidgetView({
         el: document.querySelector('.js-chart-1'),
@@ -114,6 +144,7 @@
      * @param {object} state - state to save
      */
     _saveState: function (component, state) {
+      this.state.version = this._getDashboardVersion();
       switch (component) {
         case 'map':
           this.state.config.map = Object.assign({}, this.state.config.map, state);
@@ -132,10 +163,42 @@
     },
 
     /**
-     * Restore the state of the dashboard
+     * Check if the version of the state matches the latest version of the dashboard
      * @param {object} state
+     * @returns {boolean} upToDate - true if up to date
+     */
+    _checkStateVersion: function (state) {
+      var dashboardVersion = this._getDashboardVersion();
+      // eslint-disable-next-line no-console
+      if (!dashboardVersion) console.warn('The dashboard isn\'t versioned. Versioning permits the detection of possible conflicts with the saved states');
+      return !dashboardVersion || state.version === dashboardVersion;
+    },
+
+    /**
+     * Restore the state of the dashboard
+     * NOTE: must be called after _renderCharts
+     * @param {object} state
+     * @returns {boolean} restored - true if the state could be restored
      */
     _restoreState: function (state) {
+      var isStateUpToDate = this._checkStateVersion(state);
+
+      if (!isStateUpToDate) {
+        this.errorNotification.hide();
+        this.warningNotification.options.content = 'The dashboard configuration has been updated and it might affect the visualizations';
+        this.warningNotification.show();
+      }
+
+      var widgetToolbox = new App.Helper.WidgetToolbox(this._getDataset());
+      var isStateValid = widgetToolbox.checkStateValidity(state);
+
+      if (!isStateValid) {
+        this.warningNotification.hide();
+        this.errorNotification.options.content = 'The dashboard\'s state couldn\'t be restored, probably because of changes of the data';
+        this.errorNotification.show();
+        return false;
+      }
+
       // We restore the first chart
       var chart1State = {
         chart: state.config.charts[0].type,
@@ -155,6 +218,8 @@
       this.chart2.renderChart();
 
       // TODO do the same for the map
+
+      return true;
     },
 
     /**

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -69,7 +69,6 @@
       this.chart1 = new App.View.ChartWidgetView({
         el: document.querySelector('.js-chart-1'),
         data: dataset,
-        chartConfig: App.Helper.ChartConfig,
         chart: charts[0].type || null,
         columnX: charts[0].x || null,
         columnY: charts[0].y || null
@@ -78,7 +77,6 @@
       this.chart2 = new App.View.ChartWidgetView({
         el: document.querySelector('.js-chart-2'),
         data: dataset,
-        chartConfig: App.Helper.ChartConfig,
         chart: charts[1].type || null,
         columnX: charts[1].x || null,
         columnY: charts[1].y || null
@@ -160,7 +158,7 @@
     },
 
     /**
-     * Render the charts
+     * Render the whole charts components
      */
     _renderCharts: function () {
       this.chart1.render();


### PR DESCRIPTION
This PR provides a two-step validation for the states. The idea is that, if a user visits a dashboard with a URL containing a specific state or restores a built-in bookmark, we can ensure the data they’re seeing is correct.

For that, two mechanisms have been implemented.

The first one ensures the accuracy of the state. The validation checks if the dashboard has been updated since the state has been saved, and if so, warns the user about possible visual changes of the visualisations. At its core is a version number (a timestamp) that is updated each time the manager changes a parameter of the dashboard that could affect the data.

The second mechanism ensures the resilience of the dashboard against outdated states. Basically, once the manager has updated the dashboard, some of the charts could be impossible to render again. In this case, the user is displayed an error and the state isn’t restored. The code relies on [Jiminy](https://github.com/Vizzuality/jiminy) to check if the state’s charts can still be rendered, and with the same fields.