### PR TITLE
fix position step tree icon

### DIFF
--- a/app/assets/javascripts/routers/management/PositionStepRouter.js
+++ b/app/assets/javascripts/routers/management/PositionStepRouter.js
@@ -125,11 +125,6 @@
       return '\
         <div class="page {{#unless enabled}} -disabled {{/unless}} {{#if highlighted}}-highlight{{/if}} js-handle">\
           <span>{{name}}</span>\
-          {{#unless enabled}}\
-            <ul class="action-buttons">\
-              <li><span class="view-button-slashed">Disabled</span></li>\
-            </ul>\
-          {{/unless}}\
         </div>\
       ';
     }


### PR DESCRIPTION
This PR addresses the following issue(s):
- removes slashed eye icon in disabled pages because it raised confusion sometimes.