### PR TITLE
Table preview legend

### DIFF
--- a/app/assets/javascripts/views/management/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/management/dashboardFiltersView.js
@@ -192,7 +192,7 @@
      * @returns {string} HTML
      */
     _renderPreviewTable: function () {
-      var res = '<table class="c-table"><tr class="header">';
+      var res = '<div class="c-table"><table><tr class="header">';
       res += this.options.fields.map(function (field) {
         return '<th>' + field.name + '</th>';
       }).join('');
@@ -205,6 +205,8 @@
           '</tr>';
       }).join('');
       res += '</table>';
+      res += '<div class="table-legend"><p>Table preview shows only 10 first rows</p></div>';
+      res += '</div>';
       return res;
     },
 

--- a/app/assets/stylesheets/components/shared/c-table.scss
+++ b/app/assets/stylesheets/components/shared/c-table.scss
@@ -1,4 +1,5 @@
-.c-table {
+.c-table,
+.c-table table{
   width: 100%;
   border-spacing: 0;
 
@@ -16,7 +17,9 @@
   }
 
   tr {
-    border-bottom: 1px dashed rgba($color-9, .6);
+    td {
+      border-bottom: 1px dashed rgba($color-9, .6);
+    }
 
     &:hover td {
       background-color: $color-2;
@@ -66,4 +69,9 @@
     }
   }
 
+  > .table-legend {
+    padding: 40px 0;
+    text-align: center;
+  }
 }
+


### PR DESCRIPTION
Add `Table preview shows only 10 first rows` legend in filters preview table and fix dashed rows in tables.

![image](https://cloud.githubusercontent.com/assets/10500650/21550453/3b3d2ea8-cdfa-11e6-9560-862be529ad17.png)
