### PR TITLE
Fix for page positions off by one

### DIFF
--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -32,7 +32,8 @@ class SitePage < Page
   validates :url, uniqueness: {scope: :site}, unless: 'content_type.eql?(nil) || content_type.eql?(ContentType::LINK)'
   validates :uri, uniqueness: {scope: :site}, unless: 'content_type.eql?(nil) || content_type.eql?(ContentType::LINK)'
   validates_presence_of :site_id
-  before_save :cheat_with_position
+  before_create :cheat_with_position_on_create
+  before_update :cheat_with_position_on_update
   after_save :update_routes
 
   validate :step_validation
@@ -171,8 +172,16 @@ class SitePage < Page
 
   end
 
-  def cheat_with_position
+  def cheat_with_position_on_create
     if self.position.present?
+      siblings.where('position >= ?', self.position).update_all('position = position + 1')
+    end
+  end
+
+  def cheat_with_position_on_update
+    if self.position > self.position_was
+      siblings.where('position <= ?', self.position).update_all('position = position - 1')
+    else
       siblings.where('position >= ?', self.position).update_all('position = position + 1')
     end
   end

--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -32,6 +32,7 @@ class SitePage < Page
   validates :url, uniqueness: {scope: :site}, unless: 'content_type.eql?(nil) || content_type.eql?(ContentType::LINK)'
   validates :uri, uniqueness: {scope: :site}, unless: 'content_type.eql?(nil) || content_type.eql?(ContentType::LINK)'
   validates_presence_of :site_id
+  before_save :cheat_with_position
   after_save :update_routes
 
   validate :step_validation
@@ -168,5 +169,11 @@ class SitePage < Page
 
     end
 
+  end
+
+  def cheat_with_position
+    if self.position.present?
+      siblings.where('position >= ?', self.position).update_all('position = position + 1')
+    end
   end
 end


### PR DESCRIPTION
Adjust position of siblings who follow or precede the inserted / moved node before closure_tree updates all positions and messes up the order.

https://www.pivotaltracker.com/story/show/136244263