### PR TITLE
Feature/translations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,8 @@
     "Jiminy": true,
     "PruneClusterForLeaflet": true,
     "PruneCluster": true,
-    "CodeMirror": true
+    "CodeMirror": true,
+    "Transifex": true
   },
   "env": {
     "browser": true

--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -17,6 +17,8 @@
 
       // NOTE: Don't forget to start Backbone.history in the router
 
+      // This component is in charge of the translation selector
+      new App.View.LanguageSelectorView();
     } else {
       // eslint-disable-next-line no-console
       console.warn('The route ' + window.route + ' doesn\'t have any associated router.');

--- a/app/assets/javascripts/templates/shared/dropdown-selector.hbs
+++ b/app/assets/javascripts/templates/shared/dropdown-selector.hbs
@@ -1,0 +1,10 @@
+<div class="c-dropdown-selector -{{align}}">
+  <div class="active-option js-list-btn" tabindex="0" aria-label="Open list of languages" aria-controls="language-selector">{{#if useShortName}}{{activeOption.shortName}}{{else}}{{activeOption.name}}{{/if}}</div>
+  <ul id="language-selector" class="options js-dropdown" role="listbox" aria-expanded="false">
+    {{#each options}}
+      <li role="option" tabindex="{{#if_eq id ../activeOption.id}}0{{else}}-1{{/if_eq}}" class="option {{#if_eq id ../activeOption.id}}-active{{/if_eq}} js-option" data-id="{{id}}">
+        {{name}}
+      </li>
+    {{/each}}
+  </ul>
+</div>

--- a/app/assets/javascripts/views/front/languageSelectorView.js
+++ b/app/assets/javascripts/views/front/languageSelectorView.js
@@ -36,6 +36,13 @@
           }.bind(this), 1000);
         }
 
+        // If the URL doesn't contain the language query parameter, we add it so it
+        // can be shareable
+        if (!/\?(.*)?lang=[a-z]{2}/.test(location.search)) {
+          var url = (!location.search.length ? '?' : '&') + 'lang=' + currentLanguageCode;
+          history.replaceState(null, '', url);
+        }
+
         this.render();
       }.bind(this));
     },
