### PR TITLE
Fix: cover attribution styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+### 28 Mar 2017
+- Changes styles of cover attribution links.
+
+### 21 Mar 2017
 - Added a default placeholder graph to the dashboard (used when the dataset is empty)
 - Made the graphs translatable (possibility to translate the titles of the axes for example)
 - Added the possibility to update the position and type of the dashboard's widgets
 - Added the new dashboard layout
 
-### 7 Mar 2017
+### 14 Mar 2017
 - Improve support for ArcGIS services
 - Update header text style
 

--- a/app/assets/stylesheets/components/front/c-cover.scss
+++ b/app/assets/stylesheets/components/front/c-cover.scss
@@ -99,9 +99,15 @@
 
     > a {
       background-color: unset;
+      color: $color-3;
+      text-decoration: none;
 
       &:hover {
         text-decoration: underline;
+      }
+
+      &::selection {
+        background-color: unset;
       }
     }
 


### PR DESCRIPTION
This PR changes color and decoration of cover-attribution links.
```
color: white;
text-decoration: none (underlined on hover);
background-color: none

```