### PR TITLE
Feature/tree structure refactor

### DIFF
--- a/app/assets/javascripts/helpers/handlebars.js
+++ b/app/assets/javascripts/helpers/handlebars.js
@@ -1,4 +1,10 @@
 Handlebars.registerHelper('if_eq', function (a, b, opts) {
-  if (a === b) return opts.fn(this);
+  // This code is really tricky: when Handlebars is passed the value null, it replaces it with an empty object.
+  // Nevertheless, any other value is also converted to an object using the constructor Boolean, Number or String
+  var isNullObject = function (obj) {
+    return (obj instanceof Object) && !(obj instanceof Number) && !(obj instanceof Boolean) && !Object.keys(obj).length;
+  };
+
+  if (a === b || (b === null && isNullObject(a))) return opts.fn(this);
   return opts.inverse(this);
 });

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -31,12 +31,23 @@
         ]
       });
 
+      this.treeContainer = document.querySelector('.js-tree');
+
       // We build the tree structure of the site
       this.treeStructureView = new App.View.TreeStructureView({
-        el: $('.js-tree'),
-        collection: new Backbone.Collection(gon.structure)
+        el: this.treeContainer,
+        collection: new Backbone.Collection(gon.structure),
+        pageTemplate: this._getPageTemplate(),
+        additionalPageTemplate: this._getAdditionalPageTemplate(),
+        moveCallback: this._onMovePage.bind(this),
+        renderCallback: this._onRenderTree.bind(this)
       });
 
+      // We attach event listeners for the buttons in the action bar
+      $('.js-submit').on('click', this._onClickSubmit.bind(this));
+      $('.js-reset').on('click', this._onClickReset.bind(this));
+
+      // If the tree has been saved successfully, we display a notification
       if (state && state === 'success') {
         new App.View.NotificationView({
           content: 'The structure has been successfully saved!',
@@ -45,24 +56,285 @@
           visible: true
         });
       }
+    },
 
