### PR TITLE
Widgets fixes

### DIFF
--- a/app/assets/stylesheets/components/management/c-add-widgets.scss
+++ b/app/assets/stylesheets/components/management/c-add-widgets.scss
@@ -1,0 +1,41 @@
+.fa-add-widget {
+  padding: 20px 30px;
+
+  h3 {
+    font-size: 34px;
+    font-weight: 300;
+    line-height: 1;
+    margin: 20px 0;
+  }
+
+  ul {
+    list-style: none;
+    width: 100%;
+  }
+
+  li {
+    display: block;
+    position: relative;
+    border-bottom: 1px solid #e8e8e8; &:last-child { border-bottom: 1px solid transparent; }
+    padding: 10px 0;
+
+    h4 {
+      display: inline-block;
+      max-width: calc(100% - 80px);
+    }
+
+    button {
+      position: absolute;
+      right: 0;
+      transform: translateY(-50%);
+      top: 50%;
+      border: none;
+      padding: 10px 20px;
+      background: #6faf3a;
+      color: #FFF;
+      font-size: 16px;
+      cursor: pointer;
+      border-radius: 30px;    }
+
+  }
+}

--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -61,6 +61,13 @@ class Management::PageStepsController < ManagementController
       when 'position'
         assign_position
       when 'title'
+        @widgets = WidgetService.get_widgets
+        @widgets = @widgets.map do |x|
+          { widget: x,
+            edit_url: edit_management_site_widget_step_path(params[:site_slug], x.id),
+            delete_url: management_site_widget_step_path(params[:site_slug], x.id) }
+        end
+        @widgets
       when 'type'
       when 'dataset'
         @datasets_contexts = @site.get_datasets_contexts

--- a/app/controllers/static_page_controller.rb
+++ b/app/controllers/static_page_controller.rb
@@ -9,16 +9,12 @@ class StaticPageController < ApplicationController
   # Gets the data of a widget
   # GET widget_data
   def widget_data
-    widget = Widget.find(params[:widget_id])
-    data = widget.get_filtered_dataset false, 10000
-    metadata = Dataset.get_metadata_for_frontend(session[:user_token], widget.dataset_id)
+    widget = WidgetService.widget(params[:widget_id])
     render json: {
       id: widget.id,
-      visualization: widget.visualization,
+      visualization: widget.widget_config,
       name: widget.name,
-      description: widget.description,
-      data: data['data'],
-      metadata: metadata
+      description: widget.description
     }
   end
 end

--- a/app/javascript/components/wysiwyg/WidgetBlock.js
+++ b/app/javascript/components/wysiwyg/WidgetBlock.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { VegaChart, getVegaTheme } from 'widget-editor';
+
+// /widget_data.json?widget_id=
+class WidgetBlock extends React.Component {
+  constructor(props) {
+    super(props);
+    this.widgetConfig = null;
+    this.state = {
+      loading: true,
+      widget: null
+    };
+  }
+  componentWillMount() {
+    const { item } = this.props;
+    this.getChart(item.content.widgetId);
+  }
+  getChart(widgetId) {
+    fetch(`${window.location.origin}/widget_data.json?widget_id=${widgetId}`).then((res) => {
+      return res.json();
+    }).then((widget) => {
+      this.setState({
+        loading: false,
+        widget
+      });
+    });
+  }
+  render() {
+    if (this.state.loading) { return null; }
+    return (
+      <VegaChart
+        data={this.state.widget.visualization}
+        theme={getVegaTheme()}
+        reloadOnResize
+      />
+    );
+  }
+}
+
+WidgetBlock.propTypes = {
+  item: PropTypes.object.isRequired
+};
+
+export default WidgetBlock;

--- a/app/javascript/components/wysiwyg/WidgetBlockCreation.js
+++ b/app/javascript/components/wysiwyg/WidgetBlockCreation.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function WidgetBlockCreation({ block, onSubmit }) {
+  const { widgets } = block.admin;
+  return (
+    <div className="fa-add-widget">
+      <h3>Select a widget</h3>
+      <ul>
+        {widgets.map((w) => {
+          return (
+            <li key={w.widget.name}>
+              <h4>{w.widget.name}</h4>
+              <button onClick={() => onSubmit({
+                widgetId: w.widget.id,
+                datasetId: w.widget.dataset,
+                categories: []
+              })}
+              >Add widget
+              </button>
+            </li>);
+        })}
+      </ul>
+    </div>
+  );
+}
+
+WidgetBlockCreation.propTypes = {
+
+};

--- a/app/javascript/components/wysiwyg/index.js
+++ b/app/javascript/components/wysiwyg/index.js
@@ -1,0 +1,2 @@
+export { default as WidgetBlock } from 'components/wysiwyg/WidgetBlock';
+export { default as WidgetBlockCreation } from 'components/wysiwyg/WidgetBlockCreation';

--- a/app/javascript/pages/admin/edit-dashboard.js
+++ b/app/javascript/pages/admin/edit-dashboard.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 
 import Wysiwyg from 'vizz-wysiwyg';
 
+import { WidgetBlock, WidgetBlockCreation } from 'components/wysiwyg';
+
 const EditDashboard = ({ admin }) => (
   <div className="l-page-list">
     <div className="wrapper">
@@ -15,6 +17,16 @@ const EditDashboard = ({ admin }) => (
           const el = document.getElementById('site_page_content');
           if (el) {
             el.value = JSON.stringify(d);
+          }
+        }}
+        blocks={{
+          widget: {
+            Component: WidgetBlock,
+            EditionComponent: WidgetBlockCreation,
+            admin,
+            icon: 'icon-widget',
+            label: 'Visualization',
+            renderer: 'modal'
           }
         }}
       />

--- a/app/views/management/page_steps/title.html.erb
+++ b/app/views/management/page_steps/title.html.erb
@@ -47,7 +47,8 @@
   <% if @page.dashboard_version > 1 %>
     <!-- New dashboards will have the content with the new fancy wysiwyg editor -->
     <%= react_component('EditDashboardPage', {
-      page: @page
+      page: @page,
+      widgets: @widgets
     } ) %>
     <%= f.hidden_field :content %>
   <% end %>


### PR DESCRIPTION
1. New wysiwyg renders the widget editor created widgets! and supports the vega3 syntax
2. Widget output now changed, also supporting widget editor syntax

![screen shot 2018-05-07 at 12 46 02](https://user-images.githubusercontent.com/971129/39698309-a2403d32-51f4-11e8-8a72-7facc2cb2a90.png)

New option added to wysiwyg
![screen shot 2018-05-07 at 12 47 17](https://user-images.githubusercontent.com/971129/39698360-d08b5604-51f4-11e8-8d1c-34b9da85eecb.png)

List of widgets you can select, based on the new widget editor
![screen shot 2018-05-07 at 12 47 46](https://user-images.githubusercontent.com/971129/39698375-dfe894a4-51f4-11e8-8f25-3f8e5d13e40a.png)

