### PR TITLE
Adds syntax highlighting to the map's configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
     "Fuse": true,
     "Jiminy": true,
     "PruneClusterForLeaflet": true,
-    "PruneCluster": true
+    "PruneCluster": true,
+    "CodeMirror": true
   },
   "env": {
     "browser": true

--- a/app/assets/javascripts/dispatchers/managementDispatcher.js
+++ b/app/assets/javascripts/dispatchers/managementDispatcher.js
@@ -19,7 +19,8 @@
       'sites/:slug/(site_pages/:id/)page_steps/filters': 'DatasetFiltersStep',
       'sites/:slug/(widgets/:id/)widget_steps/filters': 'WidgetFiltersStep',
       'sites/:slug/(widgets/:id/)widget_steps/visualization': 'VisualizationStep',
-      'sites/:slug/(site_pages/:id/)page_steps/preview': 'PreviewStep'
+      'sites/:slug/(site_pages/:id/)page_steps/preview': 'PreviewStep',
+      'sites/:slug/(site_pages/:id/)page_steps/map': 'MapStep'
     }
   });
 

--- a/app/assets/javascripts/routers/management/MapStepRouter.js
+++ b/app/assets/javascripts/routers/management/MapStepRouter.js
@@ -1,0 +1,20 @@
+((function (App) {
+  'use strict';
+
+  App.Router.ManagementMapStep = Backbone.Router.extend({
+
+    routes: {
+      '(/)': 'index'
+    },
+
+    initialize: function (params) {
+      this.slug = params[0] || null;
+    },
+
+    index: function () {
+      var editor = document.querySelector('.js-editor');
+      CodeMirror.fromTextArea(editor, { mode: 'javascript', json: true });
+    }
+
+  });
+})(this.App));

--- a/app/assets/stylesheets/components/shared/c-inputs-container.scss
+++ b/app/assets/stylesheets/components/shared/c-inputs-container.scss
@@ -2,6 +2,10 @@
   width: 100%;
   max-width: 570px;
 
+  &.-large {
+    max-width: 880px;
+  }
+
   > .container {
     padding: 25px 35px;
     border-top: 1px solid;
@@ -45,7 +49,7 @@
       font-weight: $font-weight-light;
     }
 
-    textarea {
+    > textarea {
       width: 100%;
       margin: 0;
       padding: 0;

--- a/app/assets/stylesheets/layouts/management/l-page-creation.scss
+++ b/app/assets/stylesheets/layouts/management/l-page-creation.scss
@@ -65,14 +65,16 @@
   }
 
   &.-map {
-    margin-top: 20px;
+    padding-top: 50px;
 
-    .c-fieldset {
-      height: calc(100vh - 360px);
+    > .wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
 
-      textarea {
-        font-family: monospace;
-      }
+    .CodeMirror {
+      height: calc(100vh - 502px);
     }
   }
 

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -5,8 +5,11 @@
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="//cdn.quilljs.com/1.1.9/quill.bubble.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.22.2/codemirror.min.css">
   <%= stylesheet_link_tag 'management/application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <script src="//cdn.quilljs.com/1.1.9/quill.js" type="text/javascript"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.22.2/codemirror.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.22.2/mode/javascript/javascript.min.js"></script>
   <%= javascript_include_tag 'management', 'data-turbolinks-track': 'reload' %>
   <%= favicon_link_tag %>
 </head>

--- a/app/views/management/page_steps/map.html.erb
+++ b/app/views/management/page_steps/map.html.erb
@@ -1,5 +1,5 @@
 <% content_for :extended_header do %>
-    <div class="c-extended-header -high">
+    <div class="c-extended-header">
       <div class="wrapper">
         <div class="description">
           <h1>Map</h1>
@@ -13,26 +13,16 @@
 <%= render partial: 'shared/navigation_header', locals: \
   {form_steps: form_steps, id: @page.id, current_step: step, step_names: @steps_names, \
   invalid_steps: @invalid_steps, invalid_state: @page.errors.any?} %>
-<%= render partial: 'shared/errors', locals: { resource: @page } %>
 
 <%= form_for(@page, url: wizard_path, method: :put, :html => {:class => 'js-form'}) do |f| %>
   <div class="l-page-creation -map">
     <div class="wrapper">
-        <% if @page.errors.any? %>
-            <div id="error_explanation">
-              <h2><%= pluralize(@page.errors.count, "error") %> prohibited this site_page from being saved:</h2>
-              <ul>
-                <% @page.errors.full_messages.each do |message| %>
-                    <li><%= message %></li>
-                <% end %>
-              </ul>
-            </div>
-        <% end %>
-
-        <div class="c-fieldset">
+        <div class="c-inputs-container -large">
           <%= f.fields_for :content, OpenStruct.new(@page.content) do |ff| %>
-              <%= ff.text_area :settings, class: 'settings' %>
-              <%= ff.label 'Map settings', class: 'col-sm-2 form-control-label' %>
+            <div class="container">
+              <%= ff.label :settings, 'Map settings' %>
+              <%= ff.text_area :settings, class: 'js-editor' %>
+            </div>
           <% end %>
         </div>
     </div>


### PR DESCRIPTION
<img width="941" alt="screen shot 2017-01-12 at 15 19 37" src="https://cloud.githubusercontent.com/assets/6073968/21895555/1941b45e-d8db-11e6-93e9-43a5cebb71d2.png">

This PR makes the edition of the standalone map's configuration easier by adding syntax highlighting. In addition, the styles have been unified with the rest of the flows.

Please, try to fix [this issue](https://www.pivotaltracker.com/story/show/136964993) before merging the PR as it could be harder to debug it.

This PR doesn't have any attached Pivotal task.