### PR TITLE
Fix: dashboard bookmark bar

### DIFF
--- a/app/assets/javascripts/templates/front/dashboard-bookmarks.hbs
+++ b/app/assets/javascripts/templates/front/dashboard-bookmarks.hbs
@@ -1,20 +1,22 @@
 <h3>Bookmarks:</h3>
-<ul class="bookmarks">
-  {{#each bookmarks}}
-    <li class="js-bookmark" tabindex="0">
-      <span class="js-name" data-id="{{@index}}">{{name}}</span>
-      <div>
-        <button type="button" class="apply js-apply" data-id="{{@index}}" title="Apply bookmark" aria-label="Apply bookmark">{{name}}</button>
-        <div class="floating-buttons">
-          <button type="button" class="-edit js-edit" title="Edit bookmark name">Edit bookmark name<svg width="15" height="15" viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><path d="M11.279 0l3.711 3.711-9.278 9.278-3.711-3.71L11.279 0zM1.537 9.742l3.711 3.711-4.392.682.681-4.393z" fill="#FFF" fill-rule="evenodd"/></svg></button>
-          <button type="button" class="-delete js-delete" data-id="{{@index}}" title="Delete bookmark">Delete bookmark<svg width="10" height="14" viewBox="0 0 10 14" xmlns="http://www.w3.org/2000/svg"><path d="M7 1V0H3v1H0v2h10V1H7zM1 14h8V4H1v10z" fill="#555" fill-rule="evenodd"/></svg></button>
+<div class="bookmarks-wrapper">
+  <ul class="bookmarks">
+    {{#each bookmarks}}
+      <li class="js-bookmark" tabindex="0">
+        <span class="js-name" data-id="{{@index}}">{{name}}</span>
+        <div>
+          <button type="button" class="apply js-apply" data-id="{{@index}}" title="Apply bookmark" aria-label="Apply bookmark">{{name}}</button>
+          <div class="floating-buttons">
+            <button type="button" class="-edit js-edit" title="Edit bookmark name">Edit bookmark name<svg width="15" height="15" viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><path d="M11.279 0l3.711 3.711-9.278 9.278-3.711-3.71L11.279 0zM1.537 9.742l3.711 3.711-4.392.682.681-4.393z" fill="#FFF" fill-rule="evenodd"/></svg></button>
+            <button type="button" class="-delete js-delete" data-id="{{@index}}" title="Delete bookmark">Delete bookmark<svg width="10" height="14" viewBox="0 0 10 14" xmlns="http://www.w3.org/2000/svg"><path d="M7 1V0H3v1H0v2h10V1H7zM1 14h8V4H1v10z" fill="#555" fill-rule="evenodd"/></svg></button>
+          </div>
         </div>
-      </div>
-    </li>
-  {{else}}
-    <li class="no-bookmark">You haven't saved any bookmark yet</li>
-  {{/each}}
-  <li class="add-button">
-    <button type="button" class="js-add-bookmark">Create bookmark</button>
-  </li>
-</ul>
+      </li>
+    {{else}}
+      <li class="no-bookmark">You haven't saved any bookmark yet</li>
+    {{/each}}
+  </ul>
+</div>
+<div class="add-button">
+  <button type="button" class="js-add-bookmark">Create bookmark</button>
+</div>

--- a/app/assets/stylesheets/components/shared/c-dashboard-bookmarks.scss
+++ b/app/assets/stylesheets/components/shared/c-dashboard-bookmarks.scss
@@ -103,7 +103,7 @@
     white-space: nowrap;
     width: auto;
     padding-left: 10px;
-    padding-right: 50px;
+    padding-right: 100px;
 
     > li {
       display: inline-block;

--- a/app/assets/stylesheets/components/shared/c-dashboard-bookmarks.scss
+++ b/app/assets/stylesheets/components/shared/c-dashboard-bookmarks.scss
@@ -54,26 +54,60 @@
     }
   }
 
-  > .bookmarks {
-    display: flex;
-    flex-grow: 1;
-    align-items: center;
-    justify-content: flex-start;
-    margin: 0 auto;
-    padding: 10px 30px;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
+  .add-button {
+    display: inline-block;
+    margin: 0;
 
-    @media #{$mq-tablet} {
-      justify-content: center;
-      width: calc(100% - 160px);
-      padding: 10px 0;
+    button {
+      margin-right: 30px;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: $color-1;
+      font-family: inherit;
+      font-size: inherit;
+      cursor: pointer;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+
+      @media #{$mq-tablet} {
+        margin-right: 0;
+      }
     }
 
+    @media #{$mq-tablet} {
+      position: absolute;
+      top: 50%;
+      right: 0;
+      transform: translateY(-50%);
+    }
+  }
+
+  .bookmarks-wrapper {
+    display: flex;
+    align-items: center;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    margin: 0 auto;
+    padding: 0 30px;
+    height: 48px;
+    width: 45%;
+
+    @media #{$mq-tablet} {
+      width: 75%;
+    }
+  }
+
+  .bookmarks {
+    white-space: nowrap;
+    width: auto;
+    padding-left: 10px;
+    padding-right: 50px;
+
     > li {
+      display: inline-block;
       position: relative;
-      flex-shrink: 0;
       height: 27px;
       margin-right: 70px;
       line-height: 27px;
@@ -94,23 +128,6 @@
 
         @media #{$mq-tablet} {
           display: block;
-        }
-      }
-
-      &.add-button button {
-        margin-right: 30px;
-        padding: 0;
-        border: 0;
-        background: transparent;
-        color: $color-1;
-        font-family: inherit;
-        font-size: inherit;
-        cursor: pointer;
-        -webkit-appearance: none;
-        -moz-appearance: none;
-
-        @media #{$mq-tablet} {
-          margin-right: 0;
         }
       }
 


### PR DESCRIPTION
This PR addresses the following issue(s):
- When adding many bookmarks to the bookmark bar, the ones that were added first wouldn't be reachable cause the container did not grow appropriately. This has been changed so now the container will grow as big as it's needed and all bookmarks are reachable.
- The scroll bar would always appear on Linus/Windows OS because the overflow prop was set to `overflow-x: scroll;` instead of `overflow-x: auto;`.

This PR tackles issues mentioned in #194 