### PR TITLE
Bug/deleteable pages

### DIFF
--- a/app/assets/javascripts/routers/management/PagesRouter.js
+++ b/app/assets/javascripts/routers/management/PagesRouter.js
@@ -16,6 +16,8 @@
               return {};
 
             case /(enable|edit|delete)/.test(key):
+              if (!row[key].value) return '';
+
               // eslint-disable-next-line no-shadow
               var res = {
                 name: null,
@@ -25,7 +27,7 @@
               // We need extra attributes when making a put or delete request
               var extraAttributes = '';
               var method = row[key].method;
-              if (method === 'delete' || method === 'put') {
+              if (method === 'delete' || method === 'put') {
                 extraAttributes = 'rel="nofollow" data-method="' + method + '"';
               }
 

--- a/app/assets/javascripts/routers/management/PagesRouter.js
+++ b/app/assets/javascripts/routers/management/PagesRouter.js
@@ -93,7 +93,8 @@
         el: $('.js-table'),
         collection: new TableCollection(gon.pages, { parse: true }),
         tableName: 'List of pages',
-        searchFieldContainer: $('.js-table-search')[0]
+        searchFieldContainer: $('.js-table-search')[0],
+        sortColumnIndex: 1
       });
 
       // We attach a dialog notification to the delete buttons

--- a/app/controllers/management/site_pages_controller.rb
+++ b/app/controllers/management/site_pages_controller.rb
@@ -16,10 +16,16 @@ class Management::SitePagesController < ManagementController
         'title' => {'value' => page.name, 'searchable' => true, 'sortable' => true},
         'url' => {'value' => page.url, 'searchable' => true, 'sortable' => true},
         'type' => {'value' => page.content_type_humanize, 'searchable' => false, 'sortable' => true},
-        'enabled' => {'value' => page.enabled},
-        'enable' => {'value' => toggle_enable_management_site_site_page_path(page.site.slug, page), 'method' => 'put'},
-        'edit' => {'value' => edit_management_site_site_page_page_step_path(page.site.slug, page, :position), 'method' => 'get'}
+        'enabled' => {'value' => page.enabled}
       }
+
+      if (not page.disableable)
+        res[:enable] = {'value' => nil}
+      else
+        res[:enable] = {'value' => toggle_enable_management_site_site_page_path(page.site.slug, page), 'method' => 'put'}
+      end
+
+      res[:edit] = {'value' => edit_management_site_site_page_page_step_path(page.site.slug, page, :position), 'method' => 'get'}
 
       if (not page.deleteable)
         res[:delete] = {'value' => nil}
@@ -56,6 +62,8 @@ class Management::SitePagesController < ManagementController
 
 
   def toggle_enable
+    return if (not @site_page.disableable)
+
     @site_page.enabled = !@site_page.enabled
     @site_page.save
 

--- a/app/controllers/management/site_pages_controller.rb
+++ b/app/controllers/management/site_pages_controller.rb
@@ -12,15 +12,22 @@ class Management::SitePagesController < ManagementController
                .order(params[:order] || 'created_at ASC')
 
     gon.pages = @pages.map do |page|
-      {
+      res = {
         'title' => {'value' => page.name, 'searchable' => true, 'sortable' => true},
         'url' => {'value' => page.url, 'searchable' => true, 'sortable' => true},
         'type' => {'value' => page.content_type_humanize, 'searchable' => false, 'sortable' => true},
         'enabled' => {'value' => page.enabled},
         'enable' => {'value' => toggle_enable_management_site_site_page_path(page.site.slug, page), 'method' => 'put'},
-        'edit' => {'value' => edit_management_site_site_page_page_step_path(page.site.slug, page, :position), 'method' => 'get'},
-        'delete' => {'value' => management_site_site_page_path(page.site.slug, page), 'method' => 'delete'}
+        'edit' => {'value' => edit_management_site_site_page_page_step_path(page.site.slug, page, :position), 'method' => 'get'}
       }
+
+      if (not page.deleteable)
+        res[:delete] = {'value' => nil}
+      else
+        res[:delete] = {'value' => management_site_site_page_path(page.site.slug, page), 'method' => 'delete'}
+      end
+
+      res
     end
 
     respond_to do |format|

--- a/app/controllers/management/site_pages_controller.rb
+++ b/app/controllers/management/site_pages_controller.rb
@@ -16,22 +16,15 @@ class Management::SitePagesController < ManagementController
         'title' => {'value' => page.name, 'searchable' => true, 'sortable' => true},
         'url' => {'value' => page.url, 'searchable' => true, 'sortable' => true},
         'type' => {'value' => page.content_type_humanize, 'searchable' => false, 'sortable' => true},
-        'enabled' => {'value' => page.enabled}
+        'enabled' => {'value' => page.enabled},
+        'enable' => page.disableable? ? \
+          {'value' => toggle_enable_management_site_site_page_path(page.site.slug, page), 'method' => 'put'} : \
+          {'value' => nil},
+        'edit' => {'value' => edit_management_site_site_page_page_step_path(page.site.slug, page, :position), \
+                   'method' => 'get'},
+        'delete' => page.deletable? ? \
+          {'value' => management_site_site_page_path(page.site.slug, page), 'method' => 'delete'} : {'value' => nil}
       }
