### PR TITLE
fix: hide url input view placeholder

### DIFF
--- a/app/assets/javascripts/templates/admin/urls-input.hbs
+++ b/app/assets/javascripts/templates/admin/urls-input.hbs
@@ -8,10 +8,12 @@
     <button type="button" class="remove-url js-remove-url" data-id="{{@index}}">Remove</button>
   </div>
 {{/each}}
+{{#if showNextInput}}
 <div class="container">
   <label for="url-0">{{#if urls.length}}Additional URL{{else}}Main URL{{/if}}</label>
   <input value="" class="js-input" placeholder="{{#if urls.length}}https://www.my-site.com{{else}}https://www.mysite.com{{/if}}" name="{{inputName}}[{{urls.length}}][host]" id="url-0">
 </div>
+{{/if}}
 <footer>
   <button type="button" class="add-url js-add-url">Add URL</button>
 </footer>

--- a/app/assets/javascripts/views/admin/urlsInputView.js
+++ b/app/assets/javascripts/views/admin/urlsInputView.js
@@ -6,6 +6,7 @@
     template: HandlebarsTemplates['admin/urls-input'],
 
     defaults: {
+      showNextInput: false
     },
 
     events: {
@@ -23,6 +24,7 @@
      * Event handler executed when the user clicks the add URL button
      */
     _addUrl: function () {
+      this.options.showNextInput = true;
       this.render();
     },
 
@@ -35,6 +37,7 @@
         var index = +e.target.dataset.id;
         var model = this.collection.at(index);
         this.collection.remove(model);
+        this.options.showNextInput = false;
         this.render();
       }
     },
@@ -64,7 +67,7 @@
     },
 
     render: function () {
-      // We add the component's class name to the elemetn
+      // We add the component's class name to the element
       this.$el.addClass(this.className);
 
       // We remove all of the previous rendered nodes
@@ -74,6 +77,7 @@
       }
 
       this.$el.append(this.template({
+        showNextInput: this.options.showNextInput,
         urls: this.collection.toJSON(),
         inputId: (window.gon && gon.global && gon.global.urlControllerId) || '',
         inputName: (window.gon && gon.global && gon.global.urlControllerName) || ''


### PR DESCRIPTION
This PR hides the default empty input on the `urlInputView` thus only showing if you click in the Add Url button.