### PR TITLE
Fix/sessions issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### 21 Feb 2017
 - Fixed an issue that prevented the map's settings to have color hightlighting
 
+### 16 Feb 2017
+- Fixed session issue when editing multiple pages
+
 ### 14 Feb 2017
 - In a site's dataset listing, only the datasets belonging to a site's context are show, even for admins.
 - Fixed bug that was duplicating the routes

--- a/app/controllers/management_controller.rb
+++ b/app/controllers/management_controller.rb
@@ -40,4 +40,14 @@ class ManagementController < ActionController::Base
 
     gon.global.user = { 'name' => current_user.name, 'profile' => edit_management_profile_path(current_user.id), 'logout' => auth_logout_url } if current_user
   end
+
+  # assumes session keys are organised by id, as in session[:page][@page_id]
+  def reset_session_key(key, id, default_value = nil)
+    session[key][id] = default_value
+  end
+
+  # assumes session keys are organised by id, as in session[:page][@page_id]
+  def delete_session_key(key, id)
+    session[key].delete(id)
+  end
 end


### PR DESCRIPTION
This is to isolate sessions when editing multiple objects of same type (pages, datasets, contexts, widgets). This now does not produce conflicts, as long as we're considering already persisted objects, as those can be uniquely referenced by an id. That does not work before the object is saved though, in which case a fake id `:new` is used and results in overwriting if user is working on multiple non-persisted objects - haven't found a good solution for that. The id (either real of `:new`) is set in an instance var. Once an object is saved, session for that object is cleared.