### PR TITLE
Updated Terms of Service page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 - Added debugging to custom router to identify potential issue when rebuilding
+- Terms of Service page update
 
 ### 29 Mar 2017
 - Add validation of template selection to site creation
 - Improve site settings update
 - Auto generate assets on deployment
+
+### 27 Mar 2017
 - API upgrade
 - Allow to pass data path to API for nested JSON documents
 - Fixed some issues when creating ArcGIS datasets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+### 4 April 2017
 - Added debugging to custom router to identify potential issue when rebuilding
 - Terms of Service page update
 
@@ -5,8 +6,6 @@
 - Add validation of template selection to site creation
 - Improve site settings update
 - Auto generate assets on deployment
-
-### 27 Mar 2017
 - API upgrade
 - Allow to pass data path to API for nested JSON documents
 - Fixed some issues when creating ArcGIS datasets

--- a/app/models/page_template.rb
+++ b/app/models/page_template.rb
@@ -21,4 +21,22 @@
 
 class PageTemplate < Page
   has_many :page_site_templates, foreign_key: 'page_id',  dependent: :destroy
+  TERMS_OF_SERVICE_SLUG = 'terms-and-privacy'
+
+  def render_terms_of_service_template(site)
+    template = File.read('lib/assets/terms_template.json.erb')
+    hosting_organization = SiteSetting.hosting_organization(site.id).value ||
+      '[HOSTING ORGANIZATION]'
+    result = TemplateRenderer.render(
+      template,
+      {hosting_organization: hosting_organization}
+    )
+    {json: result}
+  end
+
+  private
+
+  def self.terms_of_service_template
+    template = File.read('lib/assets/terms_template.json.erb')
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -194,7 +194,7 @@ class Site < ApplicationRecord
   end
 
   # triggered when hosting organization changed
