### PR TITLE
Add config option for site default language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add option to select a site's default language
+
 ### 4 April 2017
 - Add custom labels support to widgets
 - Added wysiwyg css cheatsheet

--- a/app/assets/stylesheets/components/shared/c-select.scss
+++ b/app/assets/stylesheets/components/shared/c-select.scss
@@ -73,4 +73,11 @@
       line-height: 24px;
     }
   }
+
+  &.-admin > select {
+    background-color: $color-2;
+    border-radius: 4px;
+    border-color: $color-13;
+    text-transform: capitalize;
+  }
 }

--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -68,6 +68,7 @@ class Admin::SiteStepsController < AdminController
       end
       if step == 'settings'
         SiteSetting.create_site_settings @site
+        @default_site_language = @site.site_settings.where(name: 'default_site_language').first
         @translate_english = @site.site_settings.where(name: 'translate_english').first
         @translate_spanish = @site.site_settings.where(name: 'translate_spanish').first
         @translate_french = @site.site_settings.where(name: 'translate_french').first
@@ -245,6 +246,7 @@ class Admin::SiteStepsController < AdminController
         site_settings_attributes: [
           :id, :position, :value, :name, :image,
           :attribution_link, :attribution_label,
+          :default_site_language,
           :translate_english, :translate_french,
           :translate_spanish, :pre_footer, :analytics_key, :keywords, :contact_email_address
         ]

--- a/app/controllers/site_page_controller.rb
+++ b/app/controllers/site_page_controller.rb
@@ -17,6 +17,7 @@ class SitePageController < ApplicationController
 
   def set_gon
     gon.push({
+               :default_site_language => @site_page.site.site_settings.default_site_language(@site_page.site_id).value || 'en',
                :translations => {
                  :en => @site_page.site.site_settings.translate_english(@site_page.site_id).value == '1',
                  :fr => @site_page.site.site_settings.translate_french(@site_page.site_id).value == '1',
@@ -98,7 +99,7 @@ class SitePageController < ApplicationController
       # ... legend fields
       gon.legend = @setting.legend
     end
-    @widgets_visibility = JSON.parse(@setting.widgets).map{|config| config["visible"] }
+    @widgets_visibility = JSON.parse(@setting.widgets).map { |config| config["visible"] }
   end
 
   def map_report

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -25,6 +25,7 @@ class SiteSetting < ApplicationRecord
 
   NAMES = %w[
     logo_image main_image alternative_image favico color flag
+    default_site_language
     translate_english translate_spanish translate_french
     pre_footer analytics_key keywords contact_email_address
     hosting_organization
@@ -76,6 +77,10 @@ class SiteSetting < ApplicationRecord
 
   def self.flag_colors(site_id)
     SiteSetting.find_by(name: 'flag', site_id: site_id)
+  end
+
+  def self.default_site_language(site_id)
+    SiteSetting.find_by(name: 'default_site_language', site_id: site_id)
   end
 
   def self.translate_english(site_id)
@@ -147,6 +152,7 @@ class SiteSetting < ApplicationRecord
       site.site_settings.new(name: 'keywords', value: '', position: 12)
       site.site_settings.new(name: 'contact_email_address', value: '', position: 13)
       site.site_settings.new(name: 'hosting_organization', value: '', position: 14)
+      site.site_settings.new(name: 'default_site_language', value: 'en', position: 15)
     end
   end
 

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -18,10 +18,17 @@
         <div class="settings c-inputs-container">
         <div class="container">
           <%= f.fields_for :site_settings, \
-            (f.object.site_settings.collect.select{|x| %w[translate_english translate_french translate_spanish].include?(x.name)}.sort_by { |s| s.position }) do |settings_form|%>
+            (f.object.site_settings.collect.select{|x| %w[translate_english translate_french translate_spanish default_site_language].include?(x.name)}.sort_by { |s| s.position }) do |settings_form|%>
             <% setting = settings_form.object %>
-            <% case setting.name when 'translate_english' %>
+            <% case setting.name when 'default_site_language' %>
+              <%= settings_form.hidden_field :position, value: '15' %>
+              <%= settings_form.hidden_field :name, value: 'default_site_language' %>
+              <div class="c-select">
+                <%= settings_form.label 'Default site language', for: 'default_site_language' %>
+                <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es}, id: 'default_site_language' %>
+              </div>
 
+              <% when 'translate_english' %>
               <%= settings_form.hidden_field :position, value: '7' %>
               <%= settings_form.hidden_field :name, value: 'translate_english' %>
               <div class="c-checkbox">
@@ -46,8 +53,8 @@
                 <%= settings_form.check_box :value, id: 'translate_spanish' %>
                 <%= settings_form.label 'Allow Spanish translations', for: 'translate_spanish' %>
               </div>
-            <%end%>
-          <%end%>
+              <% end %>
+          <% end %>
         </div>
           <%= f.fields_for :site_settings, (f.object.site_settings.collect.sort_by { |s| s.position }) do |settings_form| %>
               <% setting = settings_form.object %>

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -23,10 +23,11 @@
             <% case setting.name when 'default_site_language' %>
               <%= settings_form.hidden_field :position, value: '15' %>
               <%= settings_form.hidden_field :name, value: 'default_site_language' %>
-              <div class="c-select">
-                <%= settings_form.label 'Default site language', for: 'default_site_language' %>
-                <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es}, id: 'default_site_language' %>
-              </div>
+
+              <%= settings_form.label 'Default site language', for: 'default_site_language' %>
+                <div class="c-select -admin">
+                  <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es}, id: 'default_site_language' %>
+                </div>
 
               <% when 'translate_english' %>
               <%= settings_form.hidden_field :position, value: '7' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
       api_key: 'a81c84348fa34de097781e4017e1a944',
       detectlang: function () {
         var match = location.search.match(/\?(?:.*)?l=([a-z]{2})/);
-        return (match && match.length) > 1 ? match[1]: 'en';
+        return (match && match.length) > 1 ? match[1]: '<%= @site_page.site.site_settings.default_site_language(@site_page.site_id).value || 'en' %>';
       }
     };
   </script>

--- a/lib/tasks/update_site_settings.rake
+++ b/lib/tasks/update_site_settings.rake
@@ -67,6 +67,10 @@ namespace :db do
               site.site_settings.create!(name: 'hosting_organization', value: '', position: 14)
               puts '...... Added hosting_organization'
             end
+            unless site.site_settings.exists?(name: 'default_site_language')
+              site.site_settings.create!(name: 'default_site_language', value: 'en', position: 15)
+              puts '...... Added default_site_language'
+            end
             puts "... Finished creation for site #{site.name}"
             puts ''
           end


### PR DESCRIPTION
Adds an option to the site settings to configure the site's default language

ToDo: review styling on new site setting