### PR TITLE
Implements and styles the filters step

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-fuse.js'
   gem 'rails-assets-datalib', '1.7.3'
   gem 'rails-assets-SINTEF-9012--PruneCluster', '1.1.0'
+  gem 'rails-assets-select2', '4.0.3'
 end
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
     rails-assets-jquery-ui (1.12.1)
       rails-assets-jquery (>= 1.6)
     rails-assets-leaflet (1.0.1)
+    rails-assets-select2 (4.0.3)
     rails-assets-underscore (1.8.3)
     rails-assets-vega (2.6.3)
       rails-assets-d3 (>= 3.5.6, < 4)
@@ -315,6 +316,7 @@ DEPENDENCIES
   rails-assets-fuse.js!
   rails-assets-jquery-ui!
   rails-assets-leaflet (= 1.0.1)!
+  rails-assets-select2 (= 4.0.3)!
   rails-assets-vega (~> 2.6.3)!
   rspec-core!
   rspec-expectations!

--- a/app/assets/javascripts/helpers/handlebars.js
+++ b/app/assets/javascripts/helpers/handlebars.js
@@ -1,3 +1,6 @@
+/**
+ * Provide a way to compare two values (i.e. classic condition)
+ */
 Handlebars.registerHelper('if_eq', function (a, b, opts) {
   // This code is really tricky: when Handlebars is passed the value null, it replaces it with an empty object.
   // Nevertheless, any other value is also converted to an object using the constructor Boolean, Number or String
@@ -7,4 +10,54 @@ Handlebars.registerHelper('if_eq', function (a, b, opts) {
 
   if (a === b || (b === null && isNullObject(a))) return opts.fn(this);
   return opts.inverse(this);
+});
+
+/**
+ * Provide an iterator through the list of values between a min and a max value (inclusive),
+ * with the provided step
+ */
+Handlebars.registerHelper('each_range', function (min, max, step, block) {
+  // Javascript is a player: if it has to sum 1.6 with 0.1, then it will return 1.7000000000000002
+  // For this reason, we have a method to count the number of decimals of a number so we
+  // later return the exact value
+  var getDecimalsCount = function (number) {
+    var str = number + '';
+    var split = str.split('.');
+    return (split.length === 1) ? 0 : split[1].length;
+  };
+
+  var count = ((max - min) / step) + 1;
+  var stepDecimals = getDecimalsCount(step); // Maxiumum number of decimals allowed
+
+  return new Array(count).fill(null).map(function (value, index) {
+    var res = min + (index * step);
+    res = +res.toFixed(stepDecimals);
+    return block.fn(res);
+  }).reduce(function (res, value) {
+    return res + value;
+  }, '');
+});
+
+/**
+ * Provide a conditional helper which checks if value is contained into array
+ */
+Handlebars.registerHelper('if_contains', function (array, value, opts) {
+  array = array || []; // eslint-disable-line no-param-reassign
+  if (array.indexOf(value) !== -1) return opts.fn(this);
+  return opts.inverse(this);
+});
+
+/**
+ * Provide a way to format dates as MM/DD/YYYY
+ */
+Handlebars.registerHelper('format_date', function (date) {
+  if (!(date instanceof Date)) {
+    date = new Date(date); // eslint-disable-line no-param-reassign
+  }
+
+  var day = date.getUTCDate();
+  var month = date.getUTCMonth() + 1;
+  var year = date.getUTCFullYear();
+
+  return [month, day, year].join('/');
 });

--- a/app/assets/javascripts/management.js
+++ b/app/assets/javascripts/management.js
@@ -25,6 +25,7 @@
 //= require fuse.js/fuse
 //= require object-assign-polyfill
 //= require jiminy
+//= require select2
 
 //= require_self
 

--- a/app/assets/javascripts/routers/management/FiltersStepRouter.js
+++ b/app/assets/javascripts/routers/management/FiltersStepRouter.js
@@ -11,9 +11,34 @@
       this.slug = params[0] || null;
     },
 
+    /**
+     * Return the fields used by the dashboardFiltersView
+     * TODO: most of it needs to be removed when the back end returns
+     * the correct values
+     * @returns {object[]} fields
+     */
+    _getFields: function () {
+      return (window.gon && gon.fields).map(function (field) {
+        if (field.type === 'date') {
+          field.min = new Date(field.min);
+          field.max = new Date(field.max);
+
+          // If the date couldn't be parsed, we just remove the field
+          if (Number.isNaN(field.min.getTime()) || Number.isNaN(field.max.getTime())) {
+            return null;
+          }
+        }
+
+        return field;
+      }).filter(function (field) {
+        return !!field;
+      });
+    },
+
     index: function () {
       var dashboardFiltersView = new App.View.DashboardFiltersView({
-        el: '.js-filters'
+        el: '.js-filters',
+        fields: this._getFields()
       });
 
       $('.js-form').on('submit', function () {

--- a/app/assets/javascripts/routers/management/FiltersStepRouter.js
+++ b/app/assets/javascripts/routers/management/FiltersStepRouter.js
@@ -39,7 +39,7 @@
       var dashboardFiltersView = new App.View.DashboardFiltersView({
         el: '.js-filters',
         fields: this._getFields(),
-        endpointUrl: window.gon.filtersEndpointUrl
+        endpointUrl: (window.gon && gon.filtersEndpointUrl) || null
       });
 
       $('.js-form').on('submit', function () {

--- a/app/assets/javascripts/routers/management/FiltersStepRouter.js
+++ b/app/assets/javascripts/routers/management/FiltersStepRouter.js
@@ -38,7 +38,8 @@
     index: function () {
       var dashboardFiltersView = new App.View.DashboardFiltersView({
         el: '.js-filters',
-        fields: this._getFields()
+        fields: this._getFields(),
+        endpointUrl: window.gon.filtersEndpointUrl
       });
 
       $('.js-form').on('submit', function () {

--- a/app/assets/javascripts/templates/management/dashboard-filters.hbs
+++ b/app/assets/javascripts/templates/management/dashboard-filters.hbs
@@ -1,26 +1,110 @@
-<div class="c-filters">
+<div class="c-dashboard-filters">
   <input type="hidden" id="site_page_dataset_setting_filters" name="site_page[dataset_setting][filters]" value="{{json}}">
 
   {{#each filters}}
-    <div>
-      <label>Filter {{id}}</label>
-      <div>
-        <select id="filter-{{@index}}" data-id="{{@index}}" class="js-input-field">
-            <option value="" disabled="disabled" {{#unless name}}selected="selected"{{/unless}}>Choose a field</option>
-            {{#each ../fields}}
-              <option value="{{name}}" {{#if_eq name ../name}}selected="selected"{{/if_eq}}>{{name}}</option>
+    <div class="filter">
+      <select id="filter-{{@index}}" data-id="{{@index}}" data-placeholder="Choose a field" class="js-field" {{#if name}}disabled="disabled"{{/if}}>
+        <option></option>
+        {{#if name}}
+          <option value="{{name}}" selected="selected">{{name}}</option>
+        {{else}}
+          {{#each ../fields}}
+            <option value="{{name}}">{{name}}</option>
+          {{/each}}
+        {{/if}}
+      </select>
+
+      {{!-- Fields for the type "number" --}}
+      {{#if name}}
+        {{#if_eq type 'number'}}
+          <select class="js-from-value" data-id="{{@index}}" data-selector-type="from" data-placeholder="From">
+            <option></option>
+            {{#if to}}
+              {{#each_range min to step}}
+                <option value="{{this}}" {{#if_eq this ../from}}selected="selected"{{/if_eq}}>{{this}}</option>
+              {{/each_range}}
+            {{else}}
+              {{#each_range min max step}}
+                <option value="{{this}}" {{#if_eq this ../from}}selected="selected"{{/if_eq}}>{{this}}</option>
+              {{/each_range}}
+            {{/if}}
+          </select>
+          <select class="js-to-value" data-id="{{@index}}" data-selector-type="to" data-placeholder="To">
+            <option></option>
+            {{#if from}}
+              {{#each_range from max step}}
+                <option value="{{this}}" {{#if_eq this ../to}}selected="selected"{{/if_eq}}>{{this}}</option>
+              {{/each_range}}
+            {{else}}
+              {{#each_range min max step}}
+                <option value="{{this}}" {{#if_eq this ../to}}selected="selected"{{/if_eq}}>{{this}}</option>
+              {{/each_range}}
+            {{/if}}
+          </select>
+        {{/if_eq}}
+
+        {{!-- Fields for the type "date" --}}
+        {{#if_eq type 'date'}}
+          <input
+            type="date"
+            class="js-from-value"
+            data-id="{{@index}}"
+            data-selector-type="from"
+            data-min="{{format_date min}}"
+            {{#if to}}
+              data-max="{{format_date to}}"
+            {{else}}
+              data-max="{{format_date max}}"
+            {{/if}}
+            placeholder="From"
+            {{#if from}}
+              value="{{format_date from}}"
+            {{/if}}
+          />
+          <input
+            type="date"
+            class="js-to-value"
+            data-id="{{@index}}"
+            data-selector-type="to"
+            data-max="{{format_date max}}"
+            {{#if from}}
+              data-min="{{format_date from}}"
+            {{else}}
+              data-min="{{format_date min}}"
+            {{/if}}
+            placeholder="To"
+            {{#if to}}
+              value="{{format_date to}}"
+            {{/if}}
+          />
+        {{/if_eq}}
+
+        {{!-- Fields for the type "string" --}}
+        {{#if_eq type 'string'}}
+          <select class="values-selector js-values" data-id="{{@index}}" multiple data-placeholder="Select the values">
+            {{#each values}}
+              <option value="{{this}}" {{#if_contains ../selectedValues this}}selected="selected"{{/if_contains}}>{{this}}</option>
             {{/each}}
+          </select>
+        {{/if_eq}}
+
+        {{!-- Field to select if the filter is variable --}}
+        <select class="js-variable" data-id="{{@index}}">
+          <option value="0" {{#unless variable}}selected="selected"{{/unless}}>Not variable</option>
+          <option value="1" {{#if variable}}selected="selected"{{/if}}>Variable</option>
         </select>
-        <input type="text" id="from-{{@index}}" data-name="from" data-id="{{@index}}" class="js-input-filter" placeholder="From" value="{{from}}">
-        <input type="text" id="to-{{@index}}" data-name="to" data-id="{{@index}}" class="js-input-filter" placeholder="To" value="{{to}}">
-        <input type="checkbox" id="variable-{{@index}}" data-id="{{@index}}" class="js-input-variable" {{#if variable}}checked="checked"{{/if}}>
-        <label for="variable-{{@index}}">Variable</label>
-        <button type="button" id="remove-{{@index}}" data-id="{{@index}}" class="js-remove-filter">Remove Filter</button>
-      </div>
+      {{/if}}
+      {{#if type}}
+        <button type="button" id="remove-{{@index}}" data-id="{{@index}}" class="remove-button js-remove-filter" title="Remove filter">Remove filter</button>
+      {{/if}}
     </div>
   {{/each}}
 
-  <div>
-    <button type="button" class="add-filter js-add-filter">Add filter</button>
+  <div class="action-bar">
+      <button type="button" class="c-button -outline -dark-text {{#if canAddNewField}}js-add-filter{{else}}-disabled{{/if}}">Add filter</button>
+      <div>
+        <div class="js-row-count"></div>
+        <button type="button" class="c-button -outline -dark-text js-preview">Preview table</button>
+      </div>
   </div>
 </div>

--- a/app/assets/javascripts/views/management/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/management/dashboardFiltersView.js
@@ -7,79 +7,389 @@
     collection: new Backbone.Collection(),
 
     defaults: {
+      // List of fields
+      // The format must follow these rules:
+      //  * the type of the fields must be either "number", "string" or "date"
+      //  * if the field is type "number" or "date", it must have a min and max attribute
+      //  * if the field is type "string", it must have a list of the values
+      // Here is an example:
+      // [
+      //   {
+      //     "name": "age",
+      //     "type": "number",
+      //     "min": 10,
+      //     "max": 20,
+      //   },
+      //   {
+      //     "name": "year",
+      //     "type": "date",
+      //     "min": "10/01/2015",
+      //     "max": "27/12/2015",
+      //   },
+      //   {
+      //     "name": "name",
+      //     "type": "string",
+      //     "values": ["Tiago", "Clément"]
+      //   }
+      // ]
+      fields: [],
       // State of the default filters
       defaultFilter: {
         name: null,
-        from: null,
-        to: null,
+        type: null,
         variable: false
       }
     },
 
     events: {
-      'click .js-add-filter': '_addFilter',
-      'click .js-remove-filter': '_removeFilter',
-      'blur .js-input-filter': '_updateFilter',
-      'change .js-input-variable': '_updateVariable',
-      'change .js-input-field': '_onChangeField'
+      'click .js-add-filter': '_onClickAddFilter',
+      'click .js-remove-filter': '_onClickRemoveFilter',
+      'change .js-field': '_onChangeField',
+      'change .js-from-value': '_onChangeFromToValue',
+      'change .js-to-value': '_onChangeFromToValue',
+      'change .js-values': '_onChangeValues',
+      'change .js-variable': '_onUpdateVariable',
+      'click .js-preview': '_onClickPreview'
     },
 
     initialize: function (settings) {
       this.options = Object.assign({}, this.defaults, settings);
-      this.fields = (window.gon && gon.fields) || [];
       this._addFilter(); // Add a default filter and render
+      this.activeRequestsCount = 0; // Number of active requests to get the table extract
+      this.warningNotification = new App.View.NotificationView({
+        type: 'warning',
+        closeable: false
+      });
     },
 
+    /**
+     * Event handler called when the user clicks the "Add filter" button
+     */
+    _onClickAddFilter: function () {
+      this._addFilter();
+    },
+
+    /**
+     * Event handler called when the user clicks the "Remove filter" button
+     * @param {object} e - event object
+     */
+    _onClickRemoveFilter: function (e) {
+      var index = +$(e.target).data('id');
+      var model = this.collection.at(index);
+      this.collection.remove(model);
+      this.render();
+    },
+
+    /**
+     * Event handler called when the user changes the field of a filter
+     * @param {object} e - event object
+     */
+    _onChangeField: function (e) {
+      var value = e.target.value;
+      var position = +e.target.dataset.id;
+      var model = this.collection.at(position);
+      model.set({
+        name: value,
+        type: _.findWhere(this.options.fields, { name: value }).type
+      });
+      this.render();
+    },
+
+    /**
+     * Event handler called when the "from" or "to" value of a filter is changed
+     * @param {object} e - object event
+     */
+    _onChangeFromToValue: function (e) {
+      var selector = e.target;
+      var index = +selector.dataset.id;
+      var model = this.collection.at(index);
+      var value = model.get('type') === 'date' ? selector.value : +selector.value;
+      var selectorType = selector.dataset['selector-type'];
+      var o = {};
+      o[selectorType] = model.get('type') === 'date' ? new Date(value) : value;
+      model.set(o);
+
+      // We need to render to disable some values of the "to" selector
+      this.render();
+    },
+
+    /**
+     * Event handler called when the selected values of a string filter are changed
+     */
+    _onChangeValues: function (e) {
+      var selector = e.target;
+      var index = +selector.dataset.id;
+      var model = this.collection.at(index);
+      var selectedOptions = Array.prototype.slice.call(selector.selectedOptions);
+      var values = selectedOptions.map(function (option) {
+        return option.value;
+      });
+      model.set({ values: values });
+      this.render();
+    },
+
+    /**
+     * Event handler called when the variable attribute of a filter is changed
+     */
+    _onUpdateVariable: function (e) {
+      var value = !!+e.target.value;
+      var position = +e.target.dataset.id;
+      var model = this.collection.at(position);
+      model.set({ variable: value });
+      this.render();
+    },
+
+    /**
+     * Event handler called when the user clicks the "Preview table" button
+     */
+    _onClickPreview: function () {
+      if (this.previewTimer) return;
+
+      if (!this.previewModal) {
+        this.previewModal = new (App.View.ModalView.extend({
+          render: this._renderPreviewTable.bind(this) // eslint-disable-line no-extra-bind
+        }))();
+      }
+
+      if (this.activeRequestsCount === 0) {
+        this.previewModal.open();
+      } else {
+        this.warningNotification.options.content = 'The preview is loading. Please wait...';
+        this.warningNotification.show();
+        this.previewTimer = setInterval(function () {
+          if (this.activeRequestsCount === 0) {
+            clearInterval(this.previewTimer);
+            this.previewTimer = null;
+            this.warningNotification.hide();
+            this.previewModal.open();
+          }
+        }.bind(this), 200);
+      }
+    },
+
+    /**
+     * Render the table into a string and return it
+     * @returns {string} HTML
+     */
+    _renderPreviewTable: function () {
+      var res = '<table class="c-table"><tr class="header">';
+      res += this.options.fields.map(function (field) {
+        return '<th>' + field.name + '</th>';
+      }).join('');
+      res += '</tr>';
+      res += this.tableExtract.rows.map(function (row) {
+        return '<tr>' +
+          Object.keys(row).map(function (field) {
+            return '<td>' + row[field] + '</td>';
+          }).join('') +
+          '</tr>';
+      }).join('');
+      res += '</table>';
+      return res;
+    },
+
+    /**
+     * Add a filter with the default options
+     */
     _addFilter: function () {
       this.collection.push(this.options.defaultFilter);
       this.render();
     },
 
-    _removeFilter: function (e) {
-      var index = $(e.target).data('id');
-      var model = this.collection.at(+index);
-      this.collection.remove(model);
-      this.render();
+    /**
+     * Return the step precision between two values
+     * The default step is 1, but if the min and max are close, the step is smaller
+     * @param {number} min
+     * @param {number} max
+     * @returns {number} step
+     */
+    _getStepPrecision: function (min, max) {
+      // eslint-disable-next-line no-nested-ternary
+      return (max - min <= 2) ? 0.1 : ((max - min <= 10) ? 0.5 : 1);
     },
 
-    _updateFilter: function (e) {
-      // TODO: Clement, check if there's a better way to do this
-      // var filter = e.target.id.match(/.*-/)[0].replace('-','');
-      var filter = e.target.getAttribute('data-name');
-      var value = e.target.value;
-      var position = +e.target.dataset.id;
-      var model = this.collection.at(position);
+    /**
+     * Enhance the selectors by initialising Select2 on the selects, and Jquery UI Datepicker on the
+     * inputs with type date
+     */
+    _enhanceSelectors: function () {
+      this.$el.find('select').select2({
+        width: 'off' // Auto width
+      });
 
-      var o = {};
-      o[filter] = value;
-      model.set(o);
+      var dateInputs = document.querySelectorAll('input[type=date]');
+      Array.prototype.slice.call(dateInputs).forEach(function (input) {
+        $(input).datepicker({
+          changeMonth: true,
+          changeYear: true,
+          minDate: input.dataset.min,
+          maxDate: input.dataset.max
+        });
+      });
     },
 
-    _onChangeField: function (e) {
-      var value = e.target.value;
-      var position = +e.target.dataset.id;
-      var model = this.collection.at(position);
-      model.set({ name: value });
+    /**
+     * Return the list of fields not used for the filtering
+     * NOTE: a field is considered as "used" when it has been selected on the screen, that
+     * does not mean it is actually filtered
+     * @returns {object[]} fields
+     */
+    _getUnusedFields: function () {
+      return this.options.fields.filter(function (field) {
+        var filter = _.findWhere(this.collection.toJSON(), { name: field.name });
+        return !filter;
+      }, this);
     },
 
-    _updateVariable: function (e) {
-      var value = e.target.checked;
-      var position = +e.target.dataset.id;
-      var model = this.collection.at(position);
-      model.set({ variable: value });
+    /**
+     * Return whether one of the filter isn't link to any column yet
+     * @returns {boolean} unspecifiedFilter
+     */
+    _isThereUnspecifiedFilter: function () {
+      return this.collection.toJSON().reduce(function (res, filter) {
+        return res || !filter.name;
+      }, false) || false;
     },
+
+    /**
+     * Return the list of serialized filters
+     * NOTE: filters non associated to a field are removed
+     * @returns {string} serializedFilters
+     */
+    _getSerializeFilters: function () {
+      var serializedFilters = this.collection.toJSON().map(function (filter) {
+        var res = Object.assign({}, filter);
+        delete res.type;
+        return res;
+      }).filter(function (filter) {
+        return filter.name;
+      });
+
+      return JSON.stringify(serializedFilters);
+    },
+
+    /**
+     * Get the URL to fetch the filtered table extract
+     * @returns {string} url
+     */
+    _getTableExtractURL: function () {
+      return '/management/sites/base-site/page_steps/filters/filtered_results.json' +
+      this.collection.toJSON().map(function (filter) {
+        var res = Object.assign({}, filter);
+        delete res.type;
+        return res;
+      }).filter(function (filter) {
+        return filter.name;
+      }).reduce(function (res, filter, index) {
+        var serializedFilter = Object.keys(filter).reduce(function (str, key) {
+          var name = key;
+          if (key === 'name') name = 'field';
+
+          var value = filter[key];
+          if (value instanceof Date) {
+            value = value.toISOString();
+          }
+
+          return str + (str.length ? '&' : '') + 'filters[' + index + '][' + name + ']=' + value;
+        }, '');
+
+        return res + (res.length ? '&' : '?') + serializedFilter;
+      }, '');
+    },
+
+    /**
+     * Return a deferred object to fetch an extract of the filtered table
+     * @returns {object} $.Deferred
+     */
+    _getTableExtract: function () {
+      // TODO query number
+      var deferred = $.Deferred(); // eslint-disable-line new-cap
+      var collection = new (Backbone.Collection.extend({
+        url: this._getTableExtractURL()
+      }))();
+
+      collection.fetch()
+        .done(function (data) { deferred.resolve(data); })
+        .fail(function () { deferred.reject(); });
+
+      return deferred;
+    },
+
+    /**
+     * Fetch the table extract, save the result to global variables and return a deferred
+     * object
+     * NOTE: the reject case means the request is not up-to-date
+     * @returns {object} $.Deferred
+     */
+    _fetchTableExtract: (function () {
+      var requestsCount = 0; // eslint-disable-line no-unused-vars
+      return function () {
+        // The ID is used to unsure the data correspond to the *last* query
+        var id = ++requestsCount;
+        this.activeRequestsCount++;
+        var deferred = $.Deferred(); // eslint-disable-line new-cap
+        this._getTableExtract()
+          .done(function (data) {
+            if (id === requestsCount) this.tableExtract = data;
+          }.bind(this)).fail(function () {
+            if (id === requestsCount) this.tableExtract = null;
+          }.bind(this)).always(function () {
+            this.activeRequestsCount--;
+            if (id === requestsCount) deferred.resolve();
+            else deferred.reject();
+          }.bind(this));
+
+        return deferred;
+      };
+    }()),
+
+    /**
+     * Update the row count with the result of the query to the server
+     */
+    _updateRowCount: _.debounce(function () {
+      this._fetchTableExtract()
+        .done(function () {
+          var count = this.tableExtract && this.tableExtract.count;
+          count = (count !== null && count !== undefined) ? (count.toLocaleString('en-US') + ' rows') : '';
+          this.el.querySelector('.js-row-count').textContent = count;
+        }.bind(this));
+    }, 500),
 
     render: function () {
+      var filters = this.collection.toJSON().map(function (filter, index) {
+        // We combine the attributes of the filter with the one of the selected field
+        // (if selected) so we get the min value, max value and/or list of possible values for
+        // the filter
+        var field = {};
+        if (filter.name) {
+          field = _.findWhere(this.options.fields, { name: filter.name });
+
+          // If we have a min and max value and the field is type number, we want to compute
+          // the step precision between the two values
+          if (field.min !== null && field.max !== null && field.type === 'number') {
+            field.step = this._getStepPrecision(field.min, field.max);
+          }
+        }
+
+        // We add an index to the final object, and rename the "values" property of the filter
+        // objet by "selectedValues"
+        var o = { id: index + 1 };
+        if (filter.values) o.selectedValues = filter.values;
+
+        return Object.assign({}, filter, field, o);
+      }, this);
+
       this.$el.html(this.template({
-        fields: this.fields,
-        filters: this.collection.toJSON().map(function (filter, index) {
-          return Object.assign({}, filter, { id: index + 1 });
-        }),
-        json: JSON.stringify(this.collection.toJSON().filter(function (filter) {
-          return filter.name;
-        }))
+        fields: this._getUnusedFields(),
+        filters: filters,
+        json: this._getSerializeFilters(),
+        canAddNewField: !!this._getUnusedFields().length && !this._isThereUnspecifiedFilter()
       }));
       this.setElement(this.el);
+
+      this._enhanceSelectors();
+
+      this._updateRowCount();
     }
   });
 })(this.App));

--- a/app/assets/javascripts/views/management/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/management/dashboardFiltersView.js
@@ -273,7 +273,7 @@
      * @returns {string} url
      */
     _getTableExtractURL: function () {
-      return '/management/sites/base-site/page_steps/filters/filtered_results.json' +
+      return this.options.endpointUrl +
       this.collection.toJSON().map(function (filter) {
         var res = Object.assign({}, filter);
         delete res.type;

--- a/app/assets/javascripts/views/management/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/management/dashboardFiltersView.js
@@ -33,6 +33,8 @@
       //   }
       // ]
       fields: [],
+      // API endpoint to fetch the table extract
+      endpointUrl: '',
       // State of the default filters
       defaultFilter: {
         name: null,
@@ -353,7 +355,7 @@
           count = (count !== null && count !== undefined) ? (count.toLocaleString('en-US') + ' rows') : '';
           this.el.querySelector('.js-row-count').textContent = count;
         }.bind(this));
-    }, 500),
+    }, 1500),
 
     render: function () {
       var filters = this.collection.toJSON().map(function (filter, index) {

--- a/app/assets/javascripts/views/shared/modalView.js
+++ b/app/assets/javascripts/views/shared/modalView.js
@@ -1,0 +1,74 @@
+((function (App) {
+  'use strict';
+
+  App.View.ModalView = Backbone.View.extend({
+    className: 'c-modal',
+
+    events: {
+      'click': '_onClickOverlay',
+      'click .js-close': 'close'
+    },
+
+    initialize: function () {
+      this._initModal();
+    },
+
+    /**
+     * Event handler called when the container is propagated a click events
+     * @param {object} e - event object
+     */
+    _onClickOverlay: function (e) {
+      if (e.target === e.currentTarget) this.close();
+    },
+
+    /**
+     * Init the modal before rendering it
+     */
+    _initModal: function () {
+      this.close();
+      document.body.appendChild(this.el);
+      this.el.innerHTML = '\
+        <div class="container">\
+          <button type="button" class="close-button js-close" title="Close">\
+            <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path fill="#555" d="M2.183 0L0 2.183l4.438 4.438-4.354 4.354 2.183 2.183 4.354-4.353 4.269 4.268 2.183-2.183-4.27-4.27 4.354-4.353L10.974.085 6.621 4.438z" fill-rule="evenodd"/></svg>\
+          </button>\
+          <div class="content js-content">\
+          </div>\
+        </div>\
+      ';
+
+      this.contentContainer = this.el.querySelector('.js-content');
+    },
+
+    /**
+     * Open the modal
+     */
+    open: function () {
+      var renderRes = this.render();
+      if (typeof renderRes === 'string') {
+        this.contentContainer.innerHTML = renderRes;
+      } else if (renderRes instanceof Backbone.View) {
+        // eslint-disable-next-line new-cap
+        new renderRes({ el: this.contentContainer });
+      }
+
+      this.el.classList.remove('-hidden');
+    },
+
+    /**
+     * Close the modal
+     */
+    close: function () {
+      this.el.classList.add('-hidden');
+    },
+
+    /**
+     * Render the content of the modal
+     * NOTE: to be overriden
+     * @returns {string|object} HTML string or Backbone view
+     */
+    render: function () {
+      return '';
+    }
+  });
+})(this.App));

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -11,6 +11,7 @@
 
 html,
 body {
+  min-height: 100vh;
   margin: 0;
   padding: 0;
 }

--- a/app/assets/stylesheets/components/management/c-dashboard-filters.scss
+++ b/app/assets/stylesheets/components/management/c-dashboard-filters.scss
@@ -1,0 +1,231 @@
+.c-dashboard-filters {
+  max-width: 700px;
+  margin: 0 auto;
+
+  > .filter {
+    display: flex;
+    position: relative;
+    align-items: flex-start;
+    justify-content: flex-start;
+    margin-bottom: 14px;
+
+    > input,
+    > select,
+    > .select2 {
+      flex-basis: calc(25% - 18px);
+      flex-grow: 0;
+      flex-shrink: 0;
+      min-height: 40px;
+      margin: 0 9px;
+    }
+
+    .values-selector + .select2 {
+      flex-grow: 1;
+    }
+
+    > input {
+      width: calc(25% - 18px);
+      padding: 0 15px;
+      border: 1px solid $color-7;
+      border-radius: 4px;
+      color: $color-4;
+      font-family: $font-family-1;
+      font-size: $font-size-normal;
+    }
+
+    .select2-selection {
+      min-height: 40px;
+      border: 1px solid $color-7;
+      border-radius: 4px;
+
+      > span {
+        height: 40px;
+        line-height: 40px;
+      }
+
+      .select2-selection__choice {
+        border-color: $color-1;
+        background-color: $color-3;
+
+        > span {
+          margin-right: 5px;
+          color: $color-1;
+          font-size: $font-size-medium;
+        }
+      }
+
+      .select2-selection__rendered {
+        display: block; // Needed otherwise extra margin/padding at the bottom of the field
+        padding-right: 35px;
+        padding-left: 15px;
+      }
+
+      .select2-selection__placeholder {
+        color: $color-4;
+      }
+
+      .select2-selection__arrow > b {
+        width: 8px;
+        height: 8px;
+        margin-left: -14px;
+        transform: translateY(-50%) rotate(45deg);
+        border-top: 0;
+        border-left: 0;
+        border-width: 2px;
+        border-color: $color-4;
+      }
+
+      .select2-search__field {
+        height: 40px;
+        margin: 0;
+      }
+    }
+
+    .select2-container--disabled {
+      .select2-selection {
+        opacity: .6;
+      }
+    }
+
+    .remove-button {
+      position: absolute;
+      top: 50%;
+      right: -10px;
+      width: 14px;
+      height: 14px;
+      margin: 0;
+      padding: 0;
+      transform: translate(100%, -50%);
+      border: 0;
+      background: asset-url('icons/close-icon.svg') no-repeat center center;
+      text-indent: -10000px;
+      cursor: pointer;
+    }
+  }
+
+  .action-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: calc(100% - 18px);
+    margin: 37px auto 0;
+    padding-top: 37px;
+    border-top: 1px solid $color-7;
+
+    > div {
+      display: flex;
+      align-items: center;
+      > .c-button { margin-left: 12px; }
+    }
+  }
+}
+
+// Global styles because the container is appended to body
+.select2-container {
+  .select2-results__options {
+    width: 100%;
+    li { width: 100%; }
+  }
+
+  .select2-results__option--highlighted[aria-selected] {
+    background-color: rgba($color-1, .3);
+    color: $color-4;
+  }
+
+  .select2-results__option--highlighted[aria-selected="true"],
+  .select2-results__option[aria-selected="true"] {
+    background-color: $color-1;
+    color: $color-3;
+  }
+
+  .select2-dropdown {
+    border-color: $color-7;
+  }
+}
+
+.ui-datepicker {
+  padding: 0 4px 4px;
+  border-radius: 4px;
+  border-color: $color-7;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+
+  .ui-datepicker-header {
+    margin: 0 -4px;
+    border: 0;
+    border-bottom: 1px solid $color-7;
+    background-color: transparent;
+  }
+
+  .ui-datepicker-calendar {
+    margin-bottom: 0;
+  }
+
+  .ui-datepicker-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 25px;
+  }
+
+  .ui-datepicker-prev,
+  .ui-datepicker-next {
+    display: flex;
+    top: 50%;
+    align-items: center;
+    justify-content: center;
+    transform: translateY(-50%);
+    border: 0;
+    background-color: transparent;
+
+    > .ui-icon {
+      position: static;
+      width: 8px;
+      height: 8px;
+      margin: 0;
+      border-right: 2px solid $color-4;
+      border-bottom: 2px solid $color-4;
+      background: none;
+      cursor: pointer;
+    }
+  }
+
+  .ui-datepicker-prev {
+    left: 0;
+
+    &.ui-datepicker-prev-hover {
+      top: 50%;
+      left: 0;
+    }
+
+    > .ui-icon {
+      transform: translateX(4px) rotate(135deg);
+    }
+  }
+
+  .ui-datepicker-next {
+    right: 0;
+
+    &.ui-datepicker-next-hover {
+      top: 50%;
+      right: 0;
+    }
+
+    > .ui-icon {
+      transform: translateX(-4px) rotate(-45deg);
+    }
+  }
+
+  .ui-state-default {
+    border-color: $color-7;
+    background-color: transparent;
+    color: $color-4;
+
+    &.ui-state-active {
+      border-color: $color-1;
+      background-color: $color-1;
+      color: $color-3;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/shared/c-modal.scss
+++ b/app/assets/stylesheets/components/shared/c-modal.scss
@@ -1,0 +1,58 @@
+// NOTE:
+// This component has been built for the management section, despite being in
+// the shared folder. As a consequence, it lacks responsive styles.
+
+.c-modal {
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: rgba($color-5, .3);
+  z-index: 20;
+
+  > .container {
+    position: relative;
+    width: 100%;
+    max-width: 880px;
+    height: 100%;
+    max-height: 600px;
+    border-radius: 4px;
+    background-color: $color-3;
+
+    > .close-button {
+      display: block;
+      position: absolute;
+      top: -10px;
+      right: 0;
+      width: 14px;
+      height: 14px;
+      margin: 0;
+      padding: 0;
+      transform: translateY(-100%);
+      border: 0;
+      background: transparent;
+      text-indent: -10000px;
+      cursor: pointer;
+
+      svg {
+        display: block;
+        path { fill: $color-3; }
+      }
+    }
+
+    > .content {
+      height: 100%;
+      overflow: auto;
+    }
+  }
+
+  &.-hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
+}

--- a/app/assets/stylesheets/layouts/management/l-page-creation.scss
+++ b/app/assets/stylesheets/layouts/management/l-page-creation.scss
@@ -79,6 +79,10 @@
     }
   }
 
+  &.-filters {
+    margin-top: 50px;
+  }
+
   &.-wysiwyg {
     margin-top: 50px;
 

--- a/app/assets/stylesheets/management/application.scss
+++ b/app/assets/stylesheets/management/application.scss
@@ -2,6 +2,7 @@
 'leaflet',
 'jquery-ui',
 'sir-trevor',
+'select2',
 'settings',
 '../base',
 '../layouts/management/*',

--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -73,7 +73,7 @@ class Management::PageStepsController < ManagementController
         # Saving all the possible visible fields for this dataset so that ...
         # ... they can be used in the filtered_results
         (@dataset_setting.columns_visible =
-          @fields.map{|f| f[:name]}.join(', ')) unless @dataset_setting.columns_visible
+          @fields.map{|f| f[:name]}.to_json) unless @dataset_setting.columns_visible
         set_current_dataset_setting_state
 
       when 'columns'

--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -68,6 +68,7 @@ class Management::PageStepsController < ManagementController
         @fields = @dataset_setting.get_fields
         @fields.each{ |f| f[:type] = 'number' if %w[double long].include?(f[:type])}
         gon.fields = @fields
+        gon.filters_endpoint_url = wizard_path('filters') + '/filtered_results.json'
 
       when 'columns'
         build_current_dataset_setting

--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -70,6 +70,12 @@ class Management::PageStepsController < ManagementController
         gon.fields = @fields
         gon.filters_endpoint_url = wizard_path('filters') + '/filtered_results.json'
 
+        # Saving all the possible visible fields for this dataset so that ...
+        # ... they can be used in the filtered_results
+        (@dataset_setting.columns_visible =
+          @fields.map{|f| f[:name]}.join(', ')) unless @dataset_setting.columns_visible
+        set_current_dataset_setting_state
+
       when 'columns'
         build_current_dataset_setting
         @fields = @dataset_setting.get_fields
@@ -186,7 +192,8 @@ class Management::PageStepsController < ManagementController
 
     temp_dataset_setting =
       DatasetSetting.new(dataset_id: @dataset_setting.dataset_id,
-          api_table_name: @dataset_setting.api_table_name)
+          api_table_name: @dataset_setting.api_table_name,
+          columns_visible: @dataset_setting.columns_visible)
 
     filters = params[:filters]
     temp_dataset_setting.set_filters (filters.blank? ? nil : filters.values)

--- a/app/models/dataset_setting.rb
+++ b/app/models/dataset_setting.rb
@@ -25,12 +25,7 @@ class DatasetSetting < ApplicationRecord
       query = "select #{selector} from #{self.api_table_name} limit #{limit}"
       return DatasetService.get_filtered_dataset self.dataset_id, query
     else
-      query = 'select '
-      if self.columns_visible
-        query += (JSON.parse self.columns_visible).join(', ')
-      else
-        query += " #{selector} "
-      end
+      query = "select #{selector}"
       query += " from #{self.api_table_name} "
       query += 'where ' + (JSON.parse self.filters).join(' AND ') if self.filters.length > 0
       query += " limit #{limit}"

--- a/app/models/dataset_setting.rb
+++ b/app/models/dataset_setting.rb
@@ -44,7 +44,7 @@ class DatasetSetting < ApplicationRecord
           filter_array << " #{filter['field']} between '#{filter['from']}' and '#{filter['to']}' "
         end
         if filter['values'] && filter['field']
-          filter_array << " #{filter['field']} in (#{filter['values'].map{|x| " '#{x}' "}.join(', ')}) "
+          filter_array << " #{filter['field']} in (#{filter['values']}) "
         end
       end
     end

--- a/app/models/dataset_setting.rb
+++ b/app/models/dataset_setting.rb
@@ -17,7 +17,7 @@ class DatasetSetting < ApplicationRecord
     selector = if count
                ' count(*) '
                elsif self.columns_visible
-                 " #{self.columns_visible} "
+                 " #{JSON.parse(self.columns_visible).join(', ')} "
                else
                  ' * '
                end

--- a/app/views/management/page_steps/_footer.html.erb
+++ b/app/views/management/page_steps/_footer.html.erb
@@ -3,7 +3,7 @@
     <%= link_to 'Cancel', management_site_site_pages_path(@site.slug), class: 'c-button -outline -dark-text' %>
     <div>
       <% unless local_assigns[:no_continue] %>
-        <%= f.button Management::PageStepsController::CONTINUE, value: Management::PageStepsController::CONTINUE, type: 'submit', class: 'c-button js-submit' %>
+        <%= f.button Management::PageStepsController::CONTINUE, value: Management::PageStepsController::CONTINUE, type: 'submit', class: 'c-button js-submit' + ((@page.id || local_assigns[:always_save]) ? ' -outline -dark-text' : '') %>
       <% end %>
       <% if @page.id || local_assigns[:always_save] %>
         <%= f.button Management::PageStepsController::SAVE, value: Management::PageStepsController::SAVE, type: 'submit', class: 'c-button js-submit' %>

--- a/app/views/management/page_steps/columns.html.erb
+++ b/app/views/management/page_steps/columns.html.erb
@@ -8,8 +8,9 @@
 <%= form_for @page, url: wizard_path, method: :put do |f| %>
     <% @fields.each do |field|%>
         <fieldset>
-          <%= field.name %>
-          <%= check_box_tag "site_page[dataset_setting][visible_fields][]", field.name %>
+          <%= field[:name] %>
+          <%= check_box_tag "site_page[dataset_setting][visible_fields][]", field[:name],
+              (JSON.parse(@dataset_setting.columns_visible)).include?(field[:name]) %>
         </fieldset>
     <% end %>
     <%= render partial: 'footer', locals: {f: f} %>

--- a/app/views/management/page_steps/filters.html.erb
+++ b/app/views/management/page_steps/filters.html.erb
@@ -25,3 +25,5 @@
   <%= render partial: 'footer', locals: {f: f} %>
 <% end %>
 <%= render partial: 'shared/errors', locals: { resource: @page } %>
+
+<%= console if Rails.env.development? %>

--- a/app/views/management/page_steps/filters.html.erb
+++ b/app/views/management/page_steps/filters.html.erb
@@ -6,7 +6,11 @@
 
 
 <%= form_for(@page, url: wizard_path, method: :put, :html => {:class => 'js-form'}) do |f| %>
-  <div class="js-filters"></div>
+  <div class="l-page-creation -filters">
+    <div class="wrapper">
+      <div class="js-filters"></div>
+    </div>
+  </div>
   <%= render partial: 'footer', locals: {f: f} %>
 <% end %>
 <%= render partial: 'shared/errors', locals: { resource: @page } %>

--- a/app/views/management/page_steps/filters.html.erb
+++ b/app/views/management/page_steps/filters.html.erb
@@ -1,3 +1,14 @@
+<% content_for :extended_header do %>
+  <div class="c-extended-header">
+    <div class="wrapper">
+      <div class="description">
+        <h1>Apply filters</h1>
+        <p>Filter the dataset and choose which columns the users will be able to filter themselves on the dashboard</p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <%= render partial: 'shared/navigation_header', locals: \
   {form_steps: form_steps, id: @page.id, current_step: step, step_names: @steps_names, \
   invalid_steps: @invalid_steps, invalid_state: @page.errors.any?} %>


### PR DESCRIPTION
This PR implements the code for the filters step of the dashboard creation/edition as well as adds its styles.

The manager can select some fields from the dataset and filter them depending on their type:
* for numbers, a min and a max selectors are available
* for dates, we have the same selectors but with date pickers
* for strings, we have a selector where they can select as much (real) values (from the dataset) as they want

Any other type of column is hidden. Please also note the the handling of the dates is still not perfect as we don't have a standardised way to retrieve them from the API.

In addition to filtering the dataset, the manager can also indicate which fields the end user will be able to use as filters on the analysis dashboard.

@santostiago, before merging, please make sure everything's working fine, above all the issues I mentioned in my comment on [this task](https://www.pivotaltracker.com/story/show/135205341).