### PR TITLE
Fix for populating the list of values for float and text fields

### DIFF
--- a/app/controllers/management/widget_steps_controller.rb
+++ b/app/controllers/management/widget_steps_controller.rb
@@ -181,8 +181,9 @@ class Management::WidgetStepsController < ManagementController
 
   def get_fields
     @fields = @widget.get_fields
-    @fields.each { |f| f[:type] = 'number' if %w[double long int].any? {|x| f[:type].downcase.include?(x)} }
-    @fields.each { |f| f[:type] = 'date' if f[:type].downcase.include?('date')}
+    @fields.each { |f| f[:type] = 'number' if %w[double long int float].any? { |x| f[:type].downcase == x } }
+    @fields.each { |f| f[:type] = 'string' if %w[string text].any? { |x| f[:type].downcase == x } }
+    @fields.each { |f| f[:type] = 'date' if f[:type].downcase == 'date' }
   end
 
   def set_widget_state

--- a/app/services/dataset_service.rb
+++ b/app/services/dataset_service.rb
@@ -128,7 +128,7 @@ class DatasetService
     string_datasets = {}
 
     fields.select { |f| DatasetFieldsHelper.is_string?(f[:type]) }.each do |field|
-      query = "select count(#{field[:name]}), #{field[:name]} from #{api_table_name} group by #{field[:name]}"
+      query = "select #{field[:name]} from #{api_table_name} group by #{field[:name]}"
       string_datasets[field[:name]] = get_filtered_dataset(dataset_id, query)
     end
 


### PR DESCRIPTION
Fixes an issue with `float` and `text` fields types when creating widgets. When selected in the list of columns, no dropdowns / inputs would appear to select from existing values, because those data types were previously not mapped to the numeric & string types in the CMS.