### PR TITLE
bugfix - tables not showing sometimes on admin pages

### DIFF
--- a/app/assets/javascripts/routers/management/DatasetStepRouter.js
+++ b/app/assets/javascripts/routers/management/DatasetStepRouter.js
@@ -26,7 +26,7 @@
           App.Helper.Notifications.page.datasetRegistration,
           {
             continueCallback: function () {
-              Turbolinks.visit(e.target.href);
+              window.location.href = e.target.href;
             }
           }
         ));

--- a/app/assets/javascripts/views/shared/quickLinksView.js
+++ b/app/assets/javascripts/views/shared/quickLinksView.js
@@ -59,7 +59,7 @@
      */
     _onChangeDropdown: function (id) {
       var link = _.findWhere(this.options.links, { id: id });
-      Turbolinks.visit(link.url);
+      window.location.href = link.url;
     },
 
     /**

--- a/app/assets/javascripts/views/shared/tabView.js
+++ b/app/assets/javascripts/views/shared/tabView.js
@@ -83,7 +83,7 @@
     _toggleTab: function (index, focus) {
       if (this.options.redirect) {
         var url = this.options.tabs[index].url;
-        Turbolinks.visit(url);
+        window.location.href = url;
       } else {
         this.options.currentTab = index;
         this._cleanTabs();

--- a/app/assets/javascripts/views/shared/userLinksView.js
+++ b/app/assets/javascripts/views/shared/userLinksView.js
@@ -38,7 +38,7 @@
      */
     _onChangeDropdown: function (id) {
       var link = _.findWhere(this.options.links, { id: id });
-      Turbolinks.visit(link.url);
+      window.location.href = link.url;
     },
 
     _renderLogout: function () {

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -1,7 +1,9 @@
 <div class="c-header-admin -bright">
   <div class="wrapper">
     <div>
+
     <div class="quick-links js-quick-links"></div>
+
       <% unless @breadcrumbs.blank? %>
           <ul class="breadcrumbs">
             <% @breadcrumbs.each do |breadcrumb| -%>

--- a/app/views/management/_header.html.erb
+++ b/app/views/management/_header.html.erb
@@ -2,6 +2,7 @@
   <div class="wrapper">
     <div>
       <div class="quick-links js-quick-links"></div>
+
       <% unless @breadcrumbs.blank? %>
           <ul class="breadcrumbs">
             <% @breadcrumbs.each do |breadcrumb| -%>


### PR DESCRIPTION
Turbolinks causes the tables to not render, this makes sure we do a full reload, so webpacker can trigger react at all times. 