### PR TITLE
Bug/table component

### DIFF
--- a/app/javascript/components/admin/table/TableActions.js
+++ b/app/javascript/components/admin/table/TableActions.js
@@ -1,76 +1,76 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-// Any action we accept for the table, add it here, otherwise it will be ignored
-export default ({ data, actions, showRowInfo }) => {
-  return actions.map((action, k) => {
-    if (action === 'toggle' &&
-        'enable' in data &&
-        'enabled' in data &&
-        data.enable.value !== null) {
-      return (
-        <td key={k}>
-          <span className="row-content">
-            <a
-              href="/management/sites/base-site/site_pages/17/toggle_enable"
-              className={`c-table-action-button -${data.enabled.value ? 'disable' : 'enable'}`}
-              title={data.enabled.value ? 'Disable' : 'Enable'}
-              rel="noreferrer noopener"
-              data-method="put"
-            >
-              {data.enabled.value ? 'Disable' : 'Enable'}
-            </a>
-          </span>
-        </td>);
-    }
+const TableActions = ({ data, actions, onClickAction }) => actions.map((action) => {
+  if (action === 'toggle' && 'enable' in data && 'enabled' in data && data.enable.value !== null) {
+    return (
+      <td key={action}>
+        <span className="row-content">
+          <button
+            type="button"
+            className={`c-table-action-button -${data.enabled.value ? 'disable' : 'enable'}`}
+            title={data.enabled.value ? 'Disable' : 'Enable'}
+            onClick={() => onClickAction(action, data)}
+          >
+            {data.enabled.value ? 'Disable' : 'Enable'}
+          </button>
+        </span>
+      </td>);
+  }
 
-    if (action === 'edit' && 'edit' in data) {
-      return (
-        <td key={k}>
-          <span className="row-content">
-            <a
-              href={data.edit.value}
-              className="c-table-action-button -edit"
-              title="Edit"
-            >Edit
-            </a>
-          </span>
-        </td>);
-    }
+  if (action === 'edit') {
+    return (
+      <td key={action}>
+        <span className="row-content">
+          <button
+            type="button"
+            className="c-table-action-button -edit"
+            title="Edit"
+            onClick={() => onClickAction(action, data)}
+          >
+            Edit
+          </button>
+        </span>
+      </td>);
+  }
 
-    if (action === 'delete' &&
-        'delete' in data &&
-        data.delete.value !== null) {
-      return (
-        <td key={k}>
-          <span className="row-content">
-            <a
-              href={data.delete.value}
-              className="c-table-action-button -delete js-confirm"
-              title="Delete"
-              rel="nofollow"
-              data-method="delete"
-            >Delete
-            </a>
-          </span>
-        </td>);
-    }
+  if (action === 'delete') {
+    return (
+      <td key={action}>
+        <span className="row-content">
+          <button
+            type="button"
+            className="c-table-action-button -delete"
+            title="Delete"
+            onClick={() => onClickAction(action, data)}
+          >
+            Delete
+          </button>
+        </span>
+      </td>);
+  }
 
-    if (/info/.test(action)) {
-      const splt = action.split('.');
-      const showInfoOn = splt[1];
-      if (showInfoOn && showInfoOn in data && data[showInfoOn].value !== null) {
-        return (
-          <td key={k}>
-            <button
-              type="button"
-              onClick={() => showRowInfo(data[showInfoOn])}
-              className="c-table-action-button -info js-metadata-info"
-            >Info
-            </button>
-          </td>);
-      }
-    }
+  if (action === 'info') {
+    return (
+      <td key={action}>
+        <button
+          type="button"
+          className="c-table-action-button -info js-metadata-info"
+          onClick={() => onClickAction(action, data)}
+        >
+          Info
+        </button>
+      </td>
+    );
+  }
 
-    return <td key={k}>-</td>;
-  });
+  return null;
+});
+
+TableActions.propTypes = {
+  data: PropTypes.object.isRequired,
+  actions: PropTypes.array.isRequired,
+  onClickAction: PropTypes.func.isRequired
 };
+
+export default TableActions;

--- a/app/javascript/components/admin/table/TableFooter.js
+++ b/app/javascript/components/admin/table/TableFooter.js
@@ -43,7 +43,7 @@ export default ({ pages, pagination, offsetPage, setRowsPerPage }) => {
           Previous page
         </button>
 
-        {pagination.page} of {pagination.pages + 1}
+        {pagination.page} of {pagination.pages}
 
         <button
           type="button"

--- a/app/javascript/components/admin/table/index.js
+++ b/app/javascript/components/admin/table/index.js
@@ -77,7 +77,14 @@ class Table extends React.Component {
   }
 
   onSearch(e) {
-    this.setState({ q: e.target.value });
+    this.setState({
+      q: e.target.value,
+      pagination: {
+        ...this.state.pagination,
+        offset: 0,
+        page: 1
+      }
+    });
   }
 
 
@@ -272,7 +279,12 @@ class Table extends React.Component {
         </table>
 
         <TableFooter
-          pagination={pagination}
+          pagination={{
+            ...pagination,
+            pages: filteredResults
+              ? Math.ceil(filteredResults.length / pagination.limit)
+              : pagination.pages
+          }}
           offsetPage={p => this.offsetPage(p)}
           setRowsPerPage={e => this.setRowsPerPage(e)}
         />
@@ -302,9 +314,13 @@ Table.propTypes = {
    */
   limit: PropTypes.number,
   /**
+   * Whether the user can search text in the table
+   */
+  searchable: PropTypes.bool,
+  /**
    * Data to display in the table
-   * Each row contains several columns with their value,
-   * an attribute to tell if the column can be searchable and another to tell if it's sortable
+   * Each row contains several columns with their value and
+   * an attribute to tell if the column can be sortable
    * NOTE: The name of the columns must be in lowercase
    * NOTE: the data will always be sorted ASC by the first column
    * The value attribute can have an array of strings
@@ -313,8 +329,8 @@ Table.propTypes = {
    * An example of the format can be:
    * [
    *   {
-   *     name: { value: '$3', searchable: true },
-   *     description: { value: ['Spain', 'France'], searchable: true, sortable: false },
+   *     name: { value: '$3' },
+   *     description: { value: ['Spain', 'France'], sortable: false },
    *     price: { value: 'iPhone 6', link: { url: 'https://www.apple.com', external: true }, searchable: false }
    *   }
    * ]
@@ -332,7 +348,8 @@ Table.propTypes = {
 };
 
 Table.defaultProps = {
-  limit: 10
+  limit: 10,
+  searchable: false
 };
 
 export default Table;

--- a/app/javascript/components/admin/table/index.js
+++ b/app/javascript/components/admin/table/index.js
@@ -35,7 +35,7 @@ class Table extends React.Component {
         limit: props.limit,
         page: 1,
         offset: 0,
-        pages: parseInt(props.data.length / props.limit)
+        pages: Math.ceil(props.data.length / props.limit)
       }
     };
 
@@ -52,8 +52,15 @@ class Table extends React.Component {
   }
 
   setRowsPerPage(e) {
-    const pagination = { ...this.state.pagination, limit: parseInt(e.target.value) };
-    this.setState({ pagination })
+    const pagination = {
+      ...this.state.pagination,
+      limit: parseInt(e.target.value),
+      pages: Math.ceil(this.props.data.length / parseInt(e.target.value)),
+      page: 1,
+      offset: 0
+    };
+
+    this.setState({ pagination });
   }
 
   offsetPage(p) {

--- a/app/javascript/components/admin/table/index.js
+++ b/app/javascript/components/admin/table/index.js
@@ -32,10 +32,10 @@ class Table extends React.Component {
       columns: cols,
       // when / if we get dynamic pagination, use that information instead
       pagination: {
-        limit: props.limit || 10,
+        limit: props.limit,
         page: 1,
         offset: 0,
-        pages: parseInt(props.data.length / (props.limit || 10))
+        pages: parseInt(props.data.length / props.limit)
       }
     };
 
@@ -192,11 +192,50 @@ class Table extends React.Component {
   }
 }
 
+/* eslint-disable max-len */
+/**
+ * Definition of a row
+ * @typedef {{ [column: string]: { value?: any, searchable?: boolean, sortable?: boolean, link?: { url: string, external: boolean }, method?: string } }}  Row
+ */
+/* eslint-enable max-len */
+
 Table.propTypes = {
+  /**
+   * Number of results per page
+   */
   limit: PropTypes.number,
-  data: PropTypes.array.isRequired,
-  columns: PropTypes.array.isRequired,
+  /**
+   * Data to display in the table
+   * Each row contains several columns with their value,
+   * an attribute to tell if the column can be searchable and another to tell if it's sortable
+   * NOTE: The name of the columns must be in lowercase
+   * NOTE: the data will always be sorted ASC by the first column
+   * The value attribute can have an array of strings
+   * An optional link attribute can be present, it contains its url and an attribute to tell
+   * if the link is external or not (this is not built for multi-value cells)
+   * An example of the format can be:
+   * [
+   *   {
+   *     name: { value: '$3', searchable: true },
+   *     description: { value: ['Spain', 'France'], searchable: true, sortable: false },
+   *     price: { value: 'iPhone 6', link: { url: 'https://www.apple.com', external: true }, searchable: false }
+   *   }
+   * ]
+   * @type {Row[]} data
+   */
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /**
+   * Name of the columns
+   * Make sure the name matches one attribute of the
+   * rows (case insensitive)
+   */
+  columns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // TODO: document
   actions: PropTypes.array.isRequired
+};
+
+Table.defaultProps = {
+  limit: 10
 };
 
 export default Table;


### PR DESCRIPTION
This PR fixes a couple of bugs with the table component:
- the user wouldn't see the last page of rows
- the pagination wouldn't work when changing the number of results per page
- the pagination wouldn't work when searching

It also brings back the sorting feature: each column can be sortable or not, document the props of the main component.

Note that the following changes might be breaking for pages that are using the component:
- a table name (prop `name`) is now required (brought back with the sorting feature)
- the actions are not hardcoded anymore but trigger a callback (prop `onClickAction`)