### PR TITLE
Fix: mobile drawer lang select

### DIFF
--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -21,20 +21,29 @@
 
       // NOTE: Don't forget to start Backbone.history in the router
 
-      // NOTE: because there's two language selectors in the webpage, we need to maintain them in sync
-      var desktopLanguageSelector = new App.View.LanguageSelectorView();
-      var mobileDesktopLanguageSelector = new App.View.LanguageSelectorView({
-        el: '.js-language-selector-mobile',
-        useShortName: false
-      });
+      // NOTE: Translations are optional, so we only render the translation selector if some language is enabled
+      var translate = false;
+      if (gon && gon.translations) {
+        translate = Object.keys(gon.translations).some(function (elem) {
+          return gon.translations[elem];
+        });
+      }
+      if (translate) {
+        // NOTE: because there's two language selectors in the webpage, we need to maintain them in sync
+        var desktopLanguageSelector = new App.View.LanguageSelectorView();
+        var mobileDesktopLanguageSelector = new App.View.LanguageSelectorView({
+          el: '.js-language-selector-mobile',
+          useShortName: false
+        });
 
-      // Here we listen to changes in one selector and manually update the other one.
-      desktopLanguageSelector.listenTo(mobileDesktopLanguageSelector, 'state:change', function (state) {
-        this.updateCurrentLanguage(state.currentLanguage);
-      });
-      mobileDesktopLanguageSelector.listenTo(desktopLanguageSelector, 'state:change', function (state) {
-        this.updateCurrentLanguage(state.currentLanguage);
-      });
+        // Here we listen to changes in one selector and manually update the other one.
+        desktopLanguageSelector.listenTo(mobileDesktopLanguageSelector, 'state:change', function (state) {
+          this.updateCurrentLanguage(state.currentLanguage);
+        });
+        mobileDesktopLanguageSelector.listenTo(desktopLanguageSelector, 'state:change', function (state) {
+          this.updateCurrentLanguage(state.currentLanguage);
+        });
+      }
     } else {
       // eslint-disable-next-line no-console
       console.warn('The route ' + window.route + ' doesn\'t have any associated router.');

--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -21,9 +21,17 @@
 
       // NOTE: Don't forget to start Backbone.history in the router
 
-      // This component is in charge of the translation selector
-      new App.View.LanguageSelectorView();
-      new App.View.LanguageSelectorView({ el: '.js-language-selector-mobile' });
+      // NOTE: because there's two language selectors in the webpage, we need to maintain them in sync
+      var desktopLanguageSelector = new App.View.LanguageSelectorView();
+      var mobileDesktopLanguageSelector = new App.View.LanguageSelectorView({ el: '.js-language-selector-mobile' });
+
+      // Here we listen to changes in one selector and manually update the other one.
+      desktopLanguageSelector.listenTo(mobileDesktopLanguageSelector, 'state:change', function (state) {
+        this.updateCurrentLanguage(state.currentLanguage);
+      });
+      mobileDesktopLanguageSelector.listenTo(desktopLanguageSelector, 'state:change', function (state) {
+        this.updateCurrentLanguage(state.currentLanguage);
+      });
     } else {
       // eslint-disable-next-line no-console
       console.warn('The route ' + window.route + ' doesn\'t have any associated router.');

--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -23,6 +23,7 @@
 
       // This component is in charge of the translation selector
       new App.View.LanguageSelectorView();
+      new App.View.LanguageSelectorView({ el: '.js-language-selector-mobile' });
     } else {
       // eslint-disable-next-line no-console
       console.warn('The route ' + window.route + ' doesn\'t have any associated router.');

--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -23,7 +23,10 @@
 
       // NOTE: because there's two language selectors in the webpage, we need to maintain them in sync
       var desktopLanguageSelector = new App.View.LanguageSelectorView();
-      var mobileDesktopLanguageSelector = new App.View.LanguageSelectorView({ el: '.js-language-selector-mobile' });
+      var mobileDesktopLanguageSelector = new App.View.LanguageSelectorView({
+        el: '.js-language-selector-mobile',
+        useShortName: false
+      });
 
       // Here we listen to changes in one selector and manually update the other one.
       desktopLanguageSelector.listenTo(mobileDesktopLanguageSelector, 'state:change', function (state) {

--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -21,7 +21,7 @@
 
       // NOTE: Don't forget to start Backbone.history in the router
 
-      // NOTE: Translations are optional, so we only render the translation selector if some language is enabled
+      // Translations are optional, so we only render the translation selector if some language is enabled
       var translate = false;
       if (gon && gon.translations) {
         translate = Object.keys(gon.translations).some(function (elem) {

--- a/app/assets/javascripts/views/front/languageSelectorView.js
+++ b/app/assets/javascripts/views/front/languageSelectorView.js
@@ -11,7 +11,9 @@
       // { name: 'French', code: 'fr' }
       languages: [],
       // Current language (use the structure above)
-      currentLanguage: null
+      currentLanguage: null,
+      // Display the short name or not
+      useShortName: true
     },
 
     initialize: function (settings) {
@@ -128,7 +130,7 @@
           el: this.el,
           options: this._getSelectorOptions(),
           activeOption: this._getSelectorActiveOption(),
-          useShortName: true,
+          useShortName: this.options.useShortName,
           align: 'right',
           onChangeCallback: this._onLanguageChange.bind(this)
         });

--- a/app/assets/javascripts/views/front/languageSelectorView.js
+++ b/app/assets/javascripts/views/front/languageSelectorView.js
@@ -76,6 +76,10 @@
       // because Turbolinks doesn't handle well the URL changes
       // Check here: https://github.com/turbolinks/turbolinks/issues/219
       history.replaceState({ turbolinks: {} }, '', search);
+
+      this.trigger('state:change', {
+        currentLanguage: _.findWhere(this.options.languages, { code: languageCode })
+      });
     },
 
     /**
@@ -110,6 +114,12 @@
     _setMapLanguage: function (languageCode) {
       var languagePicker = document.querySelector('.app-header__language[data-lang="' + languageCode + '"]');
       if (languagePicker) languagePicker.click();
+    },
+
+    updateCurrentLanguage: function (lang) {
+      this.options.currentLanguage = lang;
+      this.dropdownSelectorView.setActive(this._getSelectorActiveOption());
+      this.dropdownSelectorView.render();
     },
 
     render: function () {

--- a/app/assets/javascripts/views/shared/dropdownSelectorView.js
+++ b/app/assets/javascripts/views/shared/dropdownSelectorView.js
@@ -216,6 +216,12 @@
       this._removeOptionsFocus();
       this.dropdown.classList.remove('-visible');
     },
+    /**
+     * Sets the Active Option object insides the this.options, not to confuse with the DOM options
+     */
+    setActive: function (active) {
+      this.options.activeOption = active;
+    },
 
     render: function () {
       this.el.innerHTML = this.template({

--- a/app/assets/stylesheets/components/front/c-header.scss
+++ b/app/assets/stylesheets/components/front/c-header.scss
@@ -153,6 +153,10 @@
       transform: translateX(100%);
 
       + .mobile-menu .hamburger-menu {
+        position: fixed;
+        top: 25px;
+        right: 30px;
+
         > div {
           &:first-of-type {
             transform: translateY(9px) rotate(-45deg);
@@ -192,9 +196,9 @@
 
           &.-active {
             background-color: $color-7;
+            opacity: 0.5;
             &::before {
-              border-top: $color-2 2px solid;
-              border-right: $color-2 2px solid;
+              display: none;
             }
           }
         }

--- a/app/assets/stylesheets/components/front/c-header.scss
+++ b/app/assets/stylesheets/components/front/c-header.scss
@@ -172,8 +172,32 @@
     }
 
     .c-dropdown-selector {
-      > ul {
+
+      > .options {
         padding: 0;
+        right: unset;
+        background-color: $color-7;
+        box-shadow: none;
+
+        &::before {
+          display: none;
+        }
+
+        > .option {
+          color: $color-2;
+
+          &:hover {
+            background-color: $color-7;
+          }
+
+          &.-active {
+            background-color: $color-7;
+            &::before {
+              border-top: $color-2 2px solid;
+              border-right: $color-2 2px solid;
+            }
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/components/front/c-header.scss
+++ b/app/assets/stylesheets/components/front/c-header.scss
@@ -180,8 +180,13 @@
       > .options {
         padding: 0;
         right: unset;
-        background-color: $color-7;
         box-shadow: none;
+
+        @if $theme == 2 {
+          background-color: $color-7;
+        } @else {
+          background-color: $color-1;
+        }
 
         &::before {
           display: none;
@@ -191,11 +196,19 @@
           color: $color-2;
 
           &:hover {
-            background-color: $color-7;
+            @if $theme == 2 {
+              background-color: $color-7;
+            } @else {
+              background-color: $color-1;
+            }
           }
 
           &.-active {
-            background-color: $color-7;
+            @if $theme == 2 {
+              background-color: $color-7;
+            } @else {
+              background-color: $color-1;
+            }
             opacity: 0.5;
             &::before {
               display: none;

--- a/app/assets/stylesheets/components/front/c-header.scss
+++ b/app/assets/stylesheets/components/front/c-header.scss
@@ -170,6 +170,12 @@
         }
       }
     }
+
+    .c-dropdown-selector {
+      > ul {
+        padding: 0;
+      }
+    }
   }
 
   > .desktop-menu {

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -30,7 +30,7 @@
         <% end -%>
       </ul>
       <ul>
-        <li class="notranslate js-language-selector-mobile"><a href="#">LANG</a></li>
+        <li class="notranslate js-language-selector-mobile"></li>
       </ul>
     </div>
   </div>

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -30,7 +30,7 @@
         <% end -%>
       </ul>
       <ul>
-        <li><a href="#">LANG</a></li>
+        <li class="notranslate js-language-selector"><a href="#">LANG</a></li>
       </ul>
     </div>
   </div>

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -30,7 +30,7 @@
         <% end -%>
       </ul>
       <ul>
-        <li class="notranslate js-language-selector"><a href="#">LANG</a></li>
+        <li class="notranslate js-language-selector-mobile"><a href="#">LANG</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This PR includes the following:
- Inits the language selector on the mobile drawer.
- Updates `DropdownSelector` to include `setActive` to its API.
- Updates `LanguageSelector` to include `updateCurrentLanguage` and `useShortName` to its API.
- Listens to changes between language selectors to maintain them in sync.
- Fixes hamburguer menu disappearing in mobile drawer when scrolling.