### PR TITLE
Feature/notifications refactor

### DIFF
--- a/app/assets/javascripts/helpers/notifications.js
+++ b/app/assets/javascripts/helpers/notifications.js
@@ -36,28 +36,23 @@
       update: {
         content: 'The structure has been successfully saved!',
         closeable: false,
-        autoCloseTimer: 5,
-        visible: true
+        autoCloseTimer: 5
       },
       saving: {
         content: 'Saving the structure...',
-        closeable: false,
-        visible: true
+        closeable: false
       },
       error: {
         content: 'The changes couldn\'t be saved',
-        type: 'error',
-        visible: true
+        type: 'error'
       },
       saveReminder: {
         content: 'Don\'t forget to save the changes before leaving the page!',
-        type: 'warning',
-        visible: true
+        type: 'warning'
       },
       visibilityReminder: {
         content: 'This page won\'t be visible to the users until all of its ancestors are enabled!',
-        type: 'warning',
-        visible: true
+        type: 'warning'
       }
     },
 

--- a/app/assets/javascripts/helpers/notifications.js
+++ b/app/assets/javascripts/helpers/notifications.js
@@ -6,7 +6,8 @@
     site: {
       deletion: {
         type: 'warning',
-        content: 'Are you sure you want to permanently delete this site?',
+        content: 'Are you sure you want to permanently delete this site and all of its pages?',
+        additionalContent: 'The change is irreversible.',
         dialogButtons: true,
         closeable: false
       }
@@ -15,7 +16,8 @@
     page: {
       deletion: {
         type: 'warning',
-        content: 'Are you sure you want to permanently delete this page?',
+        content: 'Are you sure you want to permanently delete this page and all of its child pages?',
+        additionalContent: 'Alternatively, you can just hide it from the user by clicking the eye icon next to it.',
         dialogButtons: true,
         closeable: false
       },
@@ -43,7 +45,7 @@
         closeable: false
       },
       error: {
-        content: 'The changes couldn\'t be saved',
+        content: 'The changes couldn\'t be saved!',
         type: 'error'
       },
       saveReminder: {
@@ -59,15 +61,17 @@
     dashboard: {
       changed: {
         type: 'warning',
-        content: 'The dashboard configuration has been updated and it might affect the visualizations'
+        content: 'The dashboard configuration has been updated and it might affect the visualizations.'
       },
       invalid: {
         type: 'error',
-        content: 'The dashboard\'s state couldn\'t be restored, probably because of changes of the data'
+        content: 'The dashboard\'s state couldn\'t be restored!',
+        additionalContent: 'This probably happens because its data changed.'
       },
       corrupted: {
         type: 'error',
-        content: 'The URL you’ve been shared is corrupted. Here is the default dashboard.'
+        content: 'The URL you’ve been shared is corrupted!',
+        additionalContent: 'As a consequence, we loaded the default dashboard.'
       },
       bookmarks: {
         deletion: {
@@ -76,19 +80,19 @@
         },
         corrupted: {
           type: 'error',
-          content: 'The bookmarks have been corrupted and can\'t be retrieved'
+          content: 'The bookmarks have been corrupted and can\'t be retrieved!'
         },
         saveError: {
           type: 'error',
-          content: 'The bookmark couldn\'t be saved properly'
+          content: 'The bookmark couldn\'t be saved properly!'
         },
         updateError: {
           type: 'error',
-          content: 'The name of the bookmark couldn\'t be updated'
+          content: 'The name of the bookmark couldn\'t be updated!'
         },
         deleteError: {
           type: 'error',
-          content: 'The bookmark couldn\'t be deleted'
+          content: 'The bookmark couldn\'t be deleted!'
         }
       }
     }

--- a/app/assets/javascripts/helpers/notifications.js
+++ b/app/assets/javascripts/helpers/notifications.js
@@ -1,0 +1,102 @@
+((function (App) {
+  'use strict';
+
+  App.Helper.Notifications = {
+
+    site: {
+      deletion: {
+        type: 'warning',
+        content: 'Are you sure you want to permanently delete this site?',
+        dialogButtons: true,
+        closeable: false
+      }
+    },
+
+    page: {
+      deletion: {
+        type: 'warning',
+        content: 'Are you sure you want to permanently delete this page?',
+        dialogButtons: true,
+        closeable: false
+      },
+      datasetRegistration: {
+        type: 'warning',
+        content: 'If you proceed to the dataset registration, the page\'s information you just entered will be lost.',
+        dialogButtons: true,
+        closeable: false
+      },
+      datasetPreview: {
+        type: 'warning',
+        content: 'The preview is loading. Please wait...',
+        closeable: false
+      }
+    },
+
+    structure: {
+      update: {
+        content: 'The structure has been successfully saved!',
+        closeable: false,
+        autoCloseTimer: 5,
+        visible: true
+      },
+      saving: {
+        content: 'Saving the structure...',
+        closeable: false,
+        visible: true
+      },
+      error: {
+        content: 'The changes couldn\'t be saved',
+        type: 'error',
+        visible: true
+      },
+      saveReminder: {
+        content: 'Don\'t forget to save the changes before leaving the page!',
+        type: 'warning',
+        visible: true
+      },
+      visibilityReminder: {
+        content: 'This page won\'t be visible to the users until all of its ancestors are enabled!',
+        type: 'warning',
+        visible: true
+      }
+    },
+
+    dashboard: {
+      changed: {
+        type: 'warning',
+        content: 'The dashboard configuration has been updated and it might affect the visualizations'
+      },
+      invalid: {
+        type: 'error',
+        content: 'The dashboard\'s state couldn\'t be restored, probably because of changes of the data'
+      },
+      corrupted: {
+        type: 'error',
+        content: 'The URL you’ve been shared is corrupted. Here is the default dashboard.'
+      },
+      bookmarks: {
+        deletion: {
+          content: 'The bookmark has been successfully deleted!',
+          autoCloseTimer: 5
+        },
+        corrupted: {
+          type: 'error',
+          content: 'The bookmarks have been corrupted and can\'t be retrieved'
+        },
+        saveError: {
+          type: 'error',
+          content: 'The bookmark couldn\'t be saved properly'
+        },
+        updateError: {
+          type: 'error',
+          content: 'The name of the bookmark couldn\'t be updated'
+        },
+        deleteError: {
+          type: 'error',
+          content: 'The bookmark couldn\'t be deleted'
+        }
+      }
+    }
+
+  };
+})(this.App));

--- a/app/assets/javascripts/routers/admin/SitesRouter.js
+++ b/app/assets/javascripts/routers/admin/SitesRouter.js
@@ -79,19 +79,18 @@
       });
 
       // We attach a dialog notification to the delete buttons
