### PR TITLE
Fix: dashboard preview missing axes label values

### DIFF
--- a/app/assets/javascripts/routers/management/PreviewStepRouter.js
+++ b/app/assets/javascripts/routers/management/PreviewStepRouter.js
@@ -166,7 +166,7 @@
               y: widget.y || null,
               xLabel: widget.xLabel,
               yLabel: widget.yLabel,
-              visible: (widget.visible !== undefined) ? widget.visible : true
+              visible: typeof widget.visible !== 'undefined' ? widget.visible : true
             };
           } else if (widget.type === 'map') {
             return {
@@ -174,16 +174,16 @@
               lat: widget.lat || 0,
               lng: widget.lng || 0,
               zoom: widget.zoom || 3,
-              visible: (widget.visible !== undefined) ? widget.visible : true
+              visible: typeof widget.visible !== 'undefined' ? widget.visible : true
             };
           }
           return widget;
         });
       } else {
         for (var i = 0, j = this.options.widgetsCount - 1; i < j; i++) {
-          widgets.push({ type: 'chart', chart: null, x: null, y: null });
+          widgets.push({ type: 'chart', chart: null, x: null, y: null, visible: true });
         }
-        widgets.unshift({ type: 'map', lat: 0, lng: 0, zoom: 3 });
+        widgets.unshift({ type: 'map', lat: 0, lng: 0, zoom: 3, visible: true });
       }
       return widgets;
     },
@@ -220,6 +220,8 @@
             chart: widget.chart,
             columnX: widget.x,
             columnY: widget.y,
+            xLabel: widget.xLabel,
+            yLabel: widget.yLabel,
             visible: widget.visible,
             switchCallback: function () {
               this._switchWidget(index, 'map');
@@ -271,7 +273,10 @@
           data: dataset,
           switchCallback: function () {
             this._switchWidget(index, 'map');
-          }.bind(this)
+          }.bind(this),
+          columnX: null,
+          columnY: null,
+          visible: true
         });
       }
       // We re-set the listeners

--- a/app/assets/javascripts/views/shared/chartWidgetView.js
+++ b/app/assets/javascripts/views/shared/chartWidgetView.js
@@ -333,10 +333,23 @@
       axis.forEach(function(axis){
         // We create the input
         var input = document.createElement('input');
-        input.setAttribute('placeholder', 'Custom ' + axis + ' label');
+        input.setAttribute('type', 'text');
         input.setAttribute('name', 'custom-' + axis);
-        const axisLabel = (axis === 'X') ? this.options.xLabel : this.options.yLabel;
-        if (axisLabel !== undefined) { input.value = axisLabel };
+        input.setAttribute('class', '-dashboard');
+
+        var axisLabel = null;
+        var placeholder = 'Custom ' + axis + ' label';
+
+        if (axis === 'X') {
+          axisLabel = this.options.xLabel;
+          if (!this.options.columnY) placeholder = 'Custom label';
+          input.setAttribute('placeholder', placeholder);
+        } else {
+          axisLabel = this.options.yLabel;
+          this.options.columnY ? input.setAttribute('placeholder', placeholder) : input.setAttribute('disabled', 'disabled');
+        }
+
+        if (axisLabel) input.value = axisLabel;
 
         // We attach the listeners
         input.addEventListener('change', function(){

--- a/app/assets/stylesheets/components/shared/c-fieldset.scss
+++ b/app/assets/stylesheets/components/shared/c-fieldset.scss
@@ -40,6 +40,10 @@
       border-color: $color-1;
       box-shadow: 0 2px 3px 0 rgba($color-1, .1);
     }
+
+    &[type="text"]:disabled .-dashboard {
+      display: none;
+    }
   }
 
   textarea {

--- a/app/assets/stylesheets/components/shared/c-fieldset.scss
+++ b/app/assets/stylesheets/components/shared/c-fieldset.scss
@@ -41,7 +41,7 @@
       box-shadow: 0 2px 3px 0 rgba($color-1, .1);
     }
 
-    &[type="text"]:disabled .-dashboard {
+    &[type="text"]:disabled.-dashboard {
       display: none;
     }
   }


### PR DESCRIPTION
This PR addresses the following issue(s):
- In the site's management, when editing a dashboard the previously set widgets' labels would not appear. This was due to the fact that the `xLabel` and `yLabel` props were not being passed on widget's init. This has been solved. (Mentioned before in #194 )
- When displaying a widget that only had one axis both the x and y axes inputs were displayed. Now if there's only one axis, we display only one input, and change the placeholder accordingly.
