### PR TITLE
If site setting does not exist, create it to save uploaded images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix issue preventing logo files and other site images to be uploaded
+
 ### 11 July 2017
 - Update MapBuilder default version to 1.1.12
 

--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -177,7 +177,7 @@ class Admin::SiteStepsController < AdminController
           # If the user is editing
           if @site.id
             settings[:site_settings_attributes].values.each do |attrs|
-              site_setting = @site.site_settings.find_by_name(attrs['name']) if attrs['name'].present?
+              site_setting = @site.site_settings.find { |s| s.name == attrs['name'] } if attrs['name'].present?
               if site_setting
                 site_setting.assign_attributes(attrs)
               else

--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -176,15 +176,23 @@ class Admin::SiteStepsController < AdminController
         begin
           # If the user is editing
           if @site.id
-            @site.site_settings.each do |site_setting|
-              setting = settings[:site_settings_attributes].values.select { |s| s['id'] == site_setting.id.to_s }
-              site_setting.assign_attributes setting.first.except('id', 'position', 'name') if setting.any?
+            settings[:site_settings_attributes].values.each do |attrs|
+              site_setting = @site.site_settings.find_by_name(attrs['name']) if attrs['name'].present?
+              if site_setting
+                site_setting.assign_attributes(attrs)
+              else
+                @site.site_settings.build(attrs)
+              end
             end
             # If the user is creating a new site
           else
             settings[:site_settings_attributes].map { |s| @site.site_settings.build(s[1]) }
             @site.form_step = 'style'
           end
+        rescue => e
+          Rails.logger.error e.class
+          Rails.logger.error e.message
+          e.backtrace.each { |l| Rails.logger.error l }
         end
 
         if save_button?


### PR DESCRIPTION
The issue: user uploads images (logo, cover) and those don't get saved\
Reason: relevant site settings don't exist; validation rules prevent from saving a site setting with empty value for images
Solution: just create those settings on demand if user uploads images

Also, added a `rescue` to the surely well-intentioned `begin`.