### PR TITLE
Reduces the size of the images uploaded via the wysiwyg

### DIFF
--- a/app/assets/javascripts/blots/imageBlock.es6
+++ b/app/assets/javascripts/blots/imageBlock.es6
@@ -48,6 +48,9 @@ class ImageBlot extends Embed {
 
     node.appendChild(image);
 
+    // We don't want the user to be able to add text within the container
+    node.setAttribute('contenteditable', false);
+
     return node;
   }
 

--- a/app/assets/javascripts/blots/imageBlock.js
+++ b/app/assets/javascripts/blots/imageBlock.js
@@ -223,6 +223,9 @@
 
         node.appendChild(image);
 
+        // We don't want the user to be able to add text within the container
+        node.setAttribute('contenteditable', false);
+
         return node;
       }
 

--- a/app/assets/javascripts/helpers/notifications.js
+++ b/app/assets/javascripts/helpers/notifications.js
@@ -36,6 +36,11 @@
         type: 'error',
         content: 'The widget\'s data couldn\'t be retrieved!',
         additionalContent: 'After a second try, if the error keeps on happening, please insert it later.'
+      },
+      imageUploadError: {
+        type: 'error',
+        content: 'The image couldn\'t be correctly uploaded!',
+        additionalContent: 'If the issue keeps on happening, try to reduce its size.'
       }
     },
 

--- a/app/assets/stylesheets/components/management/c-wysiwyg.scss
+++ b/app/assets/stylesheets/components/management/c-wysiwyg.scss
@@ -262,12 +262,13 @@
 
     .-image {
       position: relative;
+      width: calc(100% + 390px);
+      margin: 35px -195px;
 
       > img {
         display: block;
-        width: calc(100% + 390px);
-        max-width: none;
-        margin: 35px -195px;
+        max-width: 100%;
+        margin: 0 auto;
         border-radius: 4px;
       }
     }


### PR DESCRIPTION
This PR prevents the upload of large images through the wysiwyg. The main reason is that the browser would eventually crash when adding several images in the same page.

To reduce their file size, each image is encoded to base64 (as before), then scaled down and rendered in a hidden canvas and finally re-encoded as base64. The default params force the images to fit into a box of the size 1060x600px.

As an example, with [this image of a cute 🐶](https://unsplash.com/collections/380/petunia-the-pug?photo=2Ts5HnA67k8), which weights 5MB, the final base64-encoded version weights only 1/3 of the original. Obviously, the ratio will depend on the size of the original image.

In addition to this feature, the PR prevents the user from adding text within the image container and the wysiwyg handles the narrow images better.