### PR TITLE
removes the veil from the lanscape theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add links to share on Facebook, Twitter and G+ on page footers
 - Add color highlight to 3rd level menu when element is selected
 - Add attribution label + link to cover images.
+- Update styling for Landscape applications
 
 ### 21 Feb 2017
 - Added possibility to change the homepage's name

--- a/app/assets/stylesheets/components/front/c-cover.scss
+++ b/app/assets/stylesheets/components/front/c-cover.scss
@@ -39,7 +39,7 @@
     @if $theme == 2 {
       background-color: rgba($color-5, .3);
     } @else {
-      background-color: rgba($color-1, .4);
+      background-color: transparent;
     }
   }
 

--- a/app/assets/stylesheets/components/front/c-cover.scss
+++ b/app/assets/stylesheets/components/front/c-cover.scss
@@ -35,13 +35,8 @@
     width: 100%;
     height: 100%;
     content: '';
+    background-color: rgba($color-5, .3);
 
-    @if $theme == 2 {
-      background-color: rgba($color-5, .3);
-    } @else {
-      background-color: transparent;
-    }
-  }
 
   > .wrapper {
     z-index: 1;


### PR DESCRIPTION
This PR removes the veil from the landscape theme.  I'm not sure this is whats asked for because this was expected behaviour, not a bug.

- [ ]  Colored bar covers cover image in landscape theme