@@ -48,6 +55,10 @@
     _onLanguageChange: function (languageCode) {
       Transifex.live.translateTo(languageCode, true);
       this._setMapLanguage(languageCode);
+
+      // We update the URL with the new language choice
+      var search = location.search.replace(/lang=[a-z]{2}/, 'lang=' + languageCode);
+      history.replaceState(null, '', search);
     },
 
     /**

--- a/app/assets/javascripts/views/front/languageSelectorView.js
+++ b/app/assets/javascripts/views/front/languageSelectorView.js
@@ -27,6 +27,15 @@
         var currentLanguageCode = Transifex.live.getSelectedLanguageCode();
         this.options.currentLanguage = _.findWhere(this.options.languages, { code: currentLanguageCode });
 
+        // If the user is seeing the standalone map, we need to update its language
+        // Nevertheless, it seems the map doesn't have any API so we're doing kind of
+        // a trick here
+        if (window.route === 'Map') {
+          setTimeout(function () {
+            this._setMapLanguage(currentLanguageCode);
+          }.bind(this), 1000);
+        }
+
         this.render();
       }.bind(this));
     },
@@ -38,6 +47,7 @@
      */
     _onLanguageChange: function (languageCode) {
       Transifex.live.translateTo(languageCode, true);
+      this._setMapLanguage(languageCode);
     },
 
     /**
@@ -63,6 +73,15 @@
         name: this.options.currentLanguage.name,
         shortName: this.options.currentLanguage.code.toUpperCase()
       };
+    },
+
+    /**
+     * Set the language of the standalone map
+     * @param {string} languageCode
+     */
+    _setMapLanguage: function (languageCode) {
+      var languagePicker = document.querySelector('.app-header__language[data-lang="' + languageCode + '"]');
+      if (languagePicker) languagePicker.click();
     },
 
     render: function () {

--- a/app/assets/javascripts/views/front/languageSelectorView.js
+++ b/app/assets/javascripts/views/front/languageSelectorView.js
@@ -1,0 +1,82 @@
+((function (App) {
+  'use strict';
+
+  App.View.LanguageSelectorView = Backbone.View.extend({
+
+    el: '.js-language-selector',
+
+    defaults: {
+      // List of available languages
+      // Each language should have this structure:
+      // { name: 'French', code: 'fr' }
+      languages: [],
+      // Current language (use the structure above)
+      currentLanguage: null
+    },
+
+    initialize: function (settings) {
+      this.options = Object.assign({}, this.defaults, settings);
+
+      // This prevents the website to stop working if Transifex
+      // doesn't load
+      if (!Transifex) return;
+
+      Transifex.live.onFetchLanguages(function (languages) {
+        this.options.languages = languages;
+
+        var currentLanguageCode = Transifex.live.getSelectedLanguageCode();
+        this.options.currentLanguage = _.findWhere(this.options.languages, { code: currentLanguageCode });
+
+        this.render();
+      }.bind(this));
+    },
+
+    /**
+     * Callback executed when the user selects a language in the
+     * dropdown
+     * @param {string} languageCode
+     */
+    _onLanguageChange: function (languageCode) {
+      Transifex.live.translateTo(languageCode, true);
+    },
+
+    /**
+     * Return the list of options available for the selector
+     * @return {object[]}
+     */
+    _getSelectorOptions: function () {
+      return this.options.languages.map(function (language) {
+        return {
+          id: language.code,
+          name: language.name,
+          shortName: language.code.toUpperCase()
+        };
+      });
+    },
+
+    /**
+     * Return the active option for the selector
+     */
+    _getSelectorActiveOption: function () {
+      return {
+        id: this.options.currentLanguage.code,
+        name: this.options.currentLanguage.name,
+        shortName: this.options.currentLanguage.code.toUpperCase()
+      };
+    },
+
+    render: function () {
+      if (!this.dropdownSelectorView) {
+        this.dropdownSelectorView = new App.View.DropdownSelectorView({
+          el: this.el,
+          options: this._getSelectorOptions(),
+          activeOption: this._getSelectorActiveOption(),
+          useShortName: true,
+          align: 'right',
+          onChangeCallback: this._onLanguageChange.bind(this)
+        });
+      }
+    }
+
+  });
+})(this.App));

--- a/app/assets/javascripts/views/shared/dropdownSelectorView.js
+++ b/app/assets/javascripts/views/shared/dropdownSelectorView.js
@@ -1,0 +1,215 @@
+((function (App) {
+  'use strict';
+
+  App.View.DropdownSelectorView = Backbone.View.extend({
+
+    template: HandlebarsTemplates['shared/dropdown-selector'],
+
+    events: {
+      'click .js-list-btn': '_onClickListBtn',
+      'keydown .js-list-btn': '_onKeydownListBtn',
+      'click .js-option': '_onClickOption',
+      'keydown .js-option': '_onKeydownOption'
+    },
+
+    defaults: {
+      // List of options for the selector
+      // Each options should have this format:
+      // { id: string, name: string, shortName: string }
+      // The shortName option is optional
+      options: [],
+      // Active option (from the list above)
+      activeOption: null,
+      // Use the short name for the active option when the selector is closed
+      useShortName: false,
+      // Position of the arrow relatively to the active option's name
+      // Choose between "right" and "left"
+      arrowPosition: 'right',
+      // Towards which direction the selector should be aligned
+      align: 'left',
+      // Callback executed when the active option is changed
+      // It's passed the id of the new active option
+      onChangeCallback: function () {}
+    },
+
+    initialize: function (settings) {
+      this.options = Object.assign({}, this.defaults, settings);
+      this.render();
+
+      this._setListeners();
+    },
+
+    /**
+     * Set the listeners not attached to any DOM element of this.el
+     */
+    _setListeners: function () {
+      document.body.addEventListener('click', function (e) {
+        if ($(e.target).closest(this.el).length) return;
+        this._hideDropdown();
+      }.bind(this));
+    },
+
+    /**
+     * Event handler executed when the active option is clicked
+     * @param {Event} e - event
+     */
+    _onClickListBtn: function (e) {
+      e.stopPropagation();
+      this._toggleDropdown();
+    },
+
+    /**
+     * Event handler executed when the user presses a key while
+     * the focus is on the active option
+     * @param {Event} e - event
+     */
+    _onKeydownListBtn: function (e) {
+      if (e.keyCode !== 13 && e.keyCode !== 32) return;
+      e.preventDefault();
+      this._toggleDropdown();
+    },
+
+    /**
+     * Event handler executed when an option is clicked
+     * @param {Event} e - event
+     */
+    _onClickOption: function (e) {
+      this._setActiveOption(e.target);
+    },
+
+    /**
+     * Event handler executed when the user presses a key while the
+     * focus is on one of the options
+     * @param {Event} e - event
+     */
+    _onKeydownOption: function (e) {
+      switch (e.keyCode) {
+        case 37: // Left arrow
+        case 38: // Up arrow
+          this._moveOptionfocusOption('previous');
+          e.preventDefault();
+          e.stopPropagation();
+          break;
+
+        case 39: // Right arrow
+        case 40: // Down arrow
+          this._moveOptionfocusOption('next');
+          e.preventDefault();
+          e.stopPropagation();
+          break;
+
+        case 13: // Enter
+        case 32: // Space
+          this._setActiveOption(e.target);
+          e.preventDefault();
+          e.stopPropagation();
+          break;
+
+        default:
+          break;
+      }
+    },
+
+    /**
+     * Set the specied option as active i.e. set an "active" class to it, update
+     * this.options, execute the "change" callback and close the dropdown
+     * @param {HTMLElement} option
+     */
+    _setActiveOption: function (option) {
+      var id = option.dataset.id;
+      var activeOption = this.el.querySelector('.js-option.-active');
+
+      activeOption.classList.remove('-active');
+      activeOption.setAttribute('tabindex', -1);
+      option.classList.add('-active');
+
+      this.options.activeOption = _.findWhere(this.options.options, { id: id });
+
+      // We update the UI with the name of the new active option
+      var activeOptionName = this.options.activeOption[this.options.useShortName ? 'shortName' : 'name'];
+      this.el.querySelector('.js-list-btn').textContent = activeOptionName;
+
+      this.options.onChangeCallback(id);
+      this._hideDropdown();
+    },
+
+    /**
+     * Move the focus on the previous or next option on the list
+     * depending on the direction
+     * If the first or last option is reached, go to the last or the
+     * first one
+     * @param {'previous'|'next'} direction
+     */
+    _moveOptionfocusOption: function (direction) {
+      var focusedOption = this.el.querySelector('.js-option:focus');
+      var previousOption = focusedOption.previousElementSibling;
+      var nextOption = focusedOption.nextElementSibling;
+
+      if ((direction === 'previous' && !previousOption) ||
+        (direction === 'next' && !nextOption)) {
+        var options = focusedOption.parentElement.querySelectorAll('.js-option');
+        var firstOption = options[0];
+        var lastOption = options[options.length - 1];
+
+        this._setOptionFocus(direction === 'previous' ? lastOption : firstOption);
+      } else {
+        this._setOptionFocus(direction === 'previous' ? previousOption : nextOption);
+      }
+
+      focusedOption.setAttribute('tabindex', -1);
+    },
+
+    /**
+     * Set the focus on a specific option
+     * @param {HTMLElement} option
+     */
+    _setOptionFocus: function (option) {
+      option.setAttribute('tabindex', 0);
+      option.focus();
+    },
+
+    /**
+     * Remove the focus of all the options
+     */
+    _removeOptionsFocus: function () {
+      var options = this.el.querySelectorAll('.js-option');
+      Array.prototype.slice.call(options).forEach(function (option) {
+        option.setAttribute('tabindex', -1);
+      });
+    },
+
+    /**
+     * Toggle the dropdown's visibility
+     */
+    _toggleDropdown: function () {
+      var isOpened = this.dropdown.classList.toggle('-visible');
+      var activeOption = this.el.querySelector('.js-option.-active');
+
+      if (isOpened) {
+        this._setOptionFocus(activeOption);
+      } else {
+        this._removeOptionsFocus();
+      }
+    },
+
+    /**
+     * Hide the dropdown
+     */
+    _hideDropdown: function () {
+      this._removeOptionsFocus();
+      this.dropdown.classList.remove('-visible');
+    },
+
+    render: function () {
+      this.el.innerHTML = this.template({
+        options: this.options.options,
+        activeOption: this.options.activeOption,
+        useShortName: this.options.useShortName,
+        align: this.options.align
+      });
+
+      this.dropdown = this.el.querySelector('.js-dropdown');
+    }
+
+  });
+})(this.App));

--- a/app/assets/stylesheets/components/front/c-cover.scss
+++ b/app/assets/stylesheets/components/front/c-cover.scss
@@ -1,15 +1,13 @@
-
 .c-cover {
   display: flex;
   position: relative;
   align-items: center;
   justify-content: center;
-  padding: 50px 0 30px 0;
+  padding: 50px 0 30px;
   // image sample. This property should be injected through javascript
   background-image: asset-url('cover.jpg');
   background-repeat: no-repeat;
   background-size: cover;
-  z-index: -1;
 
   @media #{$mq-mobile} {
     padding: 100px 0;
@@ -28,13 +26,16 @@
     width: 100%;
     height: 100%;
     content: '';
-    z-index: -1;
 
     @if $theme == 2 {
       background-color: rgba($color-5, .3);
     } @else {
       background-color: rgba($color-1, .4);
     }
+  }
+
+  > .wrapper {
+    z-index: 1;
   }
 
   .cover-title {

--- a/app/assets/stylesheets/components/front/c-header.scss
+++ b/app/assets/stylesheets/components/front/c-header.scss
@@ -326,7 +326,6 @@
                   } @else {
                     background-color: rgba($color-1, .1);
                   }
-
                 }
 
                 a {

--- a/app/assets/stylesheets/components/shared/c-dropdown-selector.scss
+++ b/app/assets/stylesheets/components/shared/c-dropdown-selector.scss
@@ -29,7 +29,7 @@
     bottom: -3px;
     left: calc(50% - 27px);
     width: auto;
-    padding: 10px 20px;
+    padding: 0;
     transform: translateY(100%);
     transition: opacity .2s, pointer-events 0 .2s;
     border-radius: 2px;
@@ -46,10 +46,9 @@
       width: 12px;
       height: 12px;
       transform: rotate(45deg);
-      border-top: 12px solid;
-      border-left: 12px solid;
-      border-color: $color-3;
+      background-color: $color-3;
       content: '';
+      z-index: -1;
     }
 
     &.-visible {
@@ -60,10 +59,33 @@
 
     .option {
       display: block;
-      padding-left: 10px;
+      padding: 0 20px;
+      border-bottom: 1px solid $color-9;
       color: $color-4;
       line-height: 2.5;
       cursor: pointer;
+
+      &:first-of-type {
+        border-top-left-radius: 2px;
+        border-top-right-radius: 2px;
+      }
+
+      &:last-of-type {
+        border-bottom: 0;
+        border-bottom-left-radius: 2px;
+        border-bottom-right-radius: 2px;
+      }
+
+      &:hover,
+      &:focus {
+        outline: none;
+
+        @if $theme == 2 {
+          background-color: $color-8;
+        } @else {
+          background-color: rgba($color-1, .1);
+        }
+      }
 
       &.-active {
         position: relative;
@@ -73,7 +95,7 @@
           display: block;
           position: absolute;
           top: 50%;
-          left: -8px;
+          left: 5px;
           width: 8px;
           height: 8px;
           transform: translateY(-50%) rotate(45deg);

--- a/app/assets/stylesheets/components/shared/c-dropdown-selector.scss
+++ b/app/assets/stylesheets/components/shared/c-dropdown-selector.scss
@@ -1,0 +1,102 @@
+.c-dropdown-selector {
+  position: relative;
+
+  > .active-option {
+    cursor: pointer;
+
+    &::after {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      margin-left: 12px;
+      transform: translateY(-3px) rotate(135deg);
+      border-bottom: 0;
+      border-left: 0;
+      content: '';
+
+      @if $theme == 1 {
+        border-top: 2px solid $color-1;
+        border-right: 2px solid $color-1;
+      } @else {
+        border-top: 2px solid $color-3;
+        border-right: 2px solid $color-3;
+      }
+    }
+  }
+
+  > .options {
+    position: absolute;
+    bottom: -3px;
+    left: calc(50% - 27px);
+    width: auto;
+    padding: 10px 20px;
+    transform: translateY(100%);
+    transition: opacity .2s, pointer-events 0 .2s;
+    border-radius: 2px;
+    background-color: $color-3;
+    box-shadow: 0 1px 3px 0 rgba($color-5, .25);
+    opacity: 0;
+    pointer-events: none;
+
+    &::before {
+      display: block;
+      position: absolute;
+      top: -6px;
+      left: 20px;
+      width: 12px;
+      height: 12px;
+      transform: rotate(45deg);
+      border-top: 12px solid;
+      border-left: 12px solid;
+      border-color: $color-3;
+      content: '';
+    }
+
+    &.-visible {
+      transition: opacity .2s;
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .option {
+      display: block;
+      padding-left: 10px;
+      color: $color-4;
+      line-height: 2.5;
+      cursor: pointer;
+
+      &.-active {
+        position: relative;
+        color: $color-1;
+
+        &::before {
+          display: block;
+          position: absolute;
+          top: 50%;
+          left: -8px;
+          width: 8px;
+          height: 8px;
+          transform: translateY(-50%) rotate(45deg);
+          border-top: 2px solid $color-1;
+          border-right: 2px solid $color-1;
+          border-bottom: 0;
+          border-left: 0;
+          content: '';
+        }
+      }
+    }
+  }
+
+  &.-right {
+    > .options {
+      right: calc(50% - 27px);
+      left: auto;
+
+      &::before {
+        right: 20px;
+        left: auto;
+      }
+    }
+  }
+
+}

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -72,7 +72,7 @@
       <% end -%>
     </ul>
     <ul>
-      <li class="js-language-selector"></li>
+      <li class="notranslate js-language-selector"></li>
     </ul>
   </div>
 

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -72,7 +72,7 @@
       <% end -%>
     </ul>
     <ul>
-      <li><a href="#">LANG</a></li>
+      <li class="js-language-selector"></li>
     </ul>
   </div>
 


### PR DESCRIPTION
This PR adds the support for live translations by integrating Transifex into the app.

To change the language, the user needs to click the menu's last item (the two-letter country name) and select one of the options from the dropdown.

Related changes/notes:
* Any visited page automatically gets its URL updated with `lang=XX` where `XX` is a country code
* The standalone map also gets automatically translated by simulating a click on the language selector of its hidden header (we don't have an API to do so)
* The language selector is fully accessible via keyboard
* A new dropdown component has been created (to display the selector itself)

**NOTE:** the translations aren't automatic. The client needs to update them on [Transifex](https://www.transifex.com).