### PR TITLE
Implements the map on the dashboard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,9 @@
     "SirTrevor": true,
     "gon": true,
     "Fuse": true,
-    "Jiminy": true
+    "Jiminy": true,
+    "PruneClusterForLeaflet": true,
+    "PruneCluster": true
   },
   "env": {
     "browser": true

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-jquery-ui'
   gem 'rails-assets-fuse.js'
   gem 'rails-assets-datalib', '1.7.3'
+  gem 'rails-assets-SINTEF-9012--PruneCluster', '1.1.0'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-assets-SINTEF-9012--PruneCluster (1.1.0)
     rails-assets-backbone (1.3.3)
       rails-assets-underscore (>= 1.8.3)
     rails-assets-d3 (3.5.17)
@@ -307,6 +308,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.0)
   rails (>= 5.0.0, < 5.1)
+  rails-assets-SINTEF-9012--PruneCluster (= 1.1.0)!
   rails-assets-backbone!
   rails-assets-d3 (~> 3.5.16)!
   rails-assets-datalib (= 1.7.3)!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require d3
 //= require vega
 //= require leaflet
+//= require PruneCluster/PruneCluster
 //= require handlebars
 //= require object-assign-polyfill
 //= require datalib

--- a/app/assets/javascripts/views/shared/mapWidgetView.js
+++ b/app/assets/javascripts/views/shared/mapWidgetView.js
@@ -1,0 +1,158 @@
+((function (App) {
+  'use strict';
+
+  App.View.MapWidgetView = Backbone.View.extend({
+    className: 'c-map-widget',
+
+    defaults: {
+      // Data to display on the chart
+      data: [],
+      // Name of the default representation (only "dots" for now)
+      type: null,
+      // Center of the map
+      center: [0, 0],
+      // Zoom of the map
+      zoom: 3,
+      // Name of the fields used to position the dots on the map
+      // { lat, lng }
+      fields: {},
+      // Options to be passed at the map instantiation
+      mapOptions: {
+        scrollWheelZoom: false
+      }
+    },
+
+    initialize: function (settings) {
+      this.options = Object.assign({}, this.defaults, settings);
+    },
+
+    /**
+     * Attach all the listeners that are not dependent on a DOM element
+     */
+    _setListeners: function () {
+      if (!this.map) return;
+
+      this.map.on('zoomend moveend', function () {
+        this.options.center = [this.map.getCenter().lat, this.map.getCenter().lng];
+        this.options.zoom = this.map.getZoom();
+        this._triggerState();
+      }.bind(this));
+    },
+
+    /**
+     * Trigger the state
+     */
+    _triggerState: function () {
+      this.trigger('state:change', {
+        lat: this.options.center[0],
+        lng: this.options.center[1],
+        zoom: this.options.zoom
+      });
+    },
+
+    /**
+     * Remove all the layers concerning the data from the map
+     */
+    _removeDataLayers: function () {
+      this.map.eachLayer(function (layer) {
+        if (layer !== this.basemap) this.map.removeLayer(layer);
+      }, this);
+    },
+
+    /**
+     * Create the icon for a dot on the map
+     */
+    _createDotIcon: function () {
+      return L.divIcon({
+        className: 'dot',
+        iconSize: [15, 15]
+      });
+    },
+
+    /**
+     * Get the content of the popup for a dot on the map
+     * @param {object} data - data associated with the marker
+     */
+    _getPopupContent: function (data) {
+      var index = data.index;
+      var row = this.options.data[index];
+      return '<div class="popup">' +
+        Object.keys(row).map(function (key) {
+          return '<div class="row"><span class="name">' + key + '</span><span class="value">' + row[key] + '</span></div>';
+        }).join('') +
+        '</div>';
+    },
+
+    /**
+     * Render the dots on the map
+     */
+    _renderDots: function () {
+      this.dots = new PruneClusterForLeaflet();
+
+      // Icon for the cluster
+      this.dots.BuildLeafletClusterIcon = function (cluster) {
+        return L.divIcon({
+          className: 'cluster',
+          iconSize: [30, 30],
+          html: '<span>' + (cluster.population > 99 ? '99+' : cluster.population) + '</span>'
+        });
+      };
+
+      this.options.data.forEach(function (row, index) {
+        var lat = row[this.options.fields.lat];
+        var lng = row[this.options.fields.lng];
+        var marker = new PruneCluster.Marker(lat, lng);
+        marker.data.icon = this._createDotIcon;
+        marker.data.popup = this._getPopupContent.bind(this);
+        marker.data.index = index;
+        // eslint-disable-next-line new-cap
+        this.dots.RegisterMarker(marker);
+      }, this);
+
+      this.dots.addTo(this.map);
+    },
+
+    /**
+     * Render the data on the map
+     */
+    _renderData: function () {
+      this._removeDataLayers();
+
+      if (this.options.type === 'dots') {
+        if (!this.options.fields.lat || !this.options.fields.lng) {
+          // eslint-disable-next-line no-console
+          console.warn('The fields name to position the dots are needed');
+          return;
+        }
+        this._renderDots();
+      }
+
+      // We save the state of the map each time we render as it can be the
+      // consequence of a change in the configuration
+      this._triggerState();
+    },
+
+    render: function () {
+      if (this.map) {
+        this.map.setView(this.options.center, this.options.zoom);
+        this._removeDataLayers();
+        this._renderData();
+      } else {
+        this.el.classList.add(this.className);
+
+        this.map = L.map(this.el, this.options.mapOptions)
+          .setView(this.options.center, this.options.zoom);
+
+        this.basemap = L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}@2x.png', {
+          attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        }).addTo(this.map);
+
+        this._setListeners();
+        this._renderData();
+      }
+
+      return this.el;
+    }
+
+  });
+})(this.App));

--- a/app/assets/stylesheets/components/front/c-map-widget.scss
+++ b/app/assets/stylesheets/components/front/c-map-widget.scss
@@ -1,0 +1,39 @@
+.c-map-widget {
+
+  .cluster,
+  .dot {
+    border-radius: 100%;
+    background-color: $color-1;
+  }
+
+  .cluster {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    span {
+      color: $color-3;
+      font-family: $font-family-1;
+      font-size: $font-size-small;
+    }
+  }
+
+  .popup {
+    .row {
+      display: flex;
+      justify-content: space-between;
+      color: $color-4;
+      font-family: $font-family-1;
+      font-size: $font-size-small;
+      line-height: 1.5;
+
+      > .name {
+        font-weight: $font-weight-bold;
+      }
+
+      > .value {
+        margin-left: 15px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR makes implements the map on the dashboard.

It displays the rows as dots and when the user clicks on them, a popup with all the data is opened. Because the number of dots can be high, they are grouped as cluster.

NOTE: for now, the map will display the rows who have fields called `latitude` and `longitude`. Once the logic is built in the back end and the management section, this limit will be removed.