-      var dialogNotification = new App.View.NotificationView(App.Helper.Notifications.site.deletion);
-
       $('.js-confirm').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation(); // Prevents rails to automatically delete the site
 
-        // Callback executed when the user clicks the continue button
-        dialogNotification.options.continueCallback = function () {
-          $.rails.handleMethod($(e.target));
-        };
-
-        // We show the dialog
-        dialogNotification.show();
+        App.notifications.broadcast(Object.assign({},
+          App.Helper.Notifications.site.deletion,
+          {
+            continueCallback: function () {
+              $.rails.handleMethod($(e.target));
+            }
+          }
+        ));
       });
     }
   });

--- a/app/assets/javascripts/routers/admin/SitesRouter.js
+++ b/app/assets/javascripts/routers/admin/SitesRouter.js
@@ -79,12 +79,7 @@
       });
 
       // We attach a dialog notification to the delete buttons
-      var dialogNotification = new App.View.NotificationView({
-        type: 'warning',
-        content: 'Are you sure you want to permanently delete this site?',
-        dialogButtons: true,
-        closeable: false
-      });
+      var dialogNotification = new App.View.NotificationView(App.Helper.Notifications.site.deletion);
 
       $('.js-confirm').on('click', function (e) {
         e.preventDefault();

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -43,11 +43,6 @@
         el: document.querySelector('.js-header')
       });
 
-      // We create instances of the notifications so we reuse them to avoid duplicates
-      // of the exact same one layered on top one of another
-      this.warningNotification = new App.View.NotificationView(App.Helper.Notifications.dashboard.changed);
-      this.errorNotification = new App.View.NotificationView({ type: 'error' });
-
       // We start the router
       Backbone.history.start({ pushState: false });
     },
@@ -393,16 +388,13 @@
       var isStateUpToDate = this._checkStateVersion(state);
 
       if (!isStateUpToDate) {
-        this.errorNotification.hide();
-        this.warningNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.changed);
       }
 
       var isStateValid = this._checkStateValidity(state);
 
       if (!isStateValid) {
-        this.warningNotification.hide();
-        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.invalid);
-        this.errorNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.invalid);
 
         // We don't forget to still show the interface
         this.filters.render();
@@ -483,9 +475,7 @@
 
       // If the decoded state is empty, it's because it failed
       if (!decodedState) {
-        this.warningNotification.hide();
-        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.corrupted);
-        this.errorNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.corrupted);
         return;
       }
 

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -45,7 +45,7 @@
 
       // We create instances of the notifications so we reuse them to avoid duplicates
       // of the exact same one layered on top one of another
-      this.warningNotification = new App.View.NotificationView({ type: 'warning' });
+      this.warningNotification = new App.View.NotificationView(App.Helper.Notifications.dashboard.changed);
       this.errorNotification = new App.View.NotificationView({ type: 'error' });
 
       // We start the router
@@ -394,7 +394,6 @@
 
       if (!isStateUpToDate) {
         this.errorNotification.hide();
-        this.warningNotification.options.content = 'The dashboard configuration has been updated and it might affect the visualizations';
         this.warningNotification.show();
       }
 
