### PR TITLE
Breaks infinite redirect loop when login via social media or unrecognised email

### DIFF
--- a/app/assets/javascripts/views/shared/userLinksView.js
+++ b/app/assets/javascripts/views/shared/userLinksView.js
@@ -15,7 +15,8 @@
         { id: 'logout', name: 'Log out', url: null }
       ],
       // id of the active link
-      activeLink: 'user'
+      activeLink: 'user',
+      accessDenied: false
     },
 
     initialize: function (settings) {
@@ -25,6 +26,7 @@
         this.options.links[0].name = gon.global.user.name;
         this.options.links[1].url = gon.global.user.profile;
         this.options.links[2].url = gon.global.user.logout;
+        this.options.accessDenied = gon.global.user.accessDenied;
       }
 
       this.render();
@@ -39,16 +41,29 @@
       Turbolinks.visit(link.url);
     },
 
+    _renderLogout: function () {
+      var el = document.querySelector('.js-user-links');
+      el.innerHTML = '';
+      var logout = document.createElement('a');
+      logout.textContent = 'Log out';
+      logout.href = this.options.links[2].url;
+      el.appendChild(logout);
+    },
+
     render: function () {
-      new App.View.DropdownSelectorView({
-        el: '.js-user-links',
-        options: this.options.links,
-        activeOption: _.findWhere(this.options.links, { id: this.options.activeLink }),
-        fixedOption: true,
-        onChangeCallback: this._onChangeDropdown.bind(this),
-        align: 'right',
-        arrowPosition: null
-      });
+      if (!this.options.accessDenied) {
+        new App.View.DropdownSelectorView({
+          el: '.js-user-links',
+          options: this.options.links,
+          activeOption: _.findWhere(this.options.links, { id: this.options.activeLink }),
+          fixedOption: true,
+          onChangeCallback: this._onChangeDropdown.bind(this),
+          align: 'right',
+          arrowPosition: null
+        });
+      } else {
+        this._renderLogout();
+      }
     }
   });
 })(this.App));

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,7 +5,7 @@ class AdminController < ActionController::Base
   # skip_before_action :verify_authenticity_token, raise: false
   before_action :ensure_admin_user
   before_action :set_admin_base_breadcrumbs
-  before_action :set_gon
+  before_action :set_user_gon
   layout 'admin'
 
   private
@@ -16,15 +16,5 @@ class AdminController < ActionController::Base
 
   def set_admin_base_breadcrumbs
     @breadcrumbs = []
-  end
-
-  def set_gon
-    gon.global.admin = if current_user
-                         current_user.admin
-                       else
-                         false
-                       end
-
-    gon.global.user = { 'name' => current_user.name, 'profile' => edit_management_profile_path(current_user.id), 'logout' => auth_logout_url } if current_user
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def layout_by_resource
-    if @current_user && !self.is_a?(SitePageController)
+    if @current_user && !self.is_a?(SitePageController) || action_name == 'no_permissions'
       'admin'
     else
       'application'

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -2,26 +2,13 @@ class AuthController < ApplicationController
   def login
     token = params[:token]
 
-    return redirect_to_api_gateway_login if token.nil?
+    redirect_to_api_gateway_login and return if token.blank?
 
     session[:user_token] = token
 
-    connect = Faraday.new(url: "#{ENV['API_URL']}") do |faraday|
-      faraday.request :url_encoded # form-encode POST params
-      faraday.response :logger # log requests to STDOUT
-      faraday.adapter Faraday.default_adapter # make requests with Net::HTTP
+    unless ensure_logged_in
+      redirect_to_api_gateway_login and return
     end
-
-    connect.authorization :Bearer, session[:user_token]
-    response = connect.get('/auth/check-logged');
-
-    if !response.status.to_s.match(/^20/)
-      session.delete(:user_token)
-      return redirect_to_api_gateway_login
-    end
-
-    session[:current_user] = JSON.parse response.body
-    session[:api_validation_ttl] = Time.now + Rails.configuration.session_revalidate_timer
 
     # TODO: Validate the user type
     redirect_url = session.delete(:return_to)

--- a/app/controllers/management/profile_controller.rb
+++ b/app/controllers/management/profile_controller.rb
@@ -7,7 +7,7 @@ class Management::ProfileController < ManagementController
 
   def update
     if params['REMOVE'] == 'yes'
-      @user.delete_from_api(session[:user_token], session[:current_user]['id'])
+      @user.delete_from_api(session[:user_token], session[:current_user][:id])
       @user.destroy!
       redirect_to auth_logout_path
       return

--- a/app/controllers/management_controller.rb
+++ b/app/controllers/management_controller.rb
@@ -5,7 +5,7 @@ class ManagementController < ActionController::Base
 
   before_action :ensure_publish_user
   before_action :set_management_base_breadcrumbs
-  before_action :set_gon
+  before_action :set_user_gon
   layout 'management'
 
   def authenticate_user_for_site!
@@ -30,15 +30,5 @@ class ManagementController < ActionController::Base
 
   def set_management_base_breadcrumbs
     @breadcrumbs = []
-  end
-
-  def set_gon
-    gon.global.admin = if current_user
-                         current_user.admin
-                       else
-                         false
-                       end
-
-    gon.global.user = { 'name' => current_user.name, 'profile' => edit_management_profile_path(current_user.id), 'logout' => auth_logout_url } if current_user
   end
 end

--- a/app/controllers/static_page_controller.rb
+++ b/app/controllers/static_page_controller.rb
@@ -1,5 +1,7 @@
 class StaticPageController < ApplicationController
 
+  skip_before_action :set_current_user, only: [:no_permissions]
+
   # GET /no-permissions
   def no_permissions
   end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -15,4 +15,25 @@ module AuthHelper
       redirect_to_api_gateway_login
     end
   end
+
+  def ensure_logged_in
+    connect = Faraday.new(url: "#{ENV['API_URL']}") do |faraday|
+      faraday.request :url_encoded # form-encode POST params
+      faraday.response :logger # log requests to STDOUT
+      faraday.adapter Faraday.default_adapter # make requests with Net::HTTP
+    end
+    connect.authorization :Bearer, session[:user_token]
+    response = connect.get('/auth/check-logged')
+    if !response.success?
+      session.delete(:user_token)
+      session.delete(:current_user)
+      session.delete(:api_validation_ttl)
+      false
+    else
+      user_data = JSON.parse response.body
+      session[:current_user] = user_data.symbolize_keys!
+      session[:api_validation_ttl] = Time.now + Rails.configuration.session_revalidate_timer
+      true
+    end
+  end
 end


### PR DESCRIPTION
In relation to this:
https://www.pivotaltracker.com/story/show/137809425

In fact there were two conditions under which the app would enter an infinite redirect loop:
- user logged in successfully using an email address that is not registered in the CMS
- user logged in successfully with a social media account

In the first case the user is informed their account in the CMS might not be set up properly. In the latter, they are informed they should log in using their email (for that to happen, they need to log out first using the API gateway)
