### PR TITLE
Fixes a bug where the router could instance twice the same views

### DIFF
--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -13,7 +13,11 @@
       // history before anything else
       Backbone.history.stop();
 
-      new App.Router[routerName]();
+      // Backbone.history.stop has some asynchronous events that can trigger twice
+      // the same route when Backbone.history.start is executed
+      setTimeout(function () {
+        new App.Router[routerName]();
+      }, 0);
 
       // NOTE: Don't forget to start Backbone.history in the router
 


### PR DESCRIPTION
This PR fixes an issue that could prevent the dashboard from loading correctly.

Basically, when switching the Backbone router's `pushState` state from `true` to `false` (by stopping it and restarting it), some asynchronous events could still be dispatched and the routes could be executed twice. In some cases, this would just throw an error in the console, but in other, the dashboard wouldn't load at all (on FF only).