@@ -402,7 +401,7 @@
 
       if (!isStateValid) {
         this.warningNotification.hide();
-        this.errorNotification.options.content = 'The dashboard\'s state couldn\'t be restored, probably because of changes of the data';
+        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.invalid);
         this.errorNotification.show();
 
         // We don't forget to still show the interface
@@ -485,7 +484,7 @@
       // If the decoded state is empty, it's because it failed
       if (!decodedState) {
         this.warningNotification.hide();
-        this.errorNotification.options.content = 'The URL you’ve been shared is corrupted. Here is the default dashboard.';
+        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.corrupted);
         this.errorNotification.show();
         return;
       }

--- a/app/assets/javascripts/routers/management/DatasetStepRouter.js
+++ b/app/assets/javascripts/routers/management/DatasetStepRouter.js
@@ -12,12 +12,7 @@
     },
 
     index: function () {
-      var dialogNotification = new App.View.NotificationView({
-        type: 'warning',
-        content: 'If you proceed to the dataset registration, the page\'s information you just entered will be lost.',
-        dialogButtons: true,
-        closeable: false
-      });
+      var dialogNotification = new App.View.NotificationView(App.Helper.Notifications.page.datasetRegistration);
 
       // Disable the register button and show a notification
       $('.js-register-dataset').on('click', function (e) {

--- a/app/assets/javascripts/routers/management/DatasetStepRouter.js
+++ b/app/assets/javascripts/routers/management/DatasetStepRouter.js
@@ -12,19 +12,18 @@
     },
 
     index: function () {
-      var dialogNotification = new App.View.NotificationView(App.Helper.Notifications.page.datasetRegistration);
-
       // Disable the register button and show a notification
       $('.js-register-dataset').on('click', function (e) {
         e.preventDefault();
 
-        // Callback executed when the user clicks the continue button
-        dialogNotification.options.continueCallback = function () {
-          Turbolinks.visit(e.target.href);
-        };
-
-        // We show the dialog
-        dialogNotification.show();
+        App.notifications.broadcast(Object.assign({},
+          App.Helper.Notifications.page.datasetRegistration,
+          {
+            continueCallback: function () {
+              Turbolinks.visit(e.target.href);
+            }
+          }
+        ));
       });
     }
 

--- a/app/assets/javascripts/routers/management/PagesRouter.js
+++ b/app/assets/javascripts/routers/management/PagesRouter.js
@@ -98,19 +98,18 @@
       });
 
       // We attach a dialog notification to the delete buttons
-      var dialogNotification = new App.View.NotificationView(App.Helper.Notifications.page.deletion);
-
       $('.js-confirm').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation(); // Prevents rails to automatically delete the page
 
-        // Callback executed when the user clicks the continue button
-        dialogNotification.options.continueCallback = function () {
-          $.rails.handleMethod($(e.target));
-        };
-
-        // We show the dialog
-        dialogNotification.show();
+        App.notifications.broadcast(Object.assign({},
+          App.Helper.Notifications.page.deletion,
+          {
+            continueCallback: function () {
+              $.rails.handleMethod($(e.target));
+            }
+          }
+        ));
       });
     }
 

--- a/app/assets/javascripts/routers/management/PagesRouter.js
+++ b/app/assets/javascripts/routers/management/PagesRouter.js
@@ -98,12 +98,7 @@
       });
 
       // We attach a dialog notification to the delete buttons