-  def update_terms_of_service_page(page_template)
+  def update_terms_of_service_page(page_template=nil)
     page_template ||= PageTemplate.find_by_uri(PageTemplate::TERMS_OF_SERVICE_SLUG)
     return false unless page_template.present?
     site_pages.where(uri: PageTemplate::TERMS_OF_SERVICE_SLUG).update_all(

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -193,6 +193,15 @@ class Site < ApplicationRecord
     end
   end
 
+  # triggered when hosting organization changed
+  def update_terms_of_service_page(page_template)
+    page_template ||= PageTemplate.find_by_uri(PageTemplate::TERMS_OF_SERVICE_SLUG)
+    return false unless page_template.present?
+    site_pages.where(uri: PageTemplate::TERMS_OF_SERVICE_SLUG).update_all(
+      content: page_template.render_terms_of_service_template(self)
+    )
+  end
+
   private
 
   def generate_slug

--- a/app/models/template_renderer.rb
+++ b/app/models/template_renderer.rb
@@ -1,0 +1,13 @@
+require 'erb'
+
+class TemplateRenderer
+  def self.empty_binding
+    binding
+  end
+
+  def self.render(template_content, locals = {})
+    b = empty_binding
+    locals.each { |k, v| b.local_variable_set(k, v) }
+    ERB.new(template_content).result(b)
+  end
+end

--- a/app/services/site_creator.rb
+++ b/app/services/site_creator.rb
@@ -13,11 +13,17 @@ class SiteCreator
     @new_page_tree = {}
 
     pages.each do |page|
+      content = if page.uri == PageTemplate::TERMS_OF_SERVICE_SLUG
+        page.render_terms_of_service_template(site)
+      else
+        page.content
+      end
+
       newPage = SitePage.create!(
         {
           name: page.name,
           description: page.description,
-          content: page.content,
+          content: content,
           uri: page.uri,
           site: site,
           show_on_menu: page.show_on_menu,

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -87,6 +87,15 @@
                     <%= settings_form.text_field :value, id: 'contact_email_address' %>
                   </div>
 
+              <% when 'hosting_organization' %>
+                  <%= settings_form.hidden_field :position, value: '14' %>
+                  <%= settings_form.hidden_field :name, value: 'hosting_organization' %>
+
+                  <div class="container -big">
+                    <%= settings_form.label 'Hosting organization', for: 'hosting_organization' %>
+                    <%= settings_form.text_field :value, id: 'hosting_organization' %>
+                  </div>
+
               <% end %>
           <% end %>
         </div>

--- a/app/views/front/_footer.html.erb
+++ b/app/views/front/_footer.html.erb
@@ -9,7 +9,7 @@
 <footer class="c-footer">
   <div class="wrapper">
     <ul class="site-links-list">
-      <li class="site-link-item"><%= link_to 'Terms of Service', '/terms-and-privacy', class: 'site-link' %></li>
+      <li class="site-link-item"><%= link_to 'Terms of Service', "/#{PageTemplate::TERMS_OF_SERVICE_SLUG}", class: 'site-link' %></li>
       <% unless @site_page.site.site_settings.contact_email_address(@site_page.site_id).value.empty? -%>
         <li class="separator"> |</li>
         <li class="site-link-item"><%= link_to 'Contact us', 'mailto:' + @site_page.site.site_settings.contact_email_address(@site_page.site_id).value, class: 'site-link' %></li>

--- a/db/migrate/20170324120306_update_terms_page_template.rb
+++ b/db/migrate/20170324120306_update_terms_page_template.rb
@@ -1,0 +1,14 @@
+class UpdateTermsPageTemplate < ActiveRecord::Migration[5.0]
+  def up
+    template = File.read('lib/assets/terms_template.json')
+    terms_templates = PageTemplate.where(uri: 'terms-and-privacy').each do |pt|
+       pt.content = {json: template}
+       pt.name = 'Terms of Service'
+       pt.save!
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/migrate/20170324120306_update_terms_page_template.rb
+++ b/db/migrate/20170324120306_update_terms_page_template.rb
@@ -1,7 +1,7 @@
 class UpdateTermsPageTemplate < ActiveRecord::Migration[5.0]
   def up
     template = File.read('lib/assets/terms_template.json')
-    terms_templates = PageTemplate.where(uri: 'terms-and-privacy').each do |pt|
+    terms_templates = Page.where(uri: 'terms-and-privacy').each do |pt|
        pt.content = {json: template}
        pt.name = 'Terms of Service'
        pt.save!

--- a/db/migrate/20170324120306_update_terms_page_template.rb
+++ b/db/migrate/20170324120306_update_terms_page_template.rb
@@ -1,10 +1,15 @@
 class UpdateTermsPageTemplate < ActiveRecord::Migration[5.0]
   def up
-    template = File.read('lib/assets/terms_template.json')
-    terms_templates = Page.where(uri: 'terms-and-privacy').each do |pt|
-       pt.content = {json: template}
-       pt.name = 'Terms of Service'
-       pt.save!
+    page_template = PageTemplate.where(uri: PageTemplate::TERMS_OF_SERVICE_SLUG).first
+    return unless page_template.present?
+    page_template.content = nil
+    page_template.name = 'Terms of Service'
+    page_template.save!
+    Site.all.each do |site|
+      unless site.site_settings.exists?(name: 'hosting_organization')
+        site.site_settings.create!(name: 'hosting_organization', value: nil, position: 14)
+      end
+      site.update_terms_of_service_page(page_template)
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170313110401) do
+ActiveRecord::Schema.define(version: 20170324120306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/assets/terms_template.json
+++ b/lib/assets/terms_template.json
@@ -1,0 +1,106 @@
+{
+  "ops": [
+    {"insert": "The World Resources Institute (WRI) and their suppliers (together sometimes referred to as \"We\" or \"Us\") make this website and the contents you and/or your company or organization (sometimes referred to as \"You\" or \"Your\") may access through it (the \"Site\") available to You under these Terms of Service (\"Terms\").\n"},
+
+    {"insert": "By using this Site, you agree to these Terms.\n"},
+
+    {"insert": "1. Using the website\n"},
+
+    {
+      "insert": "a. We provide You with access to the Site and its content in order to strengthen forest management and land use planning as well as to provide unbiased up-to-date information on the status of the [PROJECT AREA]’s forests. Your use of the Site does not give You any ownership rights in the intellectual property of the Site or in its contents. You agree to use the Site and its contents only for lawful purposes and not to defame, harass or threaten any one or to make available any obscene, pornographic or offensive material. You agree that in using the Site You will not damage or impair the Site or anyone else's use of the Site.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "b. Except for items that are identified as being subject to additional restrictions, You may use the Site and its content, and copy, adapt and distribute the content to others under this license [LINK to default license – CC by 4.0 for FA, CC BY-NC-SA 4.0 for landscapes].\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "c. You are solely responsible for Your use of the Site and all activity that occurs under Your account. You agree to indemnify, hold harmless and, at our request, defend Us and our related persons from all liability arising from Your use of the Site, Your User Content (as defined below), or Your violation of these Terms. We may suspend access to the Site if We suspect You or those using Your account are violating these Terms.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "d. You can stop using the Site and its contents at any time, and We can cease providing the Site and its contents at any time.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "e. We may change these Terms from time to time to reflect changes in the law and Site. You should review these Terms regularly for any changes. If You don't agree with a change in the Terms, You should stop accessing and using the Site.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {"insert": "2. Third Party Terms\n"},
+
+    {"insert": "The Site incorporates data and information from others partners. While we may review any content, and remove it if we believe it violates the law, these Terms or our policies, We do not commit to review all content, and You should not rely on Us to do so.\n"},
+
+    {"insert": "3. Disclaimers and Limitations\n"},
+
+    {
+      "insert": "a. YOU AGREE THAT YOUR USE OF THE SITE AND ITS CONTENT IS AT YOUR SOLE RISK. WE MAKE NO PROMISES OR COMMITMENTS ABOUT THE SITE OR ITS CONTENT, AND THE\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "SITE AND CONTENT ARE PROVIDED ON AN “AS IS” BASIS AND WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED. TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, STATUTORY, EXPRESS OR IMPLIED, INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "b. UNDER NO CIRCUMSTANCES WILL WE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES (INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS, DATA, OR USE OR COST OF COVER) RESULTING FROM YOUR USE OR THE INABILITY TO USE THE SITE OR ITS CONTENTS, EVEN IF WE WERE AWARE OF THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU FOR ALL CLAIMS OR DAMAGES FOR ANY REASON IN EXCESS OF ONE HUNDRED DOLLARS ($100 USD). CERTAIN JURISDICTIONS DO NOT ALLOW EXCLUSIONS OR LIMITATIONS ON IMPLIED WARRANTIES OR LIMITATIONS ON LIABILITY, AND THEREFORE SOME OR ALL OF THE DISCLAIMERS, EXCLUSIONS, OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU MAY HAVE ADDITIONAL RIGHTS.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {"insert": "4. Copyright Protection\n"},
+
+    {"insert": "If You are a copyright owner or an agent thereof, and believe that any content on the Site infringes Your copyrights, You may send a notice in writing to World Resources Institute Tel: + 1 (202) 729-7600 E-mail: [WEBSITE EMAIL] with the following information:\n"},
+
+    {
+      "insert": "a. Your signature as a person authorized to act on behalf of the owner of an exclusive right that is allegedly infringed;\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "b. Identification of the exact location on the Site of copyrighted work claimed to have been infringed, or, if multiple copyrighted works on the Site are covered by a single notification, a representative list of such works as located on the Site;\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "c. The address, telephone number, and e-mail address of the complaining party;\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "d. A statement that the complaining party has a good faith belief that use of the material in the manner complained of is not authorized by the copyright owner, its agent, or the law; and\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "e. A statement that the information in the notification is accurate, and under penalty of perjury, that the complaining party is authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {"insert": "5. Additional Terms\n"},
+
+    {
+      "insert": "a. If we do not promptly enforce the Terms, We have not given up any other rights or the right to enforce them or other Terms in the future.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "b. If any particular provision of these Terms is not enforceable, that doesn't affect the enforceability of any other provision of the Terms.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "c. These Terms are between You and Us, and no one else can enforce them.\n",
+      "attributes": {"indent": "+1"}
+    },
+
+    {
+      "insert": "d. These Terms are the entire statement of the agreement between You and Us regarding the Site and its contents.\n",
+      "attributes": {"indent": "+1"}
+    }
+  ]
+}

--- a/lib/assets/terms_template.json.erb
+++ b/lib/assets/terms_template.json.erb
@@ -1,6 +1,6 @@
 {
   "ops": [
-    {"insert": "The World Resources Institute (WRI) and their suppliers (together sometimes referred to as \"We\" or \"Us\") make this website and the contents you and/or your company or organization (sometimes referred to as \"You\" or \"Your\") may access through it (the \"Site\") available to You under these Terms of Service (\"Terms\").\n"},
+    {"insert": "The <%= hosting_organization.present? ? "#{hosting_organization}, the " : '' %>World Resources Institute (WRI) and their suppliers (together sometimes referred to as \"We\" or \"Us\") make this website and the contents you and/or your company or organization (sometimes referred to as \"You\" or \"Your\") may access through it (the \"Site\") available to You under these Terms of Service (\"Terms\").\n"},
 
     {"insert": "By using this Site, you agree to these Terms.\n"},
 

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -21,17 +21,17 @@ def create_pages_templates
       site_templates: [@fa_template, @la_template]
     }
   )
-  tpl = File.read('lib/assets/terms_template.json')
+
   PageTemplate.create!(
     {
       name: 'Terms and privacy',
       description: 'Terms and privacy',
-      uri: 'terms-and-privacy',
+      uri: PageTemplate::TERMS_OF_SERVICE_SLUG,
       parent: home,
       show_on_menu: false,
       content_type: ContentType::STATIC_CONTENT,
       site_templates: [@fa_template, @la_template],
-      content: {json: tpl}
+      content: nil # content rendered from .erb template upon site creation
     }
   )
   puts 'Template pages created successfully'

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -21,6 +21,7 @@ def create_pages_templates
       site_templates: [@fa_template, @la_template]
     }
   )
+  tpl = File.read('lib/assets/terms_template.json')
   PageTemplate.create!(
     {
       name: 'Terms and privacy',
@@ -30,7 +31,7 @@ def create_pages_templates
       show_on_menu: false,
       content_type: ContentType::STATIC_CONTENT,
       site_templates: [@fa_template, @la_template],
-      content: {json: '{"ops":[{"insert":"Terms and privacy"}]}'}
+      content: {json: tpl}
     }
   )
   puts 'Template pages created successfully'

--- a/lib/tasks/update_site_settings.rake
+++ b/lib/tasks/update_site_settings.rake
@@ -63,6 +63,10 @@ namespace :db do
               site.site_settings.create!(name: 'contact_email_address', value: '', position: 13)
               puts '...... Added contact_email_address'
             end
+            unless site.site_settings.exists?(name: 'hosting_organization')
+              site.site_settings.create!(name: 'hosting_organization', value: '', position: 14)
+              puts '...... Added hosting_organization'
+            end
             puts "... Finished creation for site #{site.name}"
             puts ''
           end


### PR DESCRIPTION
- Template for "Terms of Service" page is store in a .json.erb file, to facilitate injecting the hosting organization variable
- A new site setting has been added to store the hosting organization
- Logic in place to rebuild the "Terms of Service" page when the hosting organization is updated
- `rake db:migrate` to update existing sites