### PR TITLE
Feat: dashboard dataset geo fields

### DIFF
--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -45,7 +45,11 @@
           //   type: 'chart',
           //   chart: null,
           //   x: null,
-          //   y: null
+          //   y: null,
+          //   xLabel: null,
+          //   yLabel: null,
+          //   displayMode: null,
+          //   visible: true
           // }
         ]
       }

--- a/app/assets/javascripts/routers/front/DashboardRouter.js
+++ b/app/assets/javascripts/routers/front/DashboardRouter.js
@@ -214,15 +214,17 @@
       widgets.forEach(function (widget, index) {
         var widgetContainer = document.querySelector('.js-widget-' + (index + 1));
         if (widget && widget.type === 'map') {
+          var location = {};
+          if (gon && gon.legend) {
+            location.lng = gon.legend.lng || 'longitude';
+            location.lat = gon.legend.lat || 'latitude';
+          }
           this['widget' + index] = new App.View.MapWidgetView({
             el: widgetContainer,
             data: dataset,
-            // TODO
-            // Once gon is updated, we should retrieve the real names of the fields used to position
-            // the dots
             fields: {
-              lat: 'latitude' || null,
-              lng: 'longitude' || null
+              lat: location.lat || null,
+              lng: location.lng || null
             },
             center: [widget.lat || 0, widget.lng || 0],
             zoom: widget.zoom,

--- a/app/assets/javascripts/routers/management/PreviewStepRouter.js
+++ b/app/assets/javascripts/routers/management/PreviewStepRouter.js
@@ -196,15 +196,17 @@
       var widgets = this._getDashboardWidgets();
       widgets.forEach(function (widget, index) {
         if (widget.type === 'map') {
+          var location = {};
+          if (gon && gon.legend) {
+            location.lng = gon.legend.lng || 'longitude';
+            location.lat = gon.legend.lat || 'latitude';
+          }
           this['widget' + index] = new App.View.MapWidgetView({
             el: document.querySelector('.js-widget-' + (index + 1)),
             data: dataset,
-            // TODO
-            // Once gon is updated, we should retrieve the real names of the fields used to position
-            // the dots
             fields: {
-              lat: 'latitude' || null,
-              lng: 'longitude' || null
+              lat: location.lat || null,
+              lng: location.lng || null
             },
             center: [widget.lat, widget.lng],
             zoom: widget.zoom,
@@ -253,15 +255,17 @@
       // We remove all the listeners
       this._removeListeners();
       if (type === 'map') {
+        var location = {};
+        if (gon && gon.legend) {
+          location.lng = gon.legend.lng || 'longitude';
+          location.lat = gon.legend.lat || 'latitude';
+        }
         this['widget' + index] = new App.View.MapWidgetView({
           el: widgetContainer,
           data: dataset,
-          // TODO
-          // Once gon is updated, we should retrieve the real names of the fields used to position
-          // the dots
           fields: {
-            lat: 'latitude' || null,
-            lng: 'longitude' || null
+            lat: location.lat || null,
+            lng: location.lng || null
           },
           switchCallback: function () {
             this._switchWidget(index, 'chart');

--- a/app/assets/javascripts/routers/management/VisualizationStepRouter.js
+++ b/app/assets/javascripts/routers/management/VisualizationStepRouter.js
@@ -72,7 +72,7 @@
           parsedChart = JSON.parse(gon.visualization);
           if (parsedChart.type !== 'chart') {
             var chart = Object.assign({}, parsedChart, { type: 'chart', chart: parsedChart.type});
-            return chart
+            return chart;
           }
         }
         return parsedChart;


### PR DESCRIPTION
This PR includes the following:
- Reads the geo location fields of the dataset, provided by gon's legend prop.
- Renders the dashboard's map widgets with the provided geo field in management and front.