### PR TITLE
fix open content pages, dont use OpenStruct`s

### DIFF
--- a/app/javascript/pages/static.js
+++ b/app/javascript/pages/static.js
@@ -8,7 +8,7 @@ import { CoverPage, WysiwygEditor, Footer } from 'components';
 const StaticPage = ({ site }) => (
   <div className="fa-page">
     <CoverPage site={site} secondary />
-    <WysiwygEditor content={JSON.parse(site.page.content.json)} />
+    <WysiwygEditor content={JSON.parse(site.page.content)} />
     <Footer site={site} />
   </div>
 );

--- a/app/views/management/page_steps/open_content.html.erb
+++ b/app/views/management/page_steps/open_content.html.erb
@@ -20,13 +20,13 @@
 
       <div class="wrapper">
         <div class="c-wysiwyg">
-          <%= f.fields_for :content, OpenStruct.new(@page.content) do |ff| %>
+          <%= f.fields_for :content, @page.content do |ff| %>
             <div class="js-content">
               <% unless params[:page_id] %>
                 <p><em>Write here the content of the page.</em></p>
               <% end %>
             </div>
-            <%= ff.hidden_field :json, class: 'js-json-content' %>
+            <%= f.hidden_field :content, class: 'js-json-content' %>
           <% end %>
         </div>
       </div>

--- a/app/views/management/page_steps/open_content_preview.html.erb
+++ b/app/views/management/page_steps/open_content_preview.html.erb
@@ -5,7 +5,7 @@
 <div class="c-content">
   <div class="wrapper">
     <div class="js-content"></div>
-    <input type="hidden" class="js-json-content" value="<%= OpenStruct.new(@page.content).json unless @page.content.blank? || OpenStruct.new(@page.content).json.blank? %>" />
+    <input type="hidden" class="js-json-content" value="<%= @page.content %>" />
   </div>
 </div>
 

--- a/app/views/site_page/open_content.html.erb
+++ b/app/views/site_page/open_content.html.erb
@@ -9,6 +9,3 @@
   pageSize: defined?(size) ? size : nil
 } ) %>
 
-<script type="text/javascript">
-  window.route = 'OpenContent';
-</script>


### PR DESCRIPTION
No more open_structs, we simply store the json inside the DB as strings, also fix for broken save content method, for old logic

these broke because we changed the way we manage the content field.

```
// Old
<%= ff.hidden_field :json, class: 'js-json-content' %>
// NEW
<%= f.hidden_field :content, class: 'js-json-content' %>
```

need to make sure the old fields work as expected, as they might use the old `json` key structure