### PR TITLE
Feat/vega charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added debugging to custom router to identify potential issue when rebuilding
 - Terms of Service page update
 - Adds visibility toggle to dashboard widgets
+- Widgets restyling
 
 ### 29 Mar 2017
 - Add validation of template selection to site creation

--- a/app/assets/javascripts/helpers/handlebars.js
+++ b/app/assets/javascripts/helpers/handlebars.js
@@ -89,3 +89,28 @@ Handlebars.registerHelper('format_date', function (date) {
 
   return [month, day, year].join('/');
 });
+
+/**
+ * Math helper
+ */
+Handlebars.registerHelper("math", function(lvalue, operator, rvalue, options) {
+  var left = parseFloat(lvalue);
+  var right = parseFloat(rvalue);
+  if (isNaN(left) || isNaN(right)) {
+    return {
+      "+": lvalue,
+      "-": lvalue,
+      "*": lvalue,
+      "/": lvalue,
+      "%": lvalue
+    }[operator];
+  }
+
+  return {
+    "+": left + right,
+    "-": left - right,
+    "*": left * right,
+    "/": left / right,
+    "%": left % right
+  }[operator];
+});

--- a/app/assets/javascripts/templates/front/charts/bar.hbs
+++ b/app/assets/javascripts/templates/front/charts/bar.hbs
@@ -23,6 +23,12 @@
       "field": {{{yColumn}}}
     },
     "nice": true
+  },
+  {
+    "name": "color",
+    "type": "ordinal",
+    "range": ["#e6e6e6","#97be32","#5c770a"],
+    "domain": {"data": "table","field": {{{xColumn}}} }
   }],
   "axes": [{
     "type": "x",
@@ -58,7 +64,8 @@
       },
       "update": {
         "fill": {
-          "value": "steelblue"
+          "field": {{{xColumn}}},
+          "scale": "color"
         }
       }
     }

--- a/app/assets/javascripts/templates/front/charts/bar.hbs
+++ b/app/assets/javascripts/templates/front/charts/bar.hbs
@@ -34,8 +34,31 @@
     "type": "x",
     "scale": "x"
   }, {
+    "grid": true,
+    "layer": "back",
     "type": "y",
-    "scale": "y"
+    "scale": "y",
+    "tickSize": 30,
+    "properties": {
+      "grid": {
+        "stroke": {"value": "#eeeeee"},
+        "strokeWidth": {"value": 2},
+        "strokeDash": {"value": [5, 5]}
+      },
+      "majorTicks": {"strokeWidth": {"value": 2}},
+      "ticks": {
+        "stroke": {"value": "#eeeeee"},
+        "strokeDash": {"value": [5, 5]}
+      },
+      "labels": {
+        "text": {
+          "template": "\{{datum.data | number:'.2s' }}"
+        },
+        "align": {"value": "left"},
+        "baseline": {"value": "bottom"},
+        "fontSize": {"value": 11}
+        }
+      }
   }],
   "marks": [{
     "type": "rect",
@@ -46,12 +69,13 @@
       "enter": {
         "x": {
           "scale": "x",
-          "field": {{{xColumn}}}
+          "field": {{{xColumn}}},
+          "offset": 10
         },
         "width": {
           "scale": "x",
           "band": true,
-          "offset": -1
+          "offset": -15
         },
         "y": {
           "scale": "y",

--- a/app/assets/javascripts/templates/front/charts/bar.hbs
+++ b/app/assets/javascripts/templates/front/charts/bar.hbs
@@ -38,9 +38,9 @@
       "properties": {
       "labels": {
         "text": {"template": "\{{datum.data}}"},
-        "align": {"value": "left"},
+        "align": {"value": "right"},
         "baseline": {"value": "middle"},
-        "angle": {"value": 45},
+        "angle": {"value": -45},
         "fontSize": {"value": 11}
         }
       }

--- a/app/assets/javascripts/templates/front/charts/bar.hbs
+++ b/app/assets/javascripts/templates/front/charts/bar.hbs
@@ -42,7 +42,13 @@
         "align": {"value": "right"},
         "baseline": {"value": "middle"},
         "angle": {"value": -45},
-        "fontSize": {"value": 11}
+        "fontSize": {"value": 11},
+        "dy": {"value": 20}
+        },
+        "title": {
+          "dx": {"value": 150},
+          "dy": {"value": 5},
+          "baseline": {"value": "top"}
         }
       }
     }, {
@@ -58,7 +64,6 @@
         "strokeWidth": {"value": 2},
         "strokeDash": {"value": [5, 5]}
       },
-      "majorTicks": {"strokeWidth": {"value": 2}},
       "ticks": {
         "stroke": {"value": "#eeeeee"},
         "strokeDash": {"value": [5, 5]}
@@ -69,7 +74,14 @@
         },
         "align": {"value": "left"},
         "baseline": {"value": "bottom"},
-        "fontSize": {"value": 11}
+        "fontSize": {"value": 11},
+        "dy": {"value": -15}
+        },
+        "title": {
+          "dx": {"value": 90},
+          "dy": {"value": -10},
+          "align": {"value": "right"},
+          "baseline": {"value": "top"}
         }
       }
   }],

