### PR TITLE
Include datasets registered for "prep" application

### DIFF
--- a/app/services/dataset_service.rb
+++ b/app/services/dataset_service.rb
@@ -14,7 +14,7 @@ class DatasetService
   # ++status++ the status of the dataset
   def self.get_datasets(status = 'saved')
     datasetRequest = @conn.get '/dataset', {'page[number]': '1', 'page[size]': '10000', \
-      'status': status, 'application': 'forest-atlas,gfw', '_': Time.now.to_f}
+      'status': status, 'application': 'forest-atlas,gfw,prep', '_': Time.now.to_f}
     datasetsJSON = JSON.parse datasetRequest.body
     datasets = []
 


### PR DESCRIPTION
Fixes https://basecamp.com/1756858/projects/12384525/todos/306054528

Some datasets were probably registered in the early days for an application called "prep". The list of datasets available for widget / dashboard creation is filtered by application name, currently "forest-atlas". The easiest thing to do was to include the "prep" application in the filter.