### PR TITLE
Fix/impossible to specify values for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Reorder dataset metadata fields
 - Configure dataset metadata fields for sorting
 - Fix issue preventing images thumbnails from being displayed in site settings
+- Widget filters for arcgis datasets: fix retrieving count of rows & fix displaying value dropdowns
 
 ### 30 May 2017
 - Fix issue where site page listing would not show all pages

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -109,16 +109,16 @@ class Widget < ApplicationRecord
   def get_row_count
     result = get_filtered_dataset true
 
-    if result['data'].kind_of?(Array)
-      count = result['data'].first.values.first
+    if result['data'].is_a?(Array) && result['data'].first.is_a?(Hash)
+      result['data'].first.values.first
+    elsif result['data'].is_a?(Array)
+      result['data'].first
     elsif result['data'].is_a?(Hash)
-      count = result['data'].values.first
+      result['data'].values.first
     else
       Rails.logger.debug 'Widget.get_row_count - Expected hash or array, got ' + result.inspect
-      count = 0
+      0
     end
-
-    return count
   end
 
   # Gets a preview of the results

--- a/app/services/dataset_service.rb
+++ b/app/services/dataset_service.rb
@@ -69,7 +69,7 @@ class DatasetService
     else
       result = JSON.parse filteredRequest.body
       result['data'] = result['data'].collect do |elem|
-        elem.delete('_id')
+        elem.delete('_id') if elem.is_a?(Hash)
         elem
       end
 

--- a/app/services/dataset_service.rb
+++ b/app/services/dataset_service.rb
@@ -165,6 +165,7 @@ class DatasetService
             field[:values] = data.map{|x| x[field[:name]]}
           end
       end
+      field[:type] = DatasetFieldsHelper.parse(field[:type])
     end
     fields
   end


### PR DESCRIPTION
Fixes 2 issues in the widget filters page:
- retrieving row count would trigger an exception because the response format was different than expected;
- field types sent to frontend were given as original types rather than simplified (string, number, date), which prevented from rendering value dropdowns