--- a/app/assets/javascripts/templates/front/charts/bar.hbs
+++ b/app/assets/javascripts/templates/front/charts/bar.hbs
@@ -1,6 +1,6 @@
 {
   "width": {{{width}}},
-  "height": {{{height}}},
+  "height": {{{math height "+" 100}}},
   "padding": "strict",
   "data": [{
     "name": "table",
@@ -31,9 +31,20 @@
     "domain": {"data": "table","field": {{{xColumn}}} }
   }],
   "axes": [{
-    "type": "x",
-    "scale": "x"
-  }, {
+      "layer": "back",
+      "type": "x",
+      "scale": "x",
+      "tickSize": 5,
+      "properties": {
+      "labels": {
+        "text": {"template": "\{{datum.data}}"},
+        "align": {"value": "left"},
+        "baseline": {"value": "middle"},
+        "angle": {"value": 45},
+        "fontSize": {"value": 11}
+        }
+      }
+    }, {
     "grid": true,
     "layer": "back",
     "type": "y",

--- a/app/assets/javascripts/templates/front/charts/line.hbs
+++ b/app/assets/javascripts/templates/front/charts/line.hbs
@@ -5,14 +5,19 @@
   "data": [
     {
       "name": "table",
-      "values": {{{data}}}
+      "values": {{{data}}},
+      "format": {
+        "parse": {
+          {{{xColumn}}}: "date"
+        }
+      }
     }
   ],
   "scales": [
     {
       "name": "x",
       "nice": true,
-      "type": "linear",
+      "type": "time",
       "zero": false,
       "range": "width",
       "domain": {"data": "table","field": {{{xColumn}}} }

--- a/app/assets/javascripts/templates/front/charts/line.hbs
+++ b/app/assets/javascripts/templates/front/charts/line.hbs
@@ -2,75 +2,46 @@
   "width": {{{width}}},
   "height": {{{height}}},
   "padding": "strict",
-  "data": [{
-    "name": "table",
-    "values": {{{data}}},
-    "format": {
-      "parse": {
-        {{{xColumn}}}: "date"
-      }
+  "data": [
+    {
+      "name": "table",
+      "values": {{{data}}}
     }
-  }],
-  "scales": [{
-    "name": "x",
-    "type": "time",
-    "range": "width",
-    "zero": false,
-    "domain": {
-      "data": "table",
-      "field": {{{xColumn}}}
-    }
-  }, {
-    "name": "y",
-    "type": "linear",
-    "range": "height",
-    "nice": true,
-    "domain": {
-      "data": "table",
-      "field": {{{yColumn}}}
-    }
-  }],
-  "axes": [{
-    "type": "x",
-    "scale": "x",
-    "ticks": 6
-  }, {
-    "type": "y",
-    "scale": "y"
-  }],
-  "marks": [{
-    "type": "area",
-    "from": {
-      "data": "table"
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "nice": true,
+      "type": "linear",
+      "zero": false,
+      "range": "width",
+      "domain": {"data": "table","field": {{{xColumn}}} }
     },
+    {
+      "name": "y",
+      "type": "linear",
+      "range": "height",
+      "domain": {"data": "table","field": {{{yColumn}}} }
+    }
+  ],
+  "axes": [
+    {"type": "x","scale": "x","ticks": 6},
+    {"type": "y","scale": "y"}
+  ],
+  "marks": [
+    {
+    "type": "area",
+    "from": {"data": "table"},
     "properties": {
       "enter": {
-        "x": {
-          "scale": "x",
-          "field": {{{xColumn}}}
+        "x": {"scale": "x","field": {{{xColumn}}} },
+        "y": {"scale": "y","field": {{{yColumn}}} },
+        "stroke": {"value": "#97be32"},
+        "strokeWidth": {"value": 2}
         },
-        "y": {
-          "scale": "y",
-          "field": {{{yColumn}}}
-        },
-        "y2": {
-          "scale": "y",
-          "value": 0
-        },
-        "fill": {
-          "value": "steelblue"
-        }
-      },
-      "update": {
-        "fillOpacity": {
-          "value": 1
-        }
-      },
-      "hover": {
-        "fillOpacity": {
-          "value": 0.5
-        }
+      "update": {"fillOpacity": {"value": 1}},
+      "hover": {"fillOpacity": {"value": 0.5}}
       }
     }
-  }]
+  ]
 }

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -31,7 +31,7 @@
     {
       "name": "legend-series-y",
       "type": "ordinal",
-      "range": [125,200],
+      "range": "height",
       "domain": {"data": "table","field": {{{xColumn}}} }
     }
   ],
@@ -52,7 +52,7 @@
           "field": {
             "group": "height"
           },
-          "mult": 0.5
+          "mult": 0.45
         },
         "startAngle": {
           "field": "layout_start"
@@ -95,7 +95,7 @@
           "field": {
             "group": "height"
           },
-          "mult": 0.5
+          "mult": 0.45
         },
         "radius": {
           "value": 80

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -18,7 +18,20 @@
       "field": "count"
     }]
   }],
-  "scales": [],
+"scales": [
+    {
+      "name": "color",
+      "type": "ordinal",
+      "range": ["#e6e6e6","#97be32","#5c770a"],
+      "domain": {"data": "table","field": "_id"}
+    },
+    {
+      "name": "legend-series-y",
+      "type": "ordinal",
+      "range": [125,200],
+      "domain": {"data": "table","field": "_id"}
+    }
+  ],
   "marks": [{
     "type": "arc",
     "from": {
@@ -45,7 +58,7 @@
           "field": "layout_end"
         },
         "innerRadius": {
-          "value": 0
+          "value": {{{math height "*" 0.2}}}
         },
         "outerRadius": {
           "value": {{{height}}},
@@ -57,7 +70,8 @@
       },
       "update": {
         "fill": {
-          "value": "#ccc"
+          "field": "_id",
+          "scale": "color"
         }
       }
     }
@@ -100,5 +114,27 @@
         }
       }
     }
