### PR TITLE
Add Clara and Jose Angel as user

### DIFF
--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -291,6 +291,18 @@ def create_users
       name: 'Tiago Santos'
     }
   )
+  @jose_angel_user = User.create(
+    {
+      email: 'joseangel.parreno@vizzuality.com',
+      name: 'Jose Angel'
+    }
+  )
+  @clara_linos_user = User.create(
+    {
+      email: 'clara.linos@vizzuality.com',
+      name: 'Clara Linos'
+    }
+  )
   @clement_prodhomme_user = User.create(
     {
       email: 'clement.prodhomme@vizzuality.com',


### PR DESCRIPTION
We haven't been able to go to `/management` after API login because the user wasn't added to the sample data.

So this PR adds Clara and Jose Angel users