-
-      if (not page.disableable)
-        res[:enable] = {'value' => nil}
-      else
-        res[:enable] = {'value' => toggle_enable_management_site_site_page_path(page.site.slug, page), 'method' => 'put'}
-      end
-
-      res[:edit] = {'value' => edit_management_site_site_page_page_step_path(page.site.slug, page, :position), 'method' => 'get'}
-
-      if (not page.deleteable)
-        res[:delete] = {'value' => nil}
-      else
-        res[:delete] = {'value' => management_site_site_page_path(page.site.slug, page), 'method' => 'delete'}
-      end
 
       res
     end
@@ -50,7 +43,7 @@ class Management::SitePagesController < ManagementController
   # DELETE /management/pages/1
   # DELETE /management/pages/1.json
   def destroy
-    return if (not @site_page.deleteable)
+    return unless @site_page.deletable?
 
     site = @site_page.site
     @site_page.destroy
@@ -62,7 +55,7 @@ class Management::SitePagesController < ManagementController
 
 
   def toggle_enable
-    return if (not @site_page.disableable)
+    return unless @site_page.disableable
 
     @site_page.enabled = !@site_page.enabled
     @site_page.save

--- a/app/controllers/management/site_pages_controller.rb
+++ b/app/controllers/management/site_pages_controller.rb
@@ -37,6 +37,8 @@ class Management::SitePagesController < ManagementController
   # DELETE /management/pages/1
   # DELETE /management/pages/1.json
   def destroy
+    return if (not @site_page.deleteable)
+
     site = @site_page.site
     @site_page.destroy
     respond_to do |format|

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -43,8 +43,12 @@ class Page < ApplicationRecord
     self.routes.map { |route| route.link(port) + self.url }
   end
 
+  def deletable?
+    [ContentType::LINK, ContentType::OPEN_CONTENT, ContentType::ANALYSIS_DASHBOARD].include? self.content_type
+  end
+
   def disableable?
-    [ContentType::LINK, ContentType::OPEN_CONTENT, ContentType::ANALYSIS_DASHBOARD, ContentType::STATIC_CONTENT].include? self.content_type
+    self.content_type != ContentType::HOMEPAGE
   end
 
   def visible?

--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -92,6 +92,11 @@ class SitePage < Page
     return (not (self.content_type.eql? ContentType::HOMEPAGE or self.content_type.eql? ContentType::MAP or self.content_type.eql? ContentType::STATIC_CONTENT))
   end
 
+   # Return whether the page can be disabled
+  def disableable
+    return (not (self.content_type.eql? ContentType::HOMEPAGE))
+  end
+
   private
   def construct_url
     if self.content['url']

--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -87,16 +87,6 @@ class SitePage < Page
     end
   end
 
-  # Return whether the page can be deleted
-  def deleteable
-    return (not (self.content_type.eql? ContentType::HOMEPAGE or self.content_type.eql? ContentType::MAP or self.content_type.eql? ContentType::STATIC_CONTENT))
-  end
-
-   # Return whether the page can be disabled
-  def disableable
-    return (not (self.content_type.eql? ContentType::HOMEPAGE))
-  end
-
   private
   def construct_url
     if self.content['url']

--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -87,6 +87,11 @@ class SitePage < Page
     end
   end
 
+  # Return whether the page can be deleted
+  def deleteable
+    return (not (self.content_type.eql? ContentType::HOMEPAGE or self.content_type.eql? ContentType::MAP or self.content_type.eql? ContentType::STATIC_CONTENT))
+  end
+
   private
   def construct_url
     if self.content['url']


### PR DESCRIPTION
This PR forbids the managers to delete the homepage, the standalone map and the static pages. It also forbids them to disable the homepage.

The changes have been made both in the back end and the front end.

@santostiago I need you to review my back end changes.

[Pivotal task](https://www.pivotaltracker.com/story/show/136965095)