### PR TITLE
Session revalidation TTL

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,4 @@
 class AdminController < ActionController::Base
-
   include PermissionsHelper
 
  # skip_before_action :verify_authenticity_token, raise: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,32 +1,19 @@
 class ApplicationController < ActionController::Base
+  include AuthHelper
+
   protect_from_forgery with: :exception
 
   layout :layout_by_resource
 
   before_action :set_current_user
 
-  def redirect_to_apigateway
-    redirect_to "#{ENV['API_URL']}/auth?callbackUrl=#{auth_login_url}&token=true"
-  end
-
-  def redirect_to_apigateway_logout
-    redirect_to "#{ENV['API_URL']}/auth/logout?callbackUrl=#{auth_login_url}"
-  end
-
-  def jwt_authentication
-    unless session.key?('user_token')
-      redirect_to_apigateway
-    end
-  end
-
-
   protected
 
   def layout_by_resource
     if @current_user && !self.is_a?(SitePageController)
-      "admin"
+      'admin'
     else
-      "application"
+      'application'
     end
   end
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,39 +1,47 @@
 class AuthController < ApplicationController
-
   def login
     token = params[:token]
 
-    if token.nil?
-      redirect_to_apigateway
-    else
-      session[:user_token] = token
+    return redirect_to_api_gateway_login if token.nil?
 
-      connect = Faraday.new(url: "#{ENV['API_URL']}") do |faraday|
-        faraday.request  :url_encoded             # form-encode POST params
-        faraday.response :logger                  # log requests to STDOUT
-        faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
-      end
+    session[:user_token] = token
 
-      connect.authorization :Bearer, session[:user_token]
-      response = connect.get('/auth/checkLogged');
+    connect = Faraday.new(url: "#{ENV['API_URL']}") do |faraday|
+      faraday.request :url_encoded # form-encode POST params
+      faraday.response :logger # log requests to STDOUT
+      faraday.adapter Faraday.default_adapter # make requests with Net::HTTP
+    end
 
-      session[:current_user] = response.body
+    connect.authorization :Bearer, session[:user_token]
+    response = connect.get('/auth/check-logged');
 
-      # TODO: Validate the user type
-      redirect_url = session.delete(:return_to)
-      if redirect_url
-        redirect_to redirect_url
-      else # TODO: The user should be redirected to the admin or management page, according to his role
-        redirect_to admin_sites_path
-      end
+    if !response.status.to_s.match(/^20/)
+      session.delete(:user_token)
+      return redirect_to_api_gateway_login
+    end
 
+    session[:current_user] = JSON.parse response.body
+    session[:api_validation_ttl] = Time.now + Rails.configuration.session_revalidate_timer
+
+    # TODO: Validate the user type
+    redirect_url = session.delete(:return_to)
+
+    if redirect_url and !is_login_redirect?(redirect_url)
+      redirect_to redirect_url
+    else # TODO: The user should be redirected to the admin or management page, according to his role
+      redirect_to admin_sites_path
     end
   end
 
   def logout
     session.delete(:user_token)
     session.delete(:current_user)
-    redirect_to_apigateway_logout
+    redirect_to_api_gateway_logout
   end
 
+  private
+
+  def is_login_redirect?(params)
+    return (params[:controller].eql?('auth') and params[:action].eql?('login'))
+  end
 end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -1,0 +1,17 @@
+module AuthHelper
+  def redirect_to_api_gateway_login
+    params.permit!
+    session[:return_to] = params
+    redirect_to "#{ENV['API_URL']}/auth?callbackUrl=#{auth_login_url}&token=true"
+  end
+
+  def redirect_to_api_gateway_logout
+    redirect_to "#{ENV['API_URL']}/auth/logout?callbackUrl=#{auth_login_url}"
+  end
+
+  def jwt_authentication
+    unless session.key?('user_token')
+      redirect_to_api_gateway_login
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,6 @@ module ForestAtlasLandscapeCms
     end
     config.log_level = :debug
     config.exceptions_app = self.routes
-
+    config.session_revalidate_timer = 10.minutes
   end
 end


### PR DESCRIPTION
Currently we validate the user's auth status on the API in every request. This makes the internet very sad because:
- We don't really need to validate every single request.
- API-side, this does not scale - it's a bunch of useless requests
- CMS-side, this adds a lot of unnecessary delay.
- Every API hiccup is visible on the CMS.

So, I added a TTL to it. Basically, with the current config, we only validate the authentication once every 10 minutes. Going live we might lower this to 1m or 30 seconds.