-      var dialogNotification = new App.View.NotificationView({
-        type: 'warning',
-        content: 'Are you sure you want to permanently delete this page?',
-        dialogButtons: true,
-        closeable: false
-      });
+      var dialogNotification = new App.View.NotificationView(App.Helper.Notifications.page.deletion);
 
       $('.js-confirm').on('click', function (e) {
         e.preventDefault();

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -50,12 +50,7 @@
 
       // If the tree has been saved successfully, we display a notification
       if (state && state === 'success') {
-        new App.View.NotificationView({
-          content: 'The structure has been successfully saved!',
-          closeable: false,
-          autoCloseTimer: 5,
-          visible: true
-        });
+        new App.View.NotificationView(App.Helper.Notifications.structure.update);
 
         this.navigate('/', { replace: true });
       }
@@ -189,11 +184,7 @@
         return;
       }
 
-      this.saveNotification = new App.View.NotificationView({
-        content: 'Don\'t forget to save the changes before leaving the page!',
-        type: 'warning',
-        visible: true
-      });
+      this.saveNotification = new App.View.NotificationView(App.Helper.Notifications.structure.saveReminder);
     },
 
     /**
@@ -216,11 +207,7 @@
         return;
       }
 
-      this.visibilityNotification = new App.View.NotificationView({
-        content: 'This page won\'t be visible to the users until all of its ancestors are enabled!',
-        type: 'warning',
-        visible: true
-      });
+      this.visibilityNotification = new App.View.NotificationView(App.Helper.Notifications.structure.visibilityReminder);
     },
 
     /**
@@ -242,11 +229,7 @@
         return;
       }
 
-      this.savingNotification = new App.View.NotificationView({
-        content: 'Saving the structure...',
-        closeable: false,
-        visible: true
-      });
+      this.savingNotification = new App.View.NotificationView(App.Helper.Notifications.structure.saving);
     },
 
     /**
@@ -267,11 +250,7 @@
         return;
       }
 
-      this.errorNotification = new App.View.NotificationView({
-        content: 'The changes couldn\'t be saved',
-        type: 'error',
-        visible: true
-      });
+      this.errorNotification = new App.View.NotificationView(App.Helper.Notifications.structure.error);
     },
 
     /**

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -106,6 +106,7 @@
     _onRenderTree: function () {
       $(this.treeContainer).find('.js-enable').on('click', this._onClickEnable.bind(this));
       $(this.treeContainer).find('.js-disable').on('click', this._onClickDisable.bind(this));
+      $(this.treeContainer).find('.js-delete').on('click', this._onClickDelete.bind(this));
       $(this.treeContainer).find('.js-add').on('click', this._onClickAddPage.bind(this));
     },
 
@@ -129,6 +130,24 @@
       var node = $(e.target).closest('.js-draggable')[0];
       this.toggleEnable(node, false);
       this._displaySaveWarning();
+    },
+
+    /**
+     * Event listener for when the deltee button is clicked on a node
+     * @param {object} e - event object
+     */
+    _onClickDelete: function (e) {
+      e.preventDefault();
+      e.stopPropagation(); // Prevents rails to automatically delete the page
+
+      App.notifications.broadcast(Object.assign({},
+        App.Helper.Notifications.page.deletion,
+        {
+          continueCallback: function () {
+            $.rails.handleMethod($(e.target));
+          }
+        }
+      ));
     },
 
     /**
@@ -159,7 +178,7 @@
             {{/if}}\
             <li><a href="{{#if editUrl}}{{editUrl}}{{else}}{{editurl}}{{/if}}" class="edit-button">Edit</a></li>\
             {{#if disableable}}\
-              <li><a rel="nofollow" data-method="delete" data-confirm="Are you sure you want to delete this page?" href="{{#if deleteUrl}}{{deleteUrl}}{{else}}{{deleteurl}}{{/if}}" class="delete-button">Delete</a></li>\
+              <li><a rel="nofollow" data-method="delete" data-confirm="Are you sure you want to delete this page?" href="{{#if deleteUrl}}{{deleteUrl}}{{else}}{{deleteurl}}{{/if}}" class="delete-button js-delete">Delete</a></li>\
             {{/if}}\
           </ul>\
         </div>\

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -50,7 +50,7 @@
 
       // If the tree has been saved successfully, we display a notification
       if (state && state === 'success') {
-        new App.View.NotificationView(App.Helper.Notifications.structure.update);
+        App.notifications.broadcast(App.Helper.Notifications.structure.update);
 
         this.navigate('/', { replace: true });
       }
@@ -179,12 +179,7 @@
      * clicking any button that would leave the page
      */
     _displaySaveWarning: function () {
-      if (this.saveNotification) {
-        this.saveNotification.show();
-        return;
-      }
-
-      this.saveNotification = new App.View.NotificationView(App.Helper.Notifications.structure.saveReminder);
+      this.saveWarningNotificationId = App.notifications.broadcast(App.Helper.Notifications.structure.saveReminder);
     },
 
     /**
@@ -192,8 +187,8 @@
      * the page
      */
     _hideSaveWarning: function () {
-      if (this.saveNotification) {
-        this.saveNotification.hide();
+      if (this.saveWarningNotificationId) {
+        App.notifications.hide(this.saveWarningNotificationId);
       }
     },
 
@@ -202,12 +197,7 @@
      * that as disabled ancestors, it won't be visible until they are all enabled
      */
     _displayVisibilityWarning: function () {
-      if (this.visibilityNotification) {
-        this.visibilityNotification.show();
-        return;
-      }
-
-      this.visibilityNotification = new App.View.NotificationView(App.Helper.Notifications.structure.visibilityReminder);
+      this.visibilityWarningNotificationId = App.notifications.broadcast(App.Helper.Notifications.structure.visibilityReminder);
     },
 
     /**
@@ -215,8 +205,8 @@
      * that as disabled ancestors, it won't be visible until they are all enabled
      */
     _hideVisibilityWarning: function () {
-      if (this.visibilityNotification) {
-        this.visibilityNotification.hide();
+      if (this.visibilityWarningNotificationId) {
+        App.notifications.hide(this.visibilityWarningNotificationId);
       }
     },
 
@@ -224,20 +214,15 @@
      * Display a notification to inform the user the tree is saving
      */
     _displaySavingNotification: function () {
-      if (this.savingNotification) {
-        this.savingNotification.show();
-        return;
-      }
-
-      this.savingNotification = new App.View.NotificationView(App.Helper.Notifications.structure.saving);
+      this.savingNotificationId = App.notifications.broadcast(App.Helper.Notifications.structure.saving);
     },
 
     /**
      * Hide the notification to inform the user the tree is saving
      */
     _hideSavingNotification: function () {
-      if (this.savingNotification) {
-        this.savingNotification.hide();
+      if (this.savingNotificationId) {
+        App.notifications.hide(this.savingNotificationId);
       }
     },
 
@@ -245,20 +230,15 @@
      * Display an error if the structure couldn't be saved in the backend
      */
     _displayErrorNotification: function () {
-      if (this.errorNotification) {
-        this.errorNotification.show();
-        return;
-      }
-
-      this.errorNotification = new App.View.NotificationView(App.Helper.Notifications.structure.error);
+      this.errorNotificationId = App.notifications.broadcast(App.Helper.Notifications.structure.error);
     },
 
     /**
      * Hide the error telling the user the structure couldn't be saved
      */
     _hideErrorNotification: function () {
-      if (this.errorNotification) {
-        this.errorNotification.hide();
+      if (this.errorNotificationId) {
+        App.notifications.hide(this.errorNotificationId);
       }
     },
 

--- a/app/assets/javascripts/templates/shared/notification.hbs
+++ b/app/assets/javascripts/templates/shared/notification.hbs
@@ -1,5 +1,11 @@
 <div class="wrapper">
-  <p id="notification-content">{{content}}</p>
+  <p id="notification-content">
+    {{#if additionalContent}}
+      <strong>{{content}}</strong><br />{{additionalContent}}
+    {{else}}
+      {{content}}
+    {{/if}}
+  </p>
 
   {{#if dialogButtons}}
     <div class="dialog-buttons js-dialog">

--- a/app/assets/javascripts/views/front/dashboardBookmarksView.js
+++ b/app/assets/javascripts/views/front/dashboardBookmarksView.js
@@ -25,13 +25,6 @@
 
     initialize: function (settings) {
       this.options = Object.assign({}, this.defaults, settings);
-
-      // These notifications are later used to display feedback
-      // By creating them now, we avoid to layer them on top of another if several notifications
-      // need to be displayed at once
-      this.successNotification = new App.View.NotificationView(App.Helper.Notifications.dashboard.bookmarks.deletion);
-      this.errorNotification = new App.View.NotificationView({ type: 'error' });
-
       this.render();
     },
 
@@ -88,8 +81,7 @@
         localStorage.removeItem(this.options.storageID);
 
         // We display an error
-        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.corrupted);
-        this.errorNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.bookmarks.corrupted);
       }
 
       return bookmarks || [];
@@ -116,8 +108,7 @@
         localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
       } catch (err) {
         // We display an error
-        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.saveError);
-        this.errorNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.bookmarks.saveError);
       }
     },
 
@@ -134,8 +125,7 @@
         localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
       } catch (err) {
         // We display an error
-        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.updateError);
-        this.errorNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.bookmarks.updateError);
       }
     },
 
