### PR TITLE
Simple filters for the analysis dashboard

### DIFF
--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -90,6 +90,18 @@
     },
 
     /**
+     * Init the filters
+     */
+    _initFilters: function () {
+      var dataset = this._getDataset();
+      this.filters = new App.View.DashboardFiltersView({
+        el: document.querySelector('.js-filters'),
+        data: dataset,
+        filteringFields: (window.gon && gon.analysisUserFilters) || []
+      });
+    },
+
+    /**
      * Init the charts
      */
     _initCharts: function () {
@@ -353,6 +365,7 @@
      * Default route to be called
      */
     indexRoute: function () {
+      this._initFilters();
       this._initCharts();
       this._initMap();
       this._setListeners();

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -340,6 +340,26 @@
     },
 
     /**
+     * Check if the state is valid by checking the graphs and the filters
+     * @param {object} state
+     * @returns {boolean} valid - true if valid
+     */
+    _checkStateValidity: function (state) {
+      var dataset = this._getDataset();
+
+      // We check the validity of the charts
+      var widgetToolbox = new App.Helper.WidgetToolbox(dataset);
+      if (!widgetToolbox.checkStateValidity(state)) return false;
+
+      // We check the validity of the filters: if the filters are based on columns that exist
+      // in the first row
+      var firstRow = dataset[0];
+      return state.config.filters.reduce(function (res, filter) {
+        return res && Object.keys(firstRow).indexOf(filter.name) !== -1;
+      }, true);
+    },
+
+    /**
      * Restore the state of the dashboard
      * NOTE: must be called after _renderCharts
      * @param {object} state
@@ -354,13 +374,19 @@
         this.warningNotification.show();
       }
 
-      var widgetToolbox = new App.Helper.WidgetToolbox(this._getDataset());
-      var isStateValid = widgetToolbox.checkStateValidity(state);
+      var isStateValid = this._checkStateValidity(state);
 
       if (!isStateValid) {
         this.warningNotification.hide();
         this.errorNotification.options.content = 'The dashboard\'s state couldn\'t be restored, probably because of changes of the data';
         this.errorNotification.show();
+
+        // We don't forget to still show the interface
+        this.filters.render();
+        this.chart1.render();
+        this.chart2.render();
+        // TODO: add the map here
+
         return false;
       }
 

--- a/app/assets/javascripts/templates/front/dashboard-filters.hbs
+++ b/app/assets/javascripts/templates/front/dashboard-filters.hbs
@@ -1,0 +1,10 @@
+{{#each filters}}
+  <div  class="js-filter">
+    <select data-id="{{@index}}">
+      <option value="" {{#unless value}}selected="selected"{{/unless}}>Filter by {{name}}</option>
+      {{#each values}}
+        <option value="{{this}}" {{#if_eq this ../value}}selected="selected"{{/if_eq}}>{{this}}</option>
+      {{/each}}
+    </select>
+  </div>
+{{/each}}

--- a/app/assets/javascripts/templates/front/dashboard-filters.hbs
+++ b/app/assets/javascripts/templates/front/dashboard-filters.hbs
@@ -1,5 +1,5 @@
 {{#each filters}}
-  <div  class="js-filter">
+  <div  class="c-select js-filter">
     <select data-id="{{@index}}">
       <option value="" {{#unless value}}selected="selected"{{/unless}}>Filter by {{name}}</option>
       {{#each values}}

--- a/app/assets/javascripts/views/front/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/front/dashboardFiltersView.js
@@ -30,7 +30,6 @@
       // eslint-disable-next-line no-underscore-dangle
       this.options._filteredData = this._copyDataset(this.options.data);
       this._initFilters();
-      this.render();
     },
 
     /**
@@ -138,6 +137,20 @@
           values: this._getUniqueFieldValues(filter).sort()
         };
       }, this);
+    },
+
+    /**
+     * Set the active filters
+     * NOTE: it doesn't reset the filters priors to settings them
+     * @param {object[]} filters to set
+     */
+    setFilters: function (filters) {
+      filters.forEach(function (filter) {
+        // eslint-disable-next-line no-underscore-dangle
+        var res = _.findWhere(this.options._filters, { name: filter.name });
+        res.value = filter.value;
+      }, this);
+      this._updateFilteredDataset();
     },
 
     render: function () {

--- a/app/assets/javascripts/views/front/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/front/dashboardFiltersView.js
@@ -1,0 +1,142 @@
+((function (App) {
+  'use strict';
+
+  App.View.DashboardFiltersView = Backbone.View.extend({
+
+    template: HandlebarsTemplates['front/dashboard-filters'],
+
+    defaults: {
+      // Original dataset
+      data: [],
+      // Fields that can be used to filter
+      filteringFields: [],
+      // Internal, dataset after the filters were applied
+      _filteredData: [],
+      // Internal, list of filters with their values
+      // Example:
+      // [
+      //   { name: 'Filter 1', value: 'a', values: [ 'a', 'b', 'c' ] }
+      // ]
+      // NOTE: the values are sorted
+      _filters: []
+    },
+
+    events: {
+      'change .js-filter': '_onChangeFilter'
+    },
+
+    initialize: function (settings) {
+      this.options = Object.assign({}, this.defaults, settings);
+      // eslint-disable-next-line no-underscore-dangle
+      this.options._filteredData = this._copyDataset(this.options.data);
+      this._initFilters();
+      this.render();
+    },
+
+    /**
+     * Event handler for a filter change
+     * @param {object} e - event object
+     */
+    _onChangeFilter: function (e) {
+      var id = +e.target.dataset.id;
+      var value = e.target.selectedOptions[0].value;
+
+      // If the user reset the filter, we set its value to null
+      if (!value.length) {
+        // eslint-disable-next-line no-underscore-dangle
+        this.options._filters[id].value = null;
+        this._updateFilteredDataset();
+        return;
+      }
+
+      // If the values are numbers, we convert the selected option's value to
+      // a number too otherwise it will give us some issues with the filtering
+      // eslint-disable-next-line no-underscore-dangle
+      if (typeof this.options._filters[id].values[0] === 'number') {
+        value = +value;
+      }
+
+      // eslint-disable-next-line no-underscore-dangle
+      this.options._filters[id].value = value;
+      this._updateFilteredDataset();
+    },
+
+    /**
+     * Update the filtered dataset according to the current filters
+     */
+    _updateFilteredDataset: function () {
+      // eslint-disable-next-line no-underscore-dangle
+      var activeFilters = this.options._filters
+        .filter(function (filter) {
+          return !!filter.value;
+        });
+
+      // eslint-disable-next-line no-underscore-dangle
+      this.options._filteredData = this._copyDataset(this.options.data)
+        .filter(function (row) {
+          return activeFilters.reduce(function (res, filter) {
+            return res && (row[filter.name] === filter.value);
+          }, true);
+        });
+
+      // Everytime the filtered dataset is updated, we trigger it
+      this._triggerDataset();
+    },
+
+    /**
+     * Trigger the filter dataset
+     */
+    _triggerDataset: function () {
+      // eslint-disable-next-line no-underscore-dangle
+      this.trigger('dataset:change', this.options._filteredData);
+    },
+
+    /**
+     * Returns a copy of a dataset
+     * @param {object[]} dataset - dataset to copy
+     * @returns { object[]} newDataset
+     */
+    _copyDataset: function (dataset) {
+      var newDataset = [];
+      for (var i = 0, j = dataset.length; i < j; i++) {
+        newDataset.push(Object.assign({}, dataset[i]));
+      }
+      return newDataset;
+    },
+
+    /**
+     * Return the unique values of the selected field
+     * @param {string} field - field's name
+     * @returns {string[]} values - list of all the unique values
+     */
+    _getUniqueFieldValues: function (field) {
+      return this.options.data.map(function (row) {
+        return row[field];
+      }).filter(function (value, index, values) {
+        return values.indexOf(value) === index;
+      });
+    },
+
+    /**
+     * Init the _filters array
+     */
+    _initFilters: function () {
+      // eslint-disable-next-line no-underscore-dangle
+      this.options._filters = this.options.filteringFields.map(function (filter) {
+        return {
+          name: filter,
+          value: null,
+          values: this._getUniqueFieldValues(filter).sort()
+        };
+      }, this);
+    },
+
+    render: function () {
+      this.el.innerHTML = this.template({
+        // eslint-disable-next-line no-underscore-dangle
+        filters: this.options._filters
+      });
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/views/front/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/front/dashboardFiltersView.js
@@ -88,6 +88,15 @@
      */
     _triggerDataset: function () {
       // eslint-disable-next-line no-underscore-dangle
+      this.trigger('filters:change', this.options._filters.map(function (filter) {
+        return {
+          name: filter.name,
+          value: filter.value
+        };
+      }).filter(function (filter) {
+        return !!filter.value;
+      }));
+      // eslint-disable-next-line no-underscore-dangle
       this.trigger('dataset:change', this.options._filteredData);
     },
 

--- a/app/assets/stylesheets/components/shared/c-select.scss
+++ b/app/assets/stylesheets/components/shared/c-select.scss
@@ -1,0 +1,52 @@
+.c-select {
+  position: relative;
+
+  &::before {
+    display: block;
+    position: absolute;
+    top: 50%;
+    right: 5px;
+    width: 8px;
+    height: 2px;
+    transform: translate(-200%, 0) rotate(45deg) ;
+    background-color: $color-4;
+    content: '';
+  }
+
+  &::after {
+    display: block;
+    position: absolute;
+    top: 50%;
+    right: 17px;
+    width: 8px;
+    height: 2px;
+    transform: rotate(-45deg);
+    background-color: $color-4;
+    content: '';
+  }
+
+  > select {
+    width: 100%;
+    height: 35px;
+    padding: 0 37px 0 21px;
+    border-radius: 100px;
+    background: transparent;
+    color: $color-4;
+    font-family: $font-family-1;
+    font-size: $font-size-normal;
+    font-weight: $font-weight-normal;
+    letter-spacing: .1px;
+    line-height: 35px;
+    text-overflow: ellipsis;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+
+    @if $theme == 2 {
+      border: 1px solid $color-1;
+      text-transform: uppercase;
+    } @else {
+      border: 0;
+      background-color: rgba($color-1, .1);
+    }
+  }
+}

--- a/app/assets/stylesheets/layouts/front/l-analysis-dashboard.scss
+++ b/app/assets/stylesheets/layouts/front/l-analysis-dashboard.scss
@@ -60,16 +60,6 @@ $secondary-container-initial-width: 400px;
   .filters {
     height: 35px;
     margin-top: 20px;
-    line-height: 35px;
-    text-align: center;
-    text-transform: uppercase;
-
-    @if $theme == 2 {
-      background: rgba($color-4, .1);
-    } @else {
-      background: rgba($color-1, .1);
-      color: $color-1;
-    }
   }
 
   .map {

--- a/app/assets/stylesheets/layouts/front/l-analysis-dashboard.scss
+++ b/app/assets/stylesheets/layouts/front/l-analysis-dashboard.scss
@@ -58,8 +58,25 @@ $secondary-container-initial-width: 400px;
   }
 
   .filters {
-    height: 35px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     margin-top: 20px;
+
+    @media #{$mq-tablet} {
+      flex-direction: row;
+      align-items: flex-start;
+      height: 35px;
+    }
+
+    > *:not(:last-of-type) {
+      margin-bottom: 15px;
+
+      @media #{$mq-tablet} {
+        margin-bottom: 0;
+        margin-right: 17px;
+      }
+    }
   }
 
   .map {

--- a/app/views/site_page/analysis_dashboard.html.erb
+++ b/app/views/site_page/analysis_dashboard.html.erb
@@ -10,7 +10,6 @@
       <%= @site_page.description %>
     </p>
     <div class="filters js-filters">
-      Filters coming soon
     </div>
     <div class="map js-map">
     </div>


### PR DESCRIPTION
This PR adds simple filters to the dashboard. With them, the user can fix a specific value to a column and see the result on the charts that update automatically. They are also stored in the global state (and thus the URL and the bookmarks) so they can be restored later.

Until we have detailed designs, feedback from the client and know what's possible with the dataset API, the filters will keep being simple.

**NOTE:** As the rest of the dashboard, the dates are not supported yet.