### PR TITLE
Feature/manager can add user to site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Made the graphs translatable (possibility to translate the titles of the axes for example)
 - Added the possibility to update the position and type of the dashboard's widgets
 - Added the new dashboard layout
+- Manager can add user to site
 
 ### 14 Mar 2017
 - Improve support for ArcGIS services

--- a/app/controllers/management/users_controller.rb
+++ b/app/controllers/management/users_controller.rb
@@ -1,0 +1,64 @@
+class Management::UsersController < ManagementController
+  before_filter :load_site
+
+  def new
+    @user = User.new
+    @user.user_site_associations.build(site: @site)
+  end
+
+  def create
+    email = user_params[:email]
+    role = user_params.delete(:site_role)
+    @user = User.find_by_email(email) if email.present?
+    if @user
+      grant_access(role)
+    else
+      create_and_grant_access(role)
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(
+      :name,
+      :email,
+      :site_role
+    )
+  end
+
+  def load_site
+    @site = Site.find_by(slug: params[:site_slug])
+  end
+
+  def grant_access(role)
+    usa = @user.user_site_associations.find_by_site_id(@site.id)
+    if usa
+      usa.role = role unless usa.role == UserType::MANAGER
+    else
+      @user.user_site_associations.build(site: @site, role: role)
+    end
+    if @user.save
+      redirect_to management_site_site_pages_url, notice: 'User granted access successfully'
+    else
+      render :new
+    end
+  end
+
+  def create_and_grant_access(role)
+    @user = User.new(user_params)
+    @user.user_site_associations.build(site: @site, role: role)
+    if @user.valid?
+      api_response = @user.send_to_api(session[:user_token], management_url)
+      if api_response[:valid]
+        @user.save
+        redirect_to management_site_site_pages_url, notice: 'User created successfully'
+      else
+        @user.errors['id'] << 'API error: ' + api_response[:error].to_s
+        render :new
+      end
+    else
+      render :new
+    end
+  end
+end

--- a/app/views/management/_extended_header.html.erb
+++ b/app/views/management/_extended_header.html.erb
@@ -10,6 +10,7 @@
         <% else %>
             <li><%= link_to 'New page', new_management_site_page_step_path, class: 'c-button -outline' %></li>
          <% end %>
+         <li><%= link_to 'New user', new_management_site_user_path(@site.slug), class: 'c-button -outline' %></li>
           <% if @url.present? %><li><a href="<%= @url %>" class="c-button">Go to site</a></li><% end %>
         </ul>
       </div>

--- a/app/views/management/users/new.html.erb
+++ b/app/views/management/users/new.html.erb
@@ -1,0 +1,39 @@
+<% content_for :extended_header do %>
+  <div class="c-extended-header">
+    <div class="wrapper">
+      <div class="description">
+        <h1>New user</h1>
+        <p>Provide user details to give them access to site</p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= form_for @user, url: management_site_users_path(@site.slug), method: :post do |f| %>
+  <div class="l-widget-creation -title">
+    <div class="wrapper">
+      <div class="c-inputs-container">
+        <div class="container -big">
+          <%= f.label :name, for: 'name' %>
+          <%= f.text_field :name, id:'name', placeholder: 'John Smith' %>
+        </div>
+        <div class="container">
+          <%= f.label :email, for: 'email' %>
+          <%= f.email_field :email, id:'email', placeholder: 'john.smith@gmail.com' %>
+        </div>
+        <div class="container -big">
+          <%= f.fields_for :user_site_associations, @user.user_site_associations do |ff| %>
+            <div class="c-radio">
+              <%= ff.radio_button :role, UserType::MANAGER %>
+              <%= ff.label :role, 'Manager', value:  UserType::MANAGER %>
+              <%= ff.radio_button :role, UserType::PUBLISHER %>
+              <%= ff.label :role, 'Publisher', value:  UserType::PUBLISHER %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <%= render partial: 'management/steps_shared/footer', locals: { f: f, cancel: management_site_site_pages_path(@site.slug), no_continue: true, always_save: true } %>
+<% end %>
+<%= render partial: 'shared/errors', locals: { resource: @user } %>

--- a/app/views/management/users/new.html.erb
+++ b/app/views/management/users/new.html.erb
@@ -22,14 +22,12 @@
           <%= f.email_field :email, id:'email', placeholder: 'john.smith@gmail.com' %>
         </div>
         <div class="container -big">
-          <%= f.fields_for :user_site_associations, @user.user_site_associations do |ff| %>
-            <div class="c-radio">
-              <%= ff.radio_button :role, UserType::MANAGER %>
-              <%= ff.label :role, 'Manager', value:  UserType::MANAGER %>
-              <%= ff.radio_button :role, UserType::PUBLISHER %>
-              <%= ff.label :role, 'Publisher', value:  UserType::PUBLISHER %>
-            </div>
-          <% end %>
+          <div class="c-radio">
+            <%= f.radio_button :site_role, UserType::MANAGER, checked: @usa.role == UserType::MANAGER %>
+            <%= f.label :site_role, 'Manager', value:  UserType::MANAGER %>
+            <%= f.radio_button :site_role, UserType::PUBLISHER, checked: @usa.role == UserType::PUBLISHER %>
+            <%= f.label :site_role, 'Publisher', value:  UserType::PUBLISHER %>
+          </div>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
               constraints: lambda { |req| req.format == :json }
         end
       end
+      resources :users, only: [:new, :create]
       get '/structure', to: 'sites#structure'
       put :update_structure
 


### PR DESCRIPTION
Allows a manager to create a new non-admin user in context of given site. If user specified by email already exists, they are granted rights to the site.