@@ -153,12 +143,11 @@
         couldSave = true;
       } catch (err) {
         // We display an error
-        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.deleteError);
-        this.errorNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.bookmarks.deleteError);
       }
 
       if (couldSave) {
-        this.successNotification.show();
+        App.notifications.broadcast(App.Helper.Notifications.dashboard.bookmarks.deletion);
       }
     },
 

--- a/app/assets/javascripts/views/front/dashboardBookmarksView.js
+++ b/app/assets/javascripts/views/front/dashboardBookmarksView.js
@@ -29,7 +29,7 @@
       // These notifications are later used to display feedback
       // By creating them now, we avoid to layer them on top of another if several notifications
       // need to be displayed at once
-      this.successNotification = new App.View.NotificationView({ autoCloseTimer: 5 });
+      this.successNotification = new App.View.NotificationView(App.Helper.Notifications.dashboard.bookmarks.deletion);
       this.errorNotification = new App.View.NotificationView({ type: 'error' });
 
       this.render();
@@ -88,7 +88,7 @@
         localStorage.removeItem(this.options.storageID);
 
         // We display an error
-        this.errorNotification.options.content = 'The bookmarks have been corrupted and can\'t be retrieved';
+        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.corrupted);
         this.errorNotification.show();
       }
 
@@ -116,7 +116,7 @@
         localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
       } catch (err) {
         // We display an error
-        this.errorNotification.options.content = 'The bookmark couldn\'t be saved properly';
+        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.saveError);
         this.errorNotification.show();
       }
     },
