### PR TITLE
Bug/dataset filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 7 Feb 2017
+- Fixed several issues with the dataset filtering: unable to set some string filters, misleading row count, unconsistent UI, etc.
 - Added GFW's datasets to the application
 - Improved the lists of datasets: removed the grouping by contexts (to avoid duplicates) and added a search field
 - Removed the warning to prevent the user from uploading a CSV dataset served over HTTPs

--- a/app/assets/javascripts/helpers/handlebars.js
+++ b/app/assets/javascripts/helpers/handlebars.js
@@ -26,7 +26,9 @@ Handlebars.registerHelper('each_range', function (min, max, step, block) {
     return (split.length === 1) ? 0 : split[1].length;
   };
 
-  var count = ((max - min) / step) + 1;
+  // We need to round the number on the next line due to JS approximation errors
+  // Example: .1 + .2 !== .3
+  var count = Math.round(((max - min) / step) + 1);
   var stepDecimals = getDecimalsCount(step); // Maxiumum number of decimals allowed
 
   return new Array(count).fill(null).map(function (value, index) {

--- a/app/assets/javascripts/templates/management/dataset-filters.hbs
+++ b/app/assets/javascripts/templates/management/dataset-filters.hbs
@@ -105,7 +105,7 @@
   <div class="action-bar">
       <button type="button" class="c-button -outline -dark-text {{#if canAddNewField}}js-add-filter{{else}}-disabled{{/if}}">Add filter</button>
       <div>
-        <div class="js-row-count"></div>
+        <div class="c-loading-spinner js-row-count"></div>
         <button type="button" class="c-button -outline -dark-text js-preview">Preview table</button>
       </div>
   </div>

--- a/app/assets/javascripts/views/management/datasetFiltersView.js
+++ b/app/assets/javascripts/views/management/datasetFiltersView.js
@@ -298,7 +298,7 @@
         return filter.name;
       });
 
-      return JSON.stringify({ filters: serializedFilters });
+      return JSON.stringify(serializedFilters);
     },
 
     /**

--- a/app/assets/javascripts/views/management/datasetFiltersView.js
+++ b/app/assets/javascripts/views/management/datasetFiltersView.js
@@ -333,15 +333,18 @@
      * @returns {object} $.Deferred
      */
     _getTableExtract: function () {
-      // TODO query number
       var deferred = $.Deferred(); // eslint-disable-line new-cap
       var collection = new (Backbone.Collection.extend({
         url: this._getTableExtractURL()
       }))();
 
+      // We set the loading spinner
+      this.rowCountContainer.classList.add('c-loading-spinner');
+      this.rowCountContainer.textContent = '';
+
       collection.fetch()
-        .done(function (data) { deferred.resolve(data); })
-        .fail(function () { deferred.reject(); });
+        .done(deferred.resolve)
+        .fail(deferred.reject);
 
       return deferred;
     },
@@ -366,6 +369,12 @@
             if (id === requestsCount) this.tableExtract = null;
           }.bind(this)).always(function () {
             this.activeRequestsCount--;
+
+            // We remove the loading spinner if that was the last request
+            if (this.activeRequestsCount === 0) {
+              this.rowCountContainer.classList.remove('c-loading-spinner');
+            }
+
             if (id === requestsCount) deferred.resolve();
             else deferred.reject();
           }.bind(this));
@@ -375,19 +384,6 @@
     }()),
 
     /**
-     * Update the row count with the result of the query to the server
-     */
-    _checkRowCount: function () {
-      this.countEl = this.el.querySelector('.js-row-count');
-      if (this.collection.toJSON().length) {
-        this.countEl.classList.add('c-loading-spinner');
-        this._updateRowCount();
-      } else {
-        this.countEl.classList.remove('c-loading-spinner');
-      }
-    },
-
-    /**
      * Get the row count with the result of the query to the server
      */
     _updateRowCount: _.debounce(function () {
@@ -395,8 +391,7 @@
         .done(function () {
           var count = this.tableExtract && this.tableExtract.count;
           var formattedCount = (count !== null && count !== undefined) ? (count.toLocaleString('en-US') + ' rows') : '';
-          this.countEl.classList.remove('c-loading-spinner');
-          this.countEl.textContent = formattedCount;
+          this.rowCountContainer.textContent = formattedCount;
 
           if (count && count > 10000) {
             this.rowCountNotificationId = App.notifications.broadcast(App.Helper.Notifications.dataset.rowCount);
@@ -440,10 +435,15 @@
       }));
       this.setElement(this.el);
 
+      this.rowCountContainer = this.el.querySelector('.js-row-count');
+
       this._enhanceSelectors();
 
+      // We fetch the number of result only if we have an API endpoint
       if (this.options.endpointUrl && this.options.endpointUrl.length) {
-        this._checkRowCount();
+        this._updateRowCount();
+      } else {
+        this.rowCountContainer.classList.remove('c-loading-spinner');
       }
     }
   });

--- a/app/assets/javascripts/views/management/datasetFiltersView.js
+++ b/app/assets/javascripts/views/management/datasetFiltersView.js
@@ -81,6 +81,9 @@
       var index = +$(e.target).data('id');
       var model = this.collection.at(index);
       this.collection.remove(model);
+
+      if (this.collection.length === 0) this._addFilter(); // Add a default
+
       this.render();
     },
 


### PR DESCRIPTION
This PR fixes a couple of issues with the dataset filtering:
* in some cases, a user wouldn't be able to set a filter due to JS' bad float approximation
* the row count would eventually update without showing the loader in the first place
* if the user would remove the last filter, we would have an empty one as placeholder
* the widget creation would be broken because of bad filter serialisation