-  }]
+  }],
+"legends": [
+    {
+      "fill": "color",
+      "properties": {
+        "labels": {
+          "y": {"scale": "legend-series-y", "offset": 0},
+          "x": {"value": 15},
+          "text": {
+            "template": "\{{datum.data|left:1|upper}}\{{datum.data|slice:1|truncate:15}}"
+            },
+          "fontSize": {"value": 14}
+        },
+        "symbols": {
+          "y": {"scale": "legend-series-y", "offset": 0},
+          "x": {"value": 0},
+          "size": {"value": 100},
+          "shape": {"value": "circle"},
+          "stroke": "#ffffff"
+        }
+      }
+    }
+  ]
 }

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -31,7 +31,7 @@
     {
       "name": "legend-series-y",
       "type": "ordinal",
-      "range": "height",
+      "range": [40, {{{math height "-" 10}}}],
       "domain": {"data": "table","field": {{{xColumn}}} }
     }
   ],
@@ -82,7 +82,8 @@
       "type": "text",
       "properties": {
         "enter": {
-          "x": {"value": 50},
+          "x": {"value": -140},
+          "y": {"value": 10},
           "text": {
             "template": {{{xLabel}}}
           },

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -9,27 +9,30 @@
       "type": "aggregate",
       "groupby": {{{xColumn}}},
       "summarize": [{
-        "field": {{{xColumn}}},
-        "ops": ["count"],
-        "as": "count"
-      }]
-    }, {
-      "type": "pie",
-      "field": "count"
-    }]
-  }],
-"scales": [
+      "field": {{{xColumn}}},
+      "ops": ["count"],
+      "as": "count" }]
+    },
+    { "type": "pie", "field": "count" }]
+    },
+    {
+      "name": "goupedData",
+      "source": "table",
+      "transform": [{ "type": "facet", "groupby": [{{{xColumn}}}] }]
+    }
+  ],
+  "scales": [
     {
       "name": "color",
       "type": "ordinal",
       "range": ["#e6e6e6","#97be32","#5c770a"],
-      "domain": {"data": "table","field": "_id"}
+      "domain": {"data": "table","field": {{{xColumn}}} }
     },
     {
       "name": "legend-series-y",
       "type": "ordinal",
       "range": [125,200],
-      "domain": {"data": "table","field": "_id"}
+      "domain": {"data": "table","field": {{{xColumn}}} }
     }
   ],
   "marks": [{

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -73,7 +73,7 @@
       },
       "update": {
         "fill": {
-          "field": "_id",
+          "field": {{{xColumn}}},
           "scale": "color"
         }
       }
@@ -124,15 +124,15 @@
       "properties": {
         "labels": {
           "y": {"scale": "legend-series-y", "offset": 0},
-          "x": {"value": 15},
+          "x": {"value": 30},
           "text": {
             "template": "\{{datum.data|left:1|upper}}\{{datum.data|slice:1|truncate:15}}"
             },
           "fontSize": {"value": 14}
         },
         "symbols": {
-          "y": {"scale": "legend-series-y", "offset": 0},
-          "x": {"value": 0},
+          "y": {"scale": "legend-series-y", "offset": -5},
+          "x": {"value": 15},
           "size": {"value": 100},
           "shape": {"value": "circle"},
           "stroke": "#ffffff"

--- a/app/assets/javascripts/templates/front/charts/scatter.hbs
+++ b/app/assets/javascripts/templates/front/charts/scatter.hbs
@@ -1,6 +1,6 @@
 {
   "width": {{{width}}},
-  "height": {{{height}}},
+  "height": {{{math height "+" 100}}},
   "padding": "strict",
   "data": [{
     "name": "table",
@@ -26,7 +26,17 @@
   }],
   "axes": [{
     "type": "x",
-    "scale": "x"
+    "scale": "x",
+    "tickSize": 5,
+    "properties": {
+      "labels": {
+        "text": {"template": "\{{datum.data}}"},
+        "align": {"value": "right"},
+        "baseline": {"value": "middle"},
+        "angle": {"value": -45},
+        "fontSize": {"value": 11}
+      }
+    }
   }, {
       "grid": true,
       "layer": "back",
@@ -59,7 +69,7 @@
     },
     "properties": {
       "enter": {
-        "x": {"scale": "x", "field": {{{xColumn}}} },
+        "x": {"scale": "x", "field": {{{xColumn}}}, "offset": 30 },
         "y": {"scale": "y", "field": {{{yColumn}}} },
         "fill": {"value": "#97be32"},
         "size": {"value": 15}

--- a/app/assets/javascripts/templates/front/charts/scatter.hbs
+++ b/app/assets/javascripts/templates/front/charts/scatter.hbs
@@ -17,7 +17,6 @@
   }, {
     "name": "y",
     "type": "linear",
-    "range": "height",
     "domain": {
       "data": "table",
       "field": {{{yColumn}}}
@@ -35,7 +34,13 @@
         "align": {"value": "right"},
         "baseline": {"value": "middle"},
         "angle": {"value": -45},
-        "fontSize": {"value": 11}
+        "fontSize": {"value": 11},
+        "dy": {"value": 20}
+      },
+      "title": {
+        "dx": {"value": 150},
+        "dy": {"value": 5},
+        "baseline": {"value": "top"}
       }
     }
   }, {
@@ -51,7 +56,6 @@
           "strokeWidth": {"value": 2},
           "strokeDash": {"value": [5,5]}
           },
-        "majorTicks": {"strokeWidth": {"value": 2}},
         "ticks": {
           "stroke": {"value": "#eeeeee"},
           "strokeDash": {"value": [5,5]}
@@ -60,7 +64,14 @@
           "text": {"template": "\{{datum.data | number:'.2s' }}"},
           "align": {"value": "left"},
           "baseline": {"value": "bottom"},
-          "fontSize": {"value": 11}
+          "fontSize": {"value": 11},
+          "dy": {"value": -10}
+          },
+          "title": {
+            "dx": {"value": 90},
+            "dy": {"value": -15},
+            "align": {"value": "right"},
+            "baseline": {"value": "top"}
           }
       }
   }],

--- a/app/assets/javascripts/templates/front/charts/scatter.hbs
+++ b/app/assets/javascripts/templates/front/charts/scatter.hbs
@@ -28,8 +28,29 @@
     "type": "x",
     "scale": "x"
   }, {
-    "type": "y",
-    "scale": "y"
+      "grid": true,
+      "layer": "back",
+      "type": "y",
+      "scale": "y",
+      "tickSize": 30,
+      "properties": {
+        "grid": {
+          "stroke": {"value": "#eeeeee"},
+          "strokeWidth": {"value": 2},
+          "strokeDash": {"value": [5,5]}
+          },
+        "majorTicks": {"strokeWidth": {"value": 2}},
+        "ticks": {
+          "stroke": {"value": "#eeeeee"},
+          "strokeDash": {"value": [5,5]}
+          },
+        "labels": {
+          "text": {"template": "\{{datum.data | number:'.2s' }}"},
+          "align": {"value": "left"},
+          "baseline": {"value": "bottom"},
+          "fontSize": {"value": 11}
+          }
+      }
   }],
   "marks": [{
     "type": "symbol",
@@ -38,28 +59,10 @@
     },
     "properties": {
       "enter": {
-        "x": {
-          "scale": "x",
-          "field": {{{xColumn}}}
-        },
-        "width": {
-          "scale": "x",
-          "band": true,
-          "offset": -1
-        },
-        "y": {
-          "scale": "y",
-          "field": {{{yColumn}}}
-        },
-        "y2": {
-          "scale": "y",
-          "value": 0
-        }
-      },
-      "update": {
-        "fill": {
-          "value": "steelblue"
-        }
+        "x": {"scale": "x", "field": {{{xColumn}}} },
+        "y": {"scale": "y", "field": {{{yColumn}}} },
+        "fill": {"value": "#97be32"},
+        "size": {"value": 15}
       }
     }
   }]

