### PR TITLE
fix: pie chart classes

### DIFF
--- a/app/assets/javascripts/helpers/handlebars.js
+++ b/app/assets/javascripts/helpers/handlebars.js
@@ -9,7 +9,7 @@ Handlebars.registerHelper('if_eq', function (a, b, opts) {
   };
 
   if (a === b || (b === null && isNullObject(a))) return opts.fn(this);
-  return opts.inverse(this);
+  else return opts.inverse(this);
 });
 
 /**
@@ -113,4 +113,11 @@ Handlebars.registerHelper("math", function(lvalue, operator, rvalue, options) {
     "/": left / right,
     "%": left % right
   }[operator];
+});
+/**
+ * safeVal helper
+ */
+Handlebars.registerHelper('safeVal', function (value, safeValue) {
+  var out = JSON.parse(value) || safeValue;
+  return new Handlebars.SafeString(out);
 });

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -15,10 +15,10 @@
     },
     {"type": "sort", "by": "-count"},
     {"type": "rank", "field": "count"},
-    {"type": "formula", "field": {{{xColumn}}}, "expr": "datum.rank > 4 ? 'Other' : datum.{{{xColumn}}}"},
+    {"type": "formula", "field": {{{xColumn}}}, "expr": "datum.rank > 4 ? 'Other' : datum.{{{safeVal xColumn "placeholder"}}}"},
     {"type": "aggregate", "groupby": {{{xColumn}}}, "summarize": [
       {
-        "field": "{{{xColumn}}}",
+        "field": {{{xColumn}}},
         "ops": ["count"],
         "as": "count"
       }]

--- a/app/assets/javascripts/templates/front/charts/pie.hbs
+++ b/app/assets/javascripts/templates/front/charts/pie.hbs
@@ -13,12 +13,17 @@
       "ops": ["count"],
       "as": "count" }]
     },
-    { "type": "pie", "field": "count" }]
+    {"type": "sort", "by": "-count"},
+    {"type": "rank", "field": "count"},
+    {"type": "formula", "field": {{{xColumn}}}, "expr": "datum.rank > 4 ? 'Other' : datum.{{{xColumn}}}"},
+    {"type": "aggregate", "groupby": {{{xColumn}}}, "summarize": [
+      {
+        "field": "{{{xColumn}}}",
+        "ops": ["count"],
+        "as": "count"
+      }]
     },
-    {
-      "name": "goupedData",
-      "source": "table",
-      "transform": [{ "type": "facet", "groupby": [{{{xColumn}}}] }]
+    { "type": "pie", "field": "count" }]
     }
   ],
   "scales": [

--- a/app/assets/javascripts/templates/front/charts/vegaTheme.hbs
+++ b/app/assets/javascripts/templates/front/charts/vegaTheme.hbs
@@ -47,7 +47,7 @@
     "hsl": [0,0,0.5]
   },
   "range": {
-    "colorRange": ["#5c770a","#97be32","#e6e6e6"],
+    "colorRange": ["#5c770a","#97be32","#e6e6e6", "#333333", "#999999"],
     "shapes": [
       "circle",
       "cross",


### PR DESCRIPTION
This PR addresses the following issue(s):
- When selecting a column with many different values, the pie chart would break. Now we only display the top 4 classes and a 5 one named `other` than summarises the rest.
