### PR TITLE
Fixed condition used to check if settings need initializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix issue with missing "style" options on site settings
 - Prepend protocol to site links on admin interface
 
 ### 18 April 2017

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -132,7 +132,7 @@ class SiteSetting < ApplicationRecord
 
   # Creates all the additional settings for a site
   def self.create_additional_settings site
-    unless site.site_settings.length > 1
+    unless site.site_settings.exists?(name: 'logo_image')
       site.site_settings.new(name: 'logo_image', value: '', position: 2)
       site.site_settings.new(name: 'main_image', value: '', position: 5)
       site.site_settings.new(name: 'alternative_image', value: '', position: 6)


### PR DESCRIPTION
This affected sites where no settings were set in the `style` step when creating the site. Upon editing, the style step was a blank page.