--- a/app/assets/javascripts/templates/front/charts/vegaTheme.hbs
+++ b/app/assets/javascripts/templates/front/charts/vegaTheme.hbs
@@ -1,0 +1,64 @@
+{
+  "background":"#fff",
+  "render": {"retina": true},
+  "axis": {
+    "layer": "back",
+    "ticks": 5,
+    "axisColor": "transparent",
+    "axisWidth": 1,
+    "gridColor": "#999999",
+    "gridOpacity": 1,
+    "tickColor": "#999999",
+    "tickLabelColor": "#555555",
+    "tickWidth": 0,
+    "tickSize": 10,
+    "tickLabelFontSize": 11,
+    "tickLabelFont": "\"Fira Sans\"",
+    "tickOffset": 0,
+    "titleFont": "\"Fira Sans\"",
+    "titleFontSize": 11,
+    "titleFontWeight": "regular",
+    "titleColor": "#555555",
+    "titleOffset": "auto",
+    "titleOffsetAutoMin": 0,
+    "titleOffsetAutoMax": 0,
+    "titleOffsetAutoMargin": 0
+  },
+  "legend": {
+    "orient": "left",
+    "padding": 0,
+    "margin": 0,
+    "labelColor": "#555555",
+    "labelFontSize": 11,
+    "labelFont": "\"Fira Sans\"",
+    "labelAlign": "left",
+    "labelBaseline": "Bottom",
+    "labelOffset": 0,
+    "symbolShape": "line",
+    "symbolSize": 2,
+    "symbolStrokeWidth": 0,
+    "titleFont": "\"Fira Sans\"",
+    "titleFontSize": 11,
+    "titleFontWeight": "medium",
+    "titleColor": "#555555"
+  },
+  "color": {
+    "rgb": [128,128,128],
+    "lab": [50,0,0],
+    "hcl": [0,0,50],
+    "hsl": [0,0,0.5]
+  },
+  "range": {
+    "colorRange": ["#e6e6e6","#97be32","#5c770a"],
+    "shapes": [
+      "circle",
+      "cross",
+      "diamond",
+      "square",
+      "triangle-down",
+      "triangle-up",
+      "line",
+      "textMark"
+    ]
+  }
+}