-      // On pressing submit
-      $('.js-submit').on('click', function (event) {
-        event.preventDefault();
-        new App.View.NotificationView({
-          content: 'Saving the structure...',
-          closeable: false,
-          autoCloseTimer: 5,
-          visible: true
-        });
-        this.treeStructureView.save(gon.updateStructurePath);
-      }.bind(this));
+    /**
+     * Event handler for when the submit button is clicked
+     * @param {object} e - event object
+     */
+    _onClickSubmit: function (e) {
+      e.preventDefault();
 
-      // On pressing reset
-      $('.js-reset').on('click', function (event) {
-        event.preventDefault();
-        this.treeStructureView.reset();
+      this._hideSaveWarning();
+      this._hideVisibilityWarning();
+      this._hideErrorNotification();
+      this._displaySavingNotification();
+
+      $.ajax({
+        url: gon.updateStructurePath,
+        type: 'PUT',
+        contentType: 'application/json',
+        data: JSON.stringify({ collection: [this.treeStructureView.getTree()] })
+      }).fail(function () {
+        this._hideSavingNotification();
+        this._displayErrorNotification();
       }.bind(this));
+    },
+
+    /**
+     * Event handler for when the reset button is clicked
+     * @param {object} e - event object
+     */
+    _onClickReset: function (e) {
+      e.preventDefault();
+      this._hideSaveWarning();
+      this._hideVisibilityWarning();
+      this._hideSavingNotification();
+      this._hideErrorNotification();
+      this.treeStructureView.reset();
+    },
+
+    /**
+     * Callback for when a page is moved
+     */
+    _onMovePage: function () {
+      // We let the user know they must not forget to save before leaving the page
+      this._displaySaveWarning();
+    },
+
+    /**
+     * Callback for when the tree is rendered
+     */
+    _onRenderTree: function () {
+      $(this.treeContainer).find('.js-enable').on('click', this._onClickEnable.bind(this));
+      $(this.treeContainer).find('.js-disable').on('click', this._onClickDisable.bind(this));
+      $(this.treeContainer).find('.js-add').on('click', this._onClickAddPage.bind(this));
+    },
+
+    /**
+     * Event listener for when the enable button is clicked on a node
+     * @param {object} e - event object
+     */
+    _onClickEnable: function (e) {
+      e.preventDefault();
+      var node = $(e.target).closest('.js-draggable')[0];
+      this.toggleEnable(node, true);
+    },
+
+    /**
+     * Event listener for when the disable button is clicked on a node
+     * @param {object} e - event object
+     */
+    _onClickDisable: function (e) {
+      e.preventDefault();
+      var node = $(e.target).closest('.js-draggable')[0];
+      this.toggleEnable(node, false);
+    },
+
+    /**
+     * Event listener for when the add page button is clicked
+     * @param {object} e - event object
+     */
+    _onClickAddPage: function (e) {
+      e.preventDefault();
+      var node = $(e.target).closest('.js-draggable')[0];
+      window.location = '' + gon.addPagePath + '?parent=' + $(node).attr('id').match(/\d+/)[0];
+    },
+
+    /**
+     * Return the template of a page
+     * @returns {string} template
+     */
+    _getPageTemplate: function () {
+      return '\
+        <span>{{name}}</span>\
+        <ul class="action-buttons">\
+          {{#if disableable}}\
+            {{#if enabled}}\
+                <li><button class="view-button js-disable">Disable</button></li>\
+            {{else}}\
+                <li><button class="view-button-slashed js-enable">Enable</button></li>\
+            {{/if}}\
+          {{/if}}\
+          <li><a href="{{#if editUrl}}{{editUrl}}{{else}}{{editurl}}{{/if}}" class="edit-button">Edit</a></li>\
+          {{#if disableable}}\
+            <li><a rel="nofollow" data-method="delete" data-confirm="Are you sure you want to delete this page?" href="{{#if deleteUrl}}{{deleteUrl}}{{else}}{{deleteurl}}{{/if}}" class="delete-button">Delete</a></li>\
+          {{/if}}\
+        </ul>\
+      ';
+    },
+
+    /**
+     * Return the template for the additional pages located at the end of each branch
+     * @returns {string} template
+     */
+    _getAdditionalPageTemplate: function () {
+      return '<button type="button" class="js-add add-page-button">Add page</button>';
+    },
+
+    /**
+     * Display a warning to remember the user to save the tree before
+     * clicking any button that would leave the page
+     */
+    _displaySaveWarning: function () {
+      if (this.saveNotification) {
+        this.saveNotification.show();
+        return;
+      }
+
+      this.saveNotification = new App.View.NotificationView({
+        content: 'Don\'t forget to save the changes before leaving the page!',
+        type: 'warning',
+        visible: true
+      });
+    },
+
+    /**
+     * Hide the warning remembering the user to save before leaving
+     * the page
+     */
+    _hideSaveWarning: function () {
+      if (this.saveNotification) {
+        this.saveNotification.hide();
+      }
+    },
+
+    /**
+     * Display a warning to remember the user that if they enable a page
+     * that as disabled ancestors, it won't be visible until they are all enabled
+     */
+    _displayVisibilityWarning: function () {
+      if (this.visibilityNotification) {
+        this.visibilityNotification.show();
+        return;
+      }
+
+      this.visibilityNotification = new App.View.NotificationView({
+        content: 'This page won\'t be visible to the users until all of its ancestors are enabled!',
+        type: 'warning',
+        visible: true
+      });
+    },
+
+    /**
+     * Hide the warning to remember the user that if they enable a page
+     * that as disabled ancestors, it won't be visible until they are all enabled
+     */
+    _hideVisibilityWarning: function () {
+      if (this.visibilityNotification) {
+        this.visibilityNotification.hide();
+      }
+    },
+
+    /**
+     * Display a notification to inform the user the tree is saving
+     */
+    _displaySavingNotification: function () {
+      if (this.savingNotification) {
+        this.savingNotification.show();
+        return;
+      }
+
+      this.savingNotification = new App.View.NotificationView({
+        content: 'Saving the structure...',
+        closeable: false,
+        visible: true
+      });
+    },
+
+    /**
+     * Hide the notification to inform the user the tree is saving
+     */
+    _hideSavingNotification: function () {
+      if (this.savingNotification) {
+        this.savingNotification.hide();
+      }
+    },
+
+    /**
+     * Display an error if the structure couldn't be saved in the backend
+     */
+    _displayErrorNotification: function () {
+      if (this.errorNotification) {
+        this.errorNotification.show();
+        return;
+      }
+
+      this.errorNotification = new App.View.NotificationView({
+        content: 'The changes couldn\'t be saved',
+        type: 'error',
+        visible: true
+      });
+    },
+
+    /**
+     * Hide the error telling the user the structure couldn't be saved
+     */
+    _hideErrorNotification: function () {
+      if (this.errorNotification) {
+        this.errorNotification.hide();
+      }
+    },
+
+    /**
+     * Recursively, toggle the enabled attribute of the subtree whose root is designated
+     * If nodeId is null, toggle the attribute for all the nodes / subtree
+     * @param {object}   currentNode - the current node / subtree
+     * @param {number}   nodeId - id of the target node, can be null
+     * @param {array}    ancestorsVisibility - visibility of the direct ancestors (true = visible)
+     * @enable {boolean} enable - whether to enable or disable the subtree
+     */
+    _toggleEnableRecursive: function (currentNode, nodeId, ancestorsVisibility, enable) {
+      var newNode = currentNode;
+      // The current node is the targeted node if:
+      //  1/ We're not searching for a concrete node and we want do disable the pages
+      //  2/ It is effectively the targeted node :)
+      var isTargetedNode = (!nodeId && !enable) || (currentNode.id === nodeId);
+
+      if (isTargetedNode) {
+        if (enable) {
+          var hasDisabledAncestor = ancestorsVisibility.reduce(function (res, vis) {
+            return res || !vis;
+          }, false);
+
+          // If the node we want to enable has a disabled ancestor, a warning is displayed
+          // to inform the user the page won't be visible until all of its ancestors are visible
+          if (hasDisabledAncestor) {
+            this._displayVisibilityWarning();
+          }
+        }
+
+        newNode.enabled = enable;
+      }
+
+      if (newNode.children) {
+        var newAncestorsVisibility = ancestorsVisibility.concat([currentNode.enabled]);
+        newNode.children = newNode.children.map(function (childNode) {
+          return this._toggleEnableRecursive(childNode, isTargetedNode ? null : nodeId, newAncestorsVisibility, enable);
+        }, this);
+      }
+
+      return newNode;
+    },
+
+    /**
+     * Toggle the visibility of a node
+     * @param {object}  node - DOM element
+     * @param {boolean} enable - whether to enable or disable
+     */
+    toggleEnable: function (node, enable) {
+      var nodeId = node.id.match(/^page-(\d+)/);
+
+      if (!nodeId || nodeId.length < 2) {
+        // TODO: the user clicked on the root
+        return;
+      }
+
+      nodeId = +nodeId[1];
+
+      var rootNode = this.treeStructureView.getTree();
+      var newTree = this._toggleEnableRecursive(rootNode, nodeId, [], enable);
+      this.treeStructureView.setTree(newTree);
     }
   });
 })(this.App));

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -55,6 +55,8 @@
           autoCloseTimer: 5,
           visible: true
         });
