### PR TITLE
fixes reading of gon widgets

### DIFF
--- a/app/assets/javascripts/blots/widgetBlock.es6
+++ b/app/assets/javascripts/blots/widgetBlock.es6
@@ -97,7 +97,7 @@ class WidgetBlot extends Embed {
     this.widget = new App.View.ChartWidgetView({
       el: this.domNode.querySelector('.js-widget-container'),
       data: chart.data,
-      chart: config.type,
+      chart: config.chart,
       columnX: config.x,
       columnY: config.y,
       enableChartSelector: false

--- a/app/assets/javascripts/blots/widgetBlock.js
+++ b/app/assets/javascripts/blots/widgetBlock.js
@@ -113,7 +113,7 @@ var WidgetBlot = function (_Embed) {
         config = JSON.parse(chart.visualization);
       } catch (e) {
         config = {
-          type: null,
+          chart: null,
           x: null,
           y: null
         };
@@ -123,7 +123,7 @@ var WidgetBlot = function (_Embed) {
       this.widget = new App.View.ChartWidgetView({
         el: this.domNode.querySelector('.js-widget-container'),
         data: chart.data,
-        chart: config.type,
+        chart: config.chart,
         columnX: config.x,
         columnY: config.y,
         enableChartSelector: false

--- a/app/assets/javascripts/routers/management/OpenContentStepRouter.js
+++ b/app/assets/javascripts/routers/management/OpenContentStepRouter.js
@@ -9,6 +9,17 @@
 
     initialize: function (params) {
       this.slug = params[0] || null;
+
+      if (gon && gon.widgets) {
+        this.widgets = gon.widgets.map(function (chart) {
+          var vis = JSON.parse(chart.visualization);
+          if (vis.type !== 'chart') {
+            vis = Object.assign({}, vis, { type: 'chart', chart: vis.type});
+          }
+          chart.visualization =  JSON.stringify(vis);
+          return chart;
+        });
+      }
     },
 
     index: function () {
@@ -18,7 +29,7 @@
       this.wysiwygView = new App.View.WysiwygView({
         el: '.js-content',
         serializedContent: serializedContent.length ? JSON.parse(serializedContent) : null,
-        widgets: window.gon && gon.widgets
+        widgets: this.widgets
       });
 
       $('.js-form').on('submit', function () {

--- a/app/assets/javascripts/routers/management/VisualizationStepRouter.js
+++ b/app/assets/javascripts/routers/management/VisualizationStepRouter.js
@@ -67,7 +67,15 @@
      */
     _getChart: function () {
       try {
-        return (window.gon && gon.visualization && JSON.parse(gon.visualization)) || {};
+        var parsedChart = {};
+        if (window.gon && gon.visualization) {
+          parsedChart = JSON.parse(gon.visualization);
+          if (parsedChart.type !== 'chart') {
+            var chart = Object.assign({}, parsedChart, { type: 'chart', chart: parsedChart.type});
+            return chart
+          }
+        }
+        return parsedChart;
       } catch (e) {
         return {};
       }

--- a/app/assets/javascripts/routers/management/VisualizationStepRouter.js
+++ b/app/assets/javascripts/routers/management/VisualizationStepRouter.js
@@ -83,7 +83,7 @@
       this.chart = new App.View.ChartWidgetView({
         el: document.querySelector('.js-chart'),
         data: dataset,
-        chart: chart.type || null,
+        chart: chart.chart || null,
         columnX: chart.x || null,
         columnY: chart.y || null
       });

--- a/app/assets/javascripts/views/management/widgetsModalView.js
+++ b/app/assets/javascripts/views/management/widgetsModalView.js
@@ -153,7 +153,7 @@
               id: widget.id,
               name: widget.name,
               description: widget.description,
-              type: JSON.parse(widget.visualization).type
+              type: JSON.parse(widget.visualization).chart
             };
           } catch (e) {
             return null;


### PR DESCRIPTION
This PR fixes issue where creating charts from _gon_ stored data crashed. 
This was due to a schema change in the widget object. Before all widgets where charts and a widget's type was a chart's type. Now there's also map widgets and so the chart's type is no longer stored at `widget.type` but in `widget.chart` instead. This PR fixes that and also adds compatibility for legacy widget charts.