### PR TITLE
Migrate the StepsBar component to React

### DIFF
--- a/app/assets/stylesheets/components/shared/c-steps-bar.scss
+++ b/app/assets/stylesheets/components/shared/c-steps-bar.scss
@@ -11,11 +11,18 @@
     border: 1px solid rgba($color-2, .3);
     border-radius: 40px;
 
-    a {
+    a,
+    button {
       display: block;
       padding: 0 25px;
       color: $color-3;
       line-height: 27px;
+      background: transparent;
+      border: 0;
+      appearance: none;
+      font-family: $font-family-1;
+      font-size: $font-size-normal;
+      cursor: pointer;
 
       &.-active {
         border-radius: 40px;

--- a/app/javascript/components/StepsBar.js
+++ b/app/javascript/components/StepsBar.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+function StepsBar(props) {
+  return (
+    <div className="c-steps-bar">
+      <div className="wrapper">
+        <ul className="steps">
+          {props.steps.map((step, i) => (
+            <li key={step}>
+              <button
+                className={classnames({
+                  '-active': i === props.currentStep,
+                  '-disabled': i > props.currentStep
+                })}
+                tabIndex={i >= props.currentStep ? '0' : '-1'}
+                onClick={() => ((i < props.currentStep) ? props.onChangeStep(i) : null)}
+              >
+                {step}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+StepsBar.propTypes = {
+  /**
+   * Index of the current step
+   */
+  currentStep: PropTypes.number,
+  /**
+   * List of the steps names
+   */
+  steps: PropTypes.arrayOf(PropTypes.string).isRequired,
+  /**
+   * Callback executed when the user clicks on another
+   * step
+   */
+  onChangeStep: PropTypes.func.isRequired // eslint-disable-line react/no-unused-prop-types
+};
+
+StepsBar.defaultProps = {
+  currentStep: 0
+};
+
+export default StepsBar;


### PR DESCRIPTION
This PR adds a new React component ,`StepsBar`, based on the HTML/Rails component we've been using.

The user has the possibility to click on the previous steps to go back to them but not to jump forward.

![Example of steps](https://user-images.githubusercontent.com/6073968/39316056-249b2798-4970-11e8-92af-442756eb5740.png)

PS: this component will be used in the widget creation.