### PR TITLE
fix: site structure deletion

### DIFF
--- a/app/assets/javascripts/routers/management/StructureRouter.js
+++ b/app/assets/javascripts/routers/management/StructureRouter.js
@@ -171,7 +171,7 @@
               {{/if}}\
             {{/if}}\
             <li><a href="{{#if editUrl}}{{editUrl}}{{else}}{{editurl}}{{/if}}" class="edit-button">Edit</a></li>\
-            {{#if disableable}}\
+            {{#if deletable}}\
               <li><a rel="nofollow" data-method="delete" data-confirm="Are you sure you want to delete this page?" href="{{#if deleteUrl}}{{deleteUrl}}{{else}}{{deleteurl}}{{/if}}" class="delete-button js-delete">Delete</a></li>\
             {{/if}}\
           </ul>\

--- a/app/controllers/management/site_pages_controller.rb
+++ b/app/controllers/management/site_pages_controller.rb
@@ -54,9 +54,20 @@ class Management::SitePagesController < ManagementController
   # DELETE /management/pages/1
   # DELETE /management/pages/1.json
   def destroy
-    return unless @site_page.deletable?
-
     site = @site_page.site
+    unless @site_page.deletable?
+      respond_to do |format|
+        format.html {
+          redirect_to(
+            {'controller' => 'management/site_pages', 'action' => 'index', 'site_slug' => site.slug},
+            {alert: 'Page cannot be destroyed.'}
+          )
+        }
+        format.json { head :no_content }
+      end
+      return
+    end
+
     @site_page.destroy
     respond_to do |format|
       format.html {

--- a/app/helpers/tree_structure_helper.rb
+++ b/app/helpers/tree_structure_helper.rb
@@ -6,15 +6,29 @@ module TreeStructureHelper
     # The hash_tree method returns a hash that for each node has a SitePage ...
     # ... as the key, and an array of hashes for values
     tree = Page.where(site_id: @site.id).select(:id, :name, :parent_id, :position, :enabled, :content_type, :show_on_menu).hash_tree
+
     return format_tree tree.keys.first, tree.values.first
   end
 
   # Formats the tree to send it to Backbone through gon
   def format_tree(node_key, node_value)
-    tree = {id: node_key.id, name: node_key.name, parent_id: node_key.parent_id,
-            position: node_key.position, enabled: node_key.enabled, content_type: node_key.content_type,
-            disableable: node_key.disableable?, deleteUrl: management_site_site_page_path(@site.slug, node_key.id),
-            editUrl: edit_management_site_site_page_page_step_path(@site.slug, node_key.id, 'position')}
+    tree = {
+      id: node_key.id,
+      name: node_key.name,
+      parent_id: node_key.parent_id,
+      position: node_key.position,
+      enabled: node_key.enabled,
+      content_type: node_key.content_type,
+      disableable: node_key.disableable?,
+      deletable: node_key.deletable?,
+      deleteUrl:
+        if node_key.deletable?
+          management_site_site_page_path(@site.slug, node_key.id)
+        else
+          nil
+        end,
+      editUrl: edit_management_site_site_page_page_step_path(@site.slug, node_key.id, 'position')
+    }
     unless node_value.blank?
       children = []
       node_value.each do |key, value|

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -24,7 +24,7 @@ class Page < ApplicationRecord
 
   belongs_to :site
   has_and_belongs_to_many :site_templates
-  has_many :page_widgets
+  has_many :page_widgets, dependent: :destroy
   has_many :widgets, through: :page_widgets, validate: false
 
   has_closure_tree order: 'position', dependent: :destroy


### PR DESCRIPTION
This PR addresses the following issue(s):
- [x] When trying to delete a page that contained widgets, the request returned a Constraint Error, now it destroys its dependencies.
- [x] When deleting a page that cannot be deleted, nothing happened, now you get a flash error saying you can't delete that page.

**TODO:**
- [x] In the site structure page, the gon should receive the deleteURL of the page only when the page is deletable or otherwise receive an attribute stating that the page is deletable or not.