--- a/app/assets/javascripts/templates/front/charts/vegaTheme.hbs
+++ b/app/assets/javascripts/templates/front/charts/vegaTheme.hbs
@@ -17,7 +17,6 @@
     "tickOffset": 0,
     "titleFont": "\"Fira Sans\"",
     "titleFontSize": 11,
-    "titleFontWeight": "regular",
     "titleColor": "#555555",
     "titleOffset": "auto",
     "titleOffsetAutoMin": 0,

--- a/app/assets/javascripts/views/shared/chartWidgetView.js
+++ b/app/assets/javascripts/views/shared/chartWidgetView.js
@@ -122,6 +122,13 @@
       if (!this.options.data.length) return HandlebarsTemplates['front/charts/empty'];
       return HandlebarsTemplates['front/charts/' + this.options.chart];
     },
+    /**
+     *  Get the vega theme
+     *  @returns {string}
+     */
+    _getVegaTheme: function () {
+      return JSON.parse(HandlebarsTemplates['front/charts/vegaTheme']());
+    },
 
     /**
      * Generate the vega spec
@@ -147,7 +154,6 @@
         this.options.columnX = columns.x;
         this.options.columnY = columns.y;
       }
-
       return this._getChartTemplate()({
         data: JSON.stringify(this.options.data),
         xColumn: JSON.stringify(this.options.columnX),
@@ -168,7 +174,7 @@
       }
 
       vg.parse
-        .spec(JSON.parse(this._generateVegaSpec()), function (error, chart) {
+        .spec(JSON.parse(this._generateVegaSpec()), this._getVegaTheme(), function (error, chart) {
           if (error) {
             App.notifications.broadcast(App.Helper.Notifications.dashboard.chartError)
             return;


### PR DESCRIPTION
This PR restyles the vega charts.

1. Donut Chart
![screen shot 2017-03-31 at 14 33 29](https://cloud.githubusercontent.com/assets/12124839/24550596/112b436c-161f-11e7-9f77-d4a9b3e1db0f.png)

2. Bar Chart
![screen shot 2017-03-31 at 14 29 13](https://cloud.githubusercontent.com/assets/12124839/24550542/cd6ad980-161e-11e7-9fcf-241cb9a6a1bf.png)

3. Scatter Plot Chart
![screen shot 2017-03-31 at 17 00 29](https://cloud.githubusercontent.com/assets/12124839/24556131/ac4eda02-1633-11e7-996c-692303f7af34.png)

4. Line Chart
![screen shot 2017-03-31 at 19 26 23](https://cloud.githubusercontent.com/assets/12124839/24561730/328bedda-1648-11e7-8d5a-c32a9be78e4d.png)


