### PR TITLE
Feat/site context tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 28 Mar 2017
 - Changes styles of cover attribution links.
+- Added a context tab to the site management page.
 
 ### 21 Mar 2017
 - Added a default placeholder graph to the dashboard (used when the dataset is empty)

--- a/app/assets/javascripts/dispatchers/managementDispatcher.js
+++ b/app/assets/javascripts/dispatchers/managementDispatcher.js
@@ -12,6 +12,7 @@
       'management/sites/:slug/structure(/)': 'Structure',
       'management/sites/:slug/widgets(/)': 'Widgets',
       'management/sites/:slug/datasets(/)': 'Datasets',
+      'management/sites/:slug/contexts(/)': 'Contexts',
       'management/sites/:slug/(datasets/:id/)dataset_steps/title': 'Index',
       'management/sites/:slug/(datasets/:id/)dataset_steps/connector': 'ConnectorStep',
       'management/sites/:slug/(datasets/:id/)dataset_steps/labels': 'Index',

--- a/app/assets/javascripts/routers/management/ContextsRouter.js
+++ b/app/assets/javascripts/routers/management/ContextsRouter.js
@@ -82,7 +82,7 @@
             { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
             { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
             { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
-            { name: 'Contexts', url: '/management/sites' + this.slug + '/contexts' }
+            { name: 'Contexts', url: '/management/sites/' + this.slug + '/contexts' }
           ]
         });
       }