+
+        this.navigate('/', { replace: true });
       }
     },
 

--- a/app/assets/javascripts/templates/management/tree-structure.hbs
+++ b/app/assets/javascripts/templates/management/tree-structure.hbs
@@ -1,23 +1,24 @@
 {{#*inline "item"}}
   <ul {{#if firstCall}}class="js-tree-root"{{/if}}>
     {{#each pages}}
-      <li class="js-draggable" id="page-{{id}}" data-name="{{name}}" data-parent="{{parent_id}}"
-          data-position="{{position}}" data-enabled="{{enabled}}" data-type="{{type}}">
-        <div class="page {{#unless enabled}} -disabled {{/unless}} js-handle">
-          <span>{{name}}</span>
-          <ul class="action-buttons">
-            {{#if disableable}}
-              {{#if enabled}}
-                  <li><button class="view-button js-disable">Disable</button></li>
+      <li
+        class="js-draggable"
+        {{#each this}}
+          {{#if_eq @key 'id'}}
+            id="page-{{this}}"
+          {{else}}
+            {{#if_eq @key 'children'}}
+            {{else}}
+              {{#if_eq this null}}
               {{else}}
-                  <li><button class="view-button-slashed js-enable">Enable</button></li>
-              {{/if}}
-            {{/if}}
-            <li><a href="{{editUrl}}" class="edit-button">Edit</a></li>
-            {{#if disableable}}
-              <li><a rel="nofollow" data-method="delete" data-confirm="Are you sure you want to delete this page?" href="{{deleteUrl}}" class="delete-button">Delete</a></li>
-            {{/if}}
-          </ul>
+                data-{{@key}}="{{this}}"
+              {{/if_eq}}
+            {{/if_eq}}
+          {{/if_eq}}
+        {{/each}}
+      >
+        <div class="page {{#unless enabled}} -disabled {{/unless}} js-handle">
+          {{> pageTemplate}}
         </div>
         {{#if children}}
           {{> item pages=children firstCall=false}}
@@ -26,7 +27,7 @@
     {{/each}}
     {{#unless firstCall}}
       <li class="js-not-nestable">
-        <button type="button" class="add-page-button">Add page</button>
+        {{> additionalPageTemplate}}
       </li>
     {{/unless}}
   </ul>

--- a/app/views/management/sites/structure.html.erb
+++ b/app/views/management/sites/structure.html.erb
@@ -15,4 +15,3 @@
     <%= link_to 'Save', management_site_update_structure_path(@site.slug), class: 'c-button js-submit' %>
   </div>
 </div>
-<%= console if Rails.env.development? %>

--- a/vendor/assets/javascripts/jquery-nested-sortable.js
+++ b/vendor/assets/javascripts/jquery-nested-sortable.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
  * jQuery UI Nested Sortable
  * v 2.1a / 2016-02-04
@@ -905,3 +906,4 @@
 		$.mjs.nestedSortable.prototype.options
 	);
 }));
+/* eslint-enable */


### PR DESCRIPTION
This PR decreases the coupling between the tree structure view and the structure page. The goal was to make the view reusable for other parts of the application.

In addition, the refactoring solved two undiscovered issues:
* when moving a page in the tree, not only the links of all of them to enable, edit and delete would disappear but also all the data that wasn't attached to the DOM
* the data sent to the server to save the tree was unnecessary heavy (we used to send the backbone collection instead of the raw data)