### PR TITLE
Feature/store widget ids used in pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add clear formatting button to WYSIWYG editor
 - Update styling for Landscape applications
 - Add site title to page header
+- Store links between pages and widgets
 
 ### 21 Feb 2017
 - Added possibility to change the homepage's name

--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -395,6 +395,7 @@ class Management::PageStepsController < ManagementController
       notice_text = @page.id ? 'saved' : 'created'
       if @page.save
         delete_session_key(:page, @page_id)
+        @page.synchronise_page_widgets(page_params.to_h)
         redirect_to wizard_path(save_step_name, site_page_id: @page.id), notice: 'Page successfully ' + notice_text
       else
         render_wizard

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -66,7 +66,26 @@ class Page < ApplicationRecord
     return false
   end
 
+  def synchronise_page_widgets(page_params_hash)
+    return unless page_params_hash.key?('content')
+    content_after = JSON.parse(page_params_hash['content']['json'])
+    widget_ids_after = get_widget_ids_from_object(content_after).flatten.compact
+    current_widget_ids = page_widgets.pluck(:widget_id)
+    removed_widget_ids = current_widget_ids.select{ |id| !widget_ids_after.include?(id) }
+    PageWidget.delete(removed_widget_ids) unless removed_widget_ids.empty?
+    added_widget_ids = widget_ids_after.select{ |id| !current_widget_ids.include?(id) }
+    added_widget_ids.each{ |id| PageWidget.create(page_id: self.id, widget_id: id)}
+  end
+
   private
+
+  def get_widget_ids_from_object(object)
+    if object.respond_to?(:key?) && object.key?('widget')
+      object['widget']['id']
+    elsif object.respond_to?(:each)
+      object.map { |o| get_widget_ids_from_object(o) }
+    end
+  end
 
   def regenerate_url
     uri = self.uri || ''

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,6 +23,8 @@ class Page < ApplicationRecord
   extend EnumerateIt
 
   has_and_belongs_to_many :site_templates
+  has_many :page_widgets
+  has_many :widgets, through: :page_widgets, validate: false
 
   has_closure_tree order: 'position', dependent: :destroy
   has_enumeration_for :content_type, with: ContentType, skip_validation: true

--- a/app/models/page_widget.rb
+++ b/app/models/page_widget.rb
@@ -1,0 +1,4 @@
+class PageWidget < ActiveRecord::Base
+  belongs_to :page
+  belongs_to :widget
+end

--- a/db/migrate/20170221115248_create_page_widgets.rb
+++ b/db/migrate/20170221115248_create_page_widgets.rb
@@ -1,0 +1,8 @@
+class CreatePageWidgets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :page_widgets do |t|
+      t.references :page, foreign_key: true
+      t.references :widget, foreign_key: true, index: true
+    end
+  end
+end

--- a/db/migrate/20170222085045_synchronise_page_widgets.rb
+++ b/db/migrate/20170222085045_synchronise_page_widgets.rb
@@ -1,0 +1,13 @@
+class SynchronisePageWidgets < ActiveRecord::Migration[5.0]
+  def change
+    # For evety existing page, store its links to widgets
+    # by parsing the content
+    pages_with_widgets = Page.
+      where(content_type: ContentType::OPEN_CONTENT).
+      where('content IS NOT NULL')
+    pages_with_widgets.each do |page|
+      content = JSON.parse(page.content['json'])
+      page.synchronise_page_widgets(content)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,6 +77,13 @@ ActiveRecord::Schema.define(version: 20170222110701) do
     t.index ["descendant_id"], name: "page_desc_idx", using: :btree
   end
 
+  create_table "page_widgets", force: :cascade do |t|
+    t.integer "page_id"
+    t.integer "widget_id"
+    t.index ["page_id"], name: "index_page_widgets_on_page_id", using: :btree
+    t.index ["widget_id"], name: "index_page_widgets_on_widget_id", using: :btree
+  end
+
   create_table "pages", force: :cascade do |t|
     t.integer  "site_id"
     t.string   "name"
@@ -190,4 +197,6 @@ ActiveRecord::Schema.define(version: 20170222110701) do
     t.string   "description"
   end
 
+  add_foreign_key "page_widgets", "pages"
+  add_foreign_key "page_widgets", "widgets"
 end


### PR DESCRIPTION
Adds a new table, `page_widgets`, which facilitates the n:n relation between pages and widgets. According to my understanding, widgets can only be inserted into open content pages (?), and when such a page is saved the content is parsed for widget ids, which are then updated in the linking table. There's also a migration to do the same for all pre-existing pages. The page-widget links will later be used to prevent deleting widgets which are used in pages, but I would like to get the saving part in place first.