--- a/app/assets/javascripts/routers/management/ContextsRouter.js
+++ b/app/assets/javascripts/routers/management/ContextsRouter.js
@@ -59,11 +59,34 @@
   });
 
   App.Router.ManagementContexts = Backbone.Router.extend({
+
     routes: {
       '(/)': 'index'
     },
 
+    initialize: function (params) {
+      this.slug = params[0] || null;
+    },
+
     index: function () {
+      var tabsContainer = $('.js-tabs');
+
+      if(tabsContainer.length){
+        // We initialize the tabs
+        new App.View.TabView({
+          el: tabsContainer,
+          redirect: true,
+          currentTab: 4,
+          tabs: [
+            { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
+            { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
+            { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
+            { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
+            { name: 'Contexts', url: '/management/sites' + this.slug + '/contexts' }
+          ]
+        });
+      }
+
       var tableCollection = new TableCollection(gon.contexts, { parse: true });
       var tableContainer = document.querySelector('.js-table');
 

--- a/app/assets/javascripts/routers/management/DatasetsRouter.js
+++ b/app/assets/javascripts/routers/management/DatasetsRouter.js
@@ -99,7 +99,8 @@
           { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
           { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
           { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
-          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
+          { name: 'Contexts', url: '/management/sites' + this.slug + '/contexts' }
         ]
       });
 

--- a/app/assets/javascripts/routers/management/DatasetsRouter.js
+++ b/app/assets/javascripts/routers/management/DatasetsRouter.js
@@ -100,7 +100,7 @@
           { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
           { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
           { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
-          { name: 'Contexts', url: '/management/sites' + this.slug + '/contexts' }
+          { name: 'Contexts', url: '/management/sites/' + this.slug + '/contexts' }
         ]
       });
 

--- a/app/assets/javascripts/routers/management/PagesRouter.js
+++ b/app/assets/javascripts/routers/management/PagesRouter.js
@@ -78,7 +78,8 @@
           { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
           { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
           { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
-          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
+          { name: 'Contexts', url: '/management/sites/' + this.slug + '/contexts' }
         ]
       });
 

--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -21,7 +21,8 @@
           { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
           { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
           { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
-          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
+          { name: 'Contexts', url: '/management/sites/' + this.slug + '/contexts' }
         ]
       });
 

--- a/app/assets/javascripts/routers/management/WidgetsRouter.js
+++ b/app/assets/javascripts/routers/management/WidgetsRouter.js
@@ -92,7 +92,8 @@
           { name: 'Site\'s structure', url: '/management/sites/' + this.slug + '/structure' },
           { name: 'Pages', url: '/management/sites/' + this.slug + '/site_pages' },
           { name: 'Datasets', url: '/management/sites/' + this.slug + '/datasets' },
-          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' }
+          { name: 'Widgets', url: '/management/sites/' + this.slug + '/widgets' },
+          { name: 'Contexts', url: '/management/sites/' + this.slug + '/contexts' }
         ]
       });
 

--- a/app/controllers/context_steps_controller.rb
+++ b/app/controllers/context_steps_controller.rb
@@ -166,11 +166,11 @@ class ContextStepsController < ManagementController
 
   # Created a list of users that are not admins
   def permitted_owners
-    @permitted_owners = User.where(role: [UserType::MANAGER, UserType::PUBLISHER])
+    @permitted_owners = User.where(admin: false)
   end
 
   def permitted_writers
-    permitted_users = User.where(role: [UserType::MANAGER, UserType::PUBLISHER])
+    permitted_users = User.where(admin: false)
     @permitted_writers = permitted_users.to_a.delete_if{|user| @context.owners.include?(user)}
   end
 

--- a/app/controllers/management/contexts_controller.rb
+++ b/app/controllers/management/contexts_controller.rb
@@ -1,3 +1,63 @@
-class ContextsController < ManagementController
+class Management::ContextsController < ManagementController
+  before_action :ensure_management_user, only: :destroy
+  before_action :set_site, only: [:index, :new, :create]
+  before_action :get_contexts, only: :index
+  before_action :set_dataset, only: [:edit, :destroy]
 
+  # Validate if user can modify the dataset
+  before_action :authenticate_user_for_site!
+
+  def index
+    gon.contexts = @gon_contexts
+  end
+
+  def destroy
+    context = Context.find(params[:id])
+    context.destroy
+    redirect_to controller: 'management/contexts', action: 'index', site_slug: @site.slug, notice: 'Context successfully removed.'
+  end
+
+  private
+  # Use callbacks to share common setup or constraints between actions.
+  def set_site
+    @site = Site.find_by({slug: params[:site_slug]})
+
+    if (@site.routes.any?)
+      # We just want a valid URL for the site
+      @url = @site.routes.first.host
+    end
+  end
+
+  def context_param
+    params.require(:context).permit(:id)
+  end
+
+  def get_contexts
+    # TODO: This would be better if fetched + filtered in the database.
+    @contexts = current_user.get_contexts(true).select { |context| context.sites.include?(@site) }
+    @gon_contexts = []
+
+    @contexts.map do |context|
+      delete_link = context.owners.include?(current_user) || current_user.admin ? \
+            context_path(context.id) : nil
+      edit_link = context.owners.include?(current_user) || current_user.admin ? \
+            edit_context_context_step_path(id: 'title', context_id: context.id) : nil
+      datasets_api = DatasetService.get_metadata_list context.context_datasets.map{|cd| cd.dataset_id}
+      datasets = datasets_api['data'].map{|d| d.dig('attributes', 'name')} \
+          unless datasets_api.blank? || datasets_api['data'].blank?
+
+      gon_context = {
+        'name' => {'value' => context.name, 'searchable' => true, 'sortable' => true},
+        'sites' => {'value' => context.sites.map{|s| s.name}, 'searchable' => true, 'sortable' => true},
+        'datasets' => {'value' => datasets, 'searchable' => true, 'sortable' => true},
+        'owners' =>  {'value' => context.owners.map{|o| o.name}, 'searchable' => true, 'sortable' => true},
+        'writers' => {'value' => context.writers.map{|w| w.name}, 'searchable' => true, 'sortable' => true},
+        'edit' => {'value' => edit_link, 'method' => 'get'},
+        'delete' => {'value' => delete_link, 'method' => 'delete'}
+      }
+
+      @gon_contexts << gon_context
+    end
+
+  end
 end

--- a/app/views/management/contexts/index.html.erb
+++ b/app/views/management/contexts/index.html.erb
@@ -1,0 +1,18 @@
+<%= render partial: 'management/extended_header', locals: {type: 'dataset'} %>
+<%= include_gon %>
+
+<div class="js-tabs"></div>
+
+<div class="l-contexts-list">
+  <div class="wrapper">
+    <div class="c-action-toolbar">
+      <ul class="buttons">
+      </ul>
+      <ul class="filters">
+        <li><div class="c-input-search js-table-search"></div></li>
+      </ul>
+    </div>
+
+    <div class="js-table"></div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,10 @@ Rails.application.routes.draw do
       end
       get '/structure', to: 'sites#structure'
       put :update_structure
+
+      resources :contexts, only: [:index, :destroy] do
+        resources :context_steps, only: [:edit, :show, :update]
+      end
     end
     get '/', to: 'static_page#dashboard'
   end


### PR DESCRIPTION
This PR includes:
- New Management/Contexts Controller. [Rails]
- New Management/Contexts view. [Rails]
- Adds contexts tab to the management_site screens. [JS]
- Adds support for tabs inside management contexts router. [JS]

Contexts filtering is currently done in the following way: 
> Fetch all user's contexts, filter all contexts that don't contain the current site. It might be interesting to filter them with a where clause instead.