@@ -134,7 +134,7 @@
         localStorage.setItem(this.options.storageID, JSON.stringify(bookmarks));
       } catch (err) {
         // We display an error
-        this.errorNotification.options.content = 'The name of the bookmark couldn\'t be updated';
+        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.updateError);
         this.errorNotification.show();
       }
     },
@@ -153,12 +153,11 @@
         couldSave = true;
       } catch (err) {
         // We display an error
-        this.errorNotification.options.content = 'The bookmark couldn\'t be deleted';
+        this.errorNotification.options = Object.assign({}, this.errorNotification.options, App.Helper.Notifications.dashboard.bookmarks.deleteError);
         this.errorNotification.show();
       }
 
       if (couldSave) {
-        this.successNotification.options.content = 'The bookmark has been successfully deleted!';
         this.successNotification.show();
       }
     },

--- a/app/assets/javascripts/views/management/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/management/dashboardFiltersView.js
@@ -61,10 +61,7 @@
       this._restoreFilters();
       this._addFilter(); // Add a default filter and render
       this.activeRequestsCount = 0; // Number of active requests to get the table extract
-      this.warningNotification = new App.View.NotificationView({
-        type: 'warning',
-        closeable: false
-      });
+      this.warningNotification = new App.View.NotificationView(App.Helper.Notifications.page.datasetPreview);
     },
 
     /**
@@ -159,7 +156,6 @@
       if (this.activeRequestsCount === 0) {
         this.previewModal.open();
       } else {
-        this.warningNotification.options.content = 'The preview is loading. Please wait...';
         this.warningNotification.show();
         this.previewTimer = setInterval(function () {
           if (this.activeRequestsCount === 0) {

--- a/app/assets/javascripts/views/management/dashboardFiltersView.js
+++ b/app/assets/javascripts/views/management/dashboardFiltersView.js
@@ -61,7 +61,6 @@
       this._restoreFilters();
       this._addFilter(); // Add a default filter and render
       this.activeRequestsCount = 0; // Number of active requests to get the table extract
-      this.warningNotification = new App.View.NotificationView(App.Helper.Notifications.page.datasetPreview);
     },
 
     /**
@@ -156,12 +155,13 @@
       if (this.activeRequestsCount === 0) {
         this.previewModal.open();
       } else {
-        this.warningNotification.show();
+        var notificationId = App.notifications.broadcast(App.Helper.Notifications.page.datasetPreview);
+
         this.previewTimer = setInterval(function () {
           if (this.activeRequestsCount === 0) {
             clearInterval(this.previewTimer);
             this.previewTimer = null;
-            this.warningNotification.hide();
+            App.notifications.hide(notificationId);
             this.previewModal.open();
           }
         }.bind(this), 200);

--- a/app/assets/javascripts/views/shared/notificationView.js
+++ b/app/assets/javascripts/views/shared/notificationView.js
@@ -24,6 +24,9 @@
       type: 'success',
       // Content of the notification, HTML will not be interpreted
       content: '',
+      // If not empty, the main content will be highlighted and this will be put below;
+      // again, no HTML
+      additionalContent: '',
       // Callback executed after the notification has been hidden (after the animation)
       afterHide: function () {},
       // Visibility of the notification (internal)
@@ -167,6 +170,7 @@
       // Render the content of the notification
       this.el.innerHTML = this.template({
         content: this.options.content,
+        additionalContent: this.options.additionalContent,
         closeable: this.options.closeable,
         // eslint-disable-next-line no-underscore-dangle
         visible: this.options._visible,

--- a/app/assets/javascripts/views/shared/notificationView.js
+++ b/app/assets/javascripts/views/shared/notificationView.js
@@ -5,11 +5,11 @@
 
 
     defaults: {
-      // (Default) visibility of the notification
-      visible: false,
-      // Whether the notification has a close button
+      // Whether the notification can be closed by the user and can be automatically
+      // closed by the JS without the user's input (should be displayed at least 5s)
       closeable: true,
       // Time for the notification to close automatically in seconds
+      // The notification won't be automatically closed by the JS before this time
       // Set the value -1 to disable the feature
       // Shouldn't be less than 5 (for accessibility)
       autoCloseTimer: -1,
@@ -23,7 +23,11 @@
       // The type can't be changed after instantiation
       type: 'success',
       // Content of the notification, HTML will not be interpreted
-      content: ''
+      content: '',
+      // Callback executed after the notification has been hidden (after the animation)
+      afterHide: function () {},
+      // Visibility of the notification (internal)
+      _visible: false
     },
 
     events: {
@@ -42,18 +46,6 @@
       this.timer = null;
 
       this._createEl();
-
-      // This double rAF pattern is enables the animation of the notification right
-      // after it is appended to the DOM in case this.options.visible is set to true
-      requestAnimationFrame(function () {
-        this.render();
-
-        requestAnimationFrame(function () {
-          if (this.options.visible) {
-            this.show();
-          }
-        }.bind(this));
-      }.bind(this));
     },
 
     /**
@@ -73,7 +65,8 @@
      * Show the notification
      */
     show: function () {
-      this.options.visible = true;
+      // eslint-disable-next-line no-underscore-dangle
+      this.options._visible = true;
       this.render();
 
       // We cancel any running timeout before setting a new one
@@ -88,7 +81,8 @@
      * Hide the notification
      */
     hide: function () {
-      this.options.visible = false;
+      // eslint-disable-next-line no-underscore-dangle
+      this.options._visible = false;
       this.timer = null;
       this.render();
     },
@@ -97,7 +91,8 @@
      * Toggle the visibility of the notification
      */
     toggle: function () {
-      if (this.options.visible) this.show();
+      // eslint-disable-next-line no-underscore-dangle
+      if (this.options._visible) this.show();
       else this.hide();
     },
 
@@ -106,7 +101,8 @@
      */
     _setFocus: function () {
       if (!this.isFocusSet) {
-        this.el.querySelector('.js-close').focus();
+        if (this.options.closeable) this.el.querySelector('.js-close').focus();
+        if (this.options.dialogButtons) this.el.querySelector('.js-dialog button[data-action="continue"]').focus();
         this.isFocusSet = true;
       }
     },
@@ -136,8 +132,11 @@
      * Event handler called when the notification stops animating
      */
     _onTransitionend: function () {
-      if (this.options.closeable && this.options.visible) {
+      // eslint-disable-next-line no-underscore-dangle
+      if (this.options._visible) {
         this._setFocus();
+      } else {
+        this.options.afterHide();
       }
     },
 
@@ -159,15 +158,18 @@
      */
     render: function () {
       this.isFocusSet = false; // Whether the focus has been set on the close button
-      this.el.classList[this.options.visible ? 'add' : 'remove']('-visible');
+      // eslint-disable-next-line no-underscore-dangle
+      this.el.classList[this.options._visible ? 'add' : 'remove']('-visible');
       this.el.classList[this.options.dialogButtons ? 'add' : 'remove']('-dialog');
-      this.el.setAttribute('aria-hidden', !this.options.visible);
+      // eslint-disable-next-line no-underscore-dangle
+      this.el.setAttribute('aria-hidden', !this.options._visible);
 
       // Render the content of the notification
       this.el.innerHTML = this.template({
         content: this.options.content,
         closeable: this.options.closeable,
-        visible: this.options.visible,
+        // eslint-disable-next-line no-underscore-dangle
+        visible: this.options._visible,
         dialogButtons: this.options.dialogButtons
       });
       this.setElement(this.el);

--- a/app/assets/javascripts/views/shared/notificationsView.js
+++ b/app/assets/javascripts/views/shared/notificationsView.js
@@ -1,0 +1,137 @@
+((function (App) {
+  'use strict';
+
+  App.View.NotificationsView = Backbone.View.extend({
+
+    el: 'body',
+
+    defaults: {
+      // List of notifications to display (FIFO)
+      pool: [],
+      // The first notification id will be lastId + 1
+      lastId: -1,
+      // Number of seconds a notification must at least be displayed before
+      // being autoclosed by the JS to display the next one
+      // NOTE: can be overriden by the autoCloseTimer value of the notification
+      // Shouldn't be less than 5 (for accessibility)
+      minimumDisplayTime: 5,
+      // Whether the current notification can be hidden to display the next one
+      _canAutoCloseNotification: false
+    },
+
+    initialize: function (settings) {
+      this.options = Object.assign({}, this.defaults, settings);
+    },
+
+    /**
+     * Display a notification to the user according to the configuration and
+     * return its id
+     * NOTE: the notification can be delayed if the previous is still being displayed
+     * NOTE: the notification may be automatically hidden after 5 seconds if a new
+     * one is broadcasted
+     * NOTE: uncloseable notifications won't be automatically hidden and will be
+     * blocking for the next ones to be displayed
+     * @param {object} config - configuration of the notification
+     * @return {number} id - notification ID
+     */
+    broadcast: function (config) {
+      var notification = new App.View.NotificationView(config);
+      notification.options.id = ++this.options.lastId;
+
+      // This rAF is needed for the first notification to appear with a animation
+      requestAnimationFrame(function () {
+        var poolSize = this.options.pool.push(notification);
+
+        if (poolSize === 1) this._displayNotification();
+        // If the previous notification can be auto closed, then we hide it, which
+        // will trigger the next one to be shown
+        else if (poolSize > 1 && this.options.pool[0].options.closeable &&
+          this.options._canAutoCloseNotification) {  // eslint-disable-line no-underscore-dangle
+          this.options.pool[0].hide();
+        }
+      }.bind(this));
+
+      return notification.options.id;
+    },
+
+    /**
+     * Hide the notification designated by its id
+     * NOTE: the notification may already be hidden
+     * NOTE: if the notification haven't been displayed yet, it
+     * won't appear
+     * @param {number} notificationId - notification ID
+     */
+    hide: function (notificationId) {
+      var poolSize = this.options.pool.length;
+      if (poolSize === 0) return;
+
+      var currentNotification = this.options.pool[0];
+
+      // If the currently displayed notification has an id greater than the one we're
+      // looking for, then the notification already disappeared
+      if (currentNotification.options.id > notificationId) return;
+
+      if (currentNotification.options.id === notificationId) {
+        // If the notification we want to hide is the one displayed, we just hide it
+        currentNotification.hide();
+      } else if (poolSize > 1) {
+        for (var i = 1, j = poolSize - 1; i < j; i++) {
+          var notification = this.options.pool[i];
+          if (notification.options.id === notificationId) {
+            // We do not hide the notification because it hasn't been displayed yet,
+            // we just remove it from the pool
+            this.options.pool.splice(i, 1);
+            break;
+          }
+        }
+      }
+    },
+
+    /**
+     * Display the oldest notification
+     */
+    _displayNotification: function () {
+      // This rAF is needed for the notification to appear with a animation
+      requestAnimationFrame(function () {
+        var notification = this.options.pool[0];
+        notification.options.afterHide = this._proceedPool.bind(this);
+
+        // We don't want interferences with the timer
+        if (this.timer) {
+          clearTimeout(this.timer);
+          this.timer = null;
+        }
+
+        notification.show();
+        this.options._canAutoCloseNotification = false; // eslint-disable-line no-underscore-dangle
+
+        if (notification.options.autoCloseTimer === -1 && notification.options.closeable) {
+          this.timer = setTimeout(function () {
+            this.options._canAutoCloseNotification = true; // eslint-disable-line no-underscore-dangle
+            var poolSize = this.options.pool.length;
+            if (poolSize > 1) notification.hide();
+          }.bind(this), this.options.minimumDisplayTime * 1000);
+        }
+      }.bind(this));
+    },
+
+    /**
+     * If the oldest notification in the pool has already been displayed, it is
+     * removed and the next one is displayed
+     */
+    _proceedPool: function () {
+      if (!this.options.pool.length) return;
+
+      var notification = this.options.pool[0];
+
+      if (!notification.options._visible) { // eslint-disable-line no-underscore-dangle
+        notification.remove(); // We delete from the DOM (fire and forget)
+        this.options.pool.shift();
+        if (this.options.pool.length) this._displayNotification();
+      }
+    }
+
+  });
+
+  App.notifications = new App.View.NotificationsView();
+})(this.App));

--- a/app/assets/stylesheets/components/shared/c-notification.scss
+++ b/app/assets/stylesheets/components/shared/c-notification.scss
@@ -26,6 +26,15 @@
       flex-wrap: wrap;
       align-items: center;
       justify-content: space-between;
+
+      @media #{$mq-tablet} {
+        height: 100%;
+      }
+    }
+
+    p {
+      line-height: 1.5;
+      text-align: left;
     }
 
     .dialog-buttons {

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,11 +1,10 @@
 <% if resource && resource.errors.any? %>
   <script>
-    new App.View.NotificationView({
-    visible: true,
-    closeable: true,
-    autoCloseTimer: -1,
-    type: 'error',
-    content: '<%== j pluralize(resource.errors.count, "error") %> occurred: <% resource.errors.full_messages.each do |message| %><%== j message + (message == resource.errors.full_messages.last ? '' : ', ') %> <% end %>'
+    App.notifications.broadcast({
+      closeable: true,
+      autoCloseTimer: -1,
+      type: 'error',
+      content: '<%== j pluralize(resource.errors.count, "error") %> occurred: <% resource.errors.full_messages.each do |message| %><%== j message + (message == resource.errors.full_messages.last ? '' : ', ') %> <% end %>'
     });
   </script>
 <% end %>

--- a/app/views/shared/_messages.html.erb
+++ b/app/views/shared/_messages.html.erb
@@ -9,8 +9,7 @@
       end
     %>
     <script>
-     new App.View.NotificationView({
-      visible: true,
+    App.notifications.broadcast({
       closeable: true,
       autoCloseTimer: <%= key == 'alert' ? '-1' : '5' %>,
       type: '<%= key %>',


### PR DESCRIPTION
![Example of a richer notification](https://cloud.githubusercontent.com/assets/6073968/21925941/912b834a-d977-11e6-903d-861f821fb549.png)

The PR refactors the notifications system to be less subject to errors:
* a global view now manages the displaying of the notifications and when to hide them
* when "broadcasting" a notification you don't have to care about if another is currently displayed anymore (fire and forget style)
* each notification's content and configuration is stored into a same file to favour their reuse
* richer notifications with the addition of a second line of text

In addition, a missing warning notification has been added to the tree structure tab when deleting a page.

