### PR TITLE
move RW wysiwg logic, new dashboard layout for admin preview

### DIFF
--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -262,22 +262,25 @@ class Management::PageStepsController < ManagementController
     # TODO: To have different permissions for different steps
     all_options = params.require(:site_page)
                         .fetch(:content, nil).try(:permit!)
-    params.require(:site_page).permit(
-      :name,
-      :description,
-      :position,
-      :uri,
-      :show_on_menu,
-      :parent_id,
-      :content_type,
-      :content,
-      dataset_setting: [
-        :dataset_id,
-        :filters,
-        :widgets,
-        visible_fields: []
-      ]
-    ).merge(content: all_options)
+    filtered_params =
+      params.require(:site_page).permit(
+        :name,
+        :description,
+        :position,
+        :uri,
+        :show_on_menu,
+        :parent_id,
+        :content_type,
+        :content,
+        dataset_setting: [
+          :dataset_id,
+          :filters,
+          :widgets,
+          visible_fields: []
+        ]
+      )
+    filtered_params.merge(content: all_options) if all_options.present?
+    filtered_params
   end
 
   # Sets the current site from the url

--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -61,13 +61,6 @@ class Management::PageStepsController < ManagementController
       when 'position'
         assign_position
       when 'title'
-        @widgets = WidgetService.get_widgets
-        @widgets = @widgets.map do |x|
-          { widget: x,
-            edit_url: edit_management_site_widget_step_path(params[:site_slug], x.id),
-            delete_url: management_site_widget_step_path(params[:site_slug], x.id) }
-        end
-        @widgets
       when 'type'
       when 'dataset'
         @datasets_contexts = @site.get_datasets_contexts
@@ -112,6 +105,14 @@ class Management::PageStepsController < ManagementController
         gon.analysis_timestamp = @dataset_setting.fields_last_modified
         gon.legend = @dataset_setting.legend.blank? ? {} : @dataset_setting.parsed_legend
         gon.test = @dataset_setting
+
+        @widgets = WidgetService.get_widgets
+        @widgets = @widgets.map do |x|
+          { widget: x,
+            edit_url: edit_management_site_widget_step_path(params[:site_slug], x.id),
+            delete_url: management_site_widget_step_path(params[:site_slug], x.id) }
+        end
+        @widgets
 
         @analysis_user_filters = @dataset_setting.columns_changeable.blank? ? [] : (JSON.parse @dataset_setting.columns_changeable)
 

--- a/app/javascript/pages/admin/edit-dashboard.js
+++ b/app/javascript/pages/admin/edit-dashboard.js
@@ -8,29 +8,26 @@ import Wysiwyg from 'vizz-wysiwyg';
 import { WidgetBlock, WidgetBlockCreation } from 'components/wysiwyg';
 
 const EditDashboard = ({ admin }) => (
-  <div className="l-page-list">
-    <div className="wrapper">
-      <h1>Dashboard Content</h1>
-      <Wysiwyg
-        items={JSON.parse(admin.page.content) || []}
-        onChange={(d) => {
-          const el = document.getElementById('site_page_content');
-          if (el) {
-            el.value = JSON.stringify(d);
-          }
-        }}
-        blocks={{
-          widget: {
-            Component: WidgetBlock,
-            EditionComponent: WidgetBlockCreation,
-            admin,
-            icon: 'icon-widget',
-            label: 'Visualization',
-            renderer: 'modal'
-          }
-        }}
-      />
-    </div>
+  <div className="wrapper">
+    <Wysiwyg
+      items={JSON.parse(admin.page.content) || []}
+      onChange={(d) => {
+        const el = document.getElementById('site_page_content');
+        if (el) {
+          el.value = JSON.stringify(d);
+        }
+      }}
+      blocks={{
+        widget: {
+          Component: WidgetBlock,
+          EditionComponent: WidgetBlockCreation,
+          admin,
+          icon: 'icon-widget',
+          label: 'Visualization',
+          renderer: 'modal'
+        }
+      }}
+    />
   </div>
 );
 

--- a/app/views/management/page_steps/preview.html.erb
+++ b/app/views/management/page_steps/preview.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_pack_tag 'application' %>
+
 <% content_for :extended_header do %>
   <!--suppress ALL -->
     <div class="c-extended-header">
@@ -57,17 +59,31 @@
       </div>
 
       <div class="wrapper">
+
+        <% if @page.dashboard_version > 1 %>
         <div class="description">
-          <% if @page.description.length > 200 %>
-            <%= @page.description[0, 200].strip + '…' %><br/>
-            <button type="button" class="js-read-more">Read more</button>
-            <div class="full-description js-description">
-              <%= @page.description %>
-            </div>
-          <% else %>
-            <%= @page.description %>
-          <% end %>
+          <%= react_component('EditDashboardPage', {
+            page: @page,
+            widgets: @widgets
+          } ) %>
+          <%= f.hidden_field :content %>
         </div>
+        <% end %>
+
+        <% if @page.dashboard_version == 1 %>
+          <div class="description">
+            <% if @page.description.length > 200 %>
+              <%= @page.description[0, 200].strip + '…' %><br/>
+              <button type="button" class="js-read-more">Read more</button>
+              <div class="full-description js-description">
+                <%= @page.description %>
+              </div>
+            <% else %>
+              <%= @page.description %>
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="filters">
           <% @analysis_user_filters.each do |filter| %>
             <div class="c-select -small">
@@ -78,14 +94,31 @@
           <% end %>
         </div>
 
-        <div class="widgets">
-          <div class="large-widget js-widget-1"></div>
-          <div class="widget js-widget-2"></div>
-          <div class="widget js-widget-3"></div>
+        <div class="tabs">
+          <ul class="tabs__menu">
+            <li><button class="tabs__btn active" data-tab="chart">Chart</button></li>
+            <li><button class="tabs__btn" data-tab="map">Map</button></li>
+            <li><button class="tabs__btn" data-tab="table">Table</button></li>
+          </ul>
+
+          <div class="tabs__items">
+            <div class="tabs__tab active" id="tabs__chart">
+              <div class="large-widget widget js-widget-2"></div>
+            </div>
+
+            <div class="tabs__tab" id="tabs__map">
+              <div class="large-widget js-widget-1"></div>
+            </div>
+
+            <div class="tabs__tab" id="tabs__table">
+              <%= react_component('PublicTableView', {
+                dashboard: if @dataset_setting then @dataset_setting.get_filtered_dataset else nil end
+              } ) %>
+            </div>
+          </div>
+
         </div>
 
-        <hr/>
-        <div class="table js-table"></div>
       </div>
     </div>
   </div>
@@ -93,3 +126,18 @@
   <%= render partial: 'management/steps_shared/footer', locals: {f: f, always_save: true, no_continue: true, wide: true } %>
 <% end %>
 <%= render partial: 'shared/errors', locals: { resource: @page} %>
+
+<script type="text/javascript">
+  // Untill we render this in react
+  // It would be more hazzle to make react work with this old logic
+  $(function () {
+    $('.tabs__btn').on('click', function (e) {
+      e.preventDefault()
+      $('.tabs__btn').removeClass('active');
+      $(this).addClass('active');
+      $('.tabs__tab').removeClass('active');
+      $('#tabs__' + $(this).attr('data-tab')).addClass('active');
+    });
+  });
+
+</script>

--- a/app/views/management/page_steps/preview.html.erb
+++ b/app/views/management/page_steps/preview.html.erb
@@ -72,12 +72,8 @@
 
         <% if @page.dashboard_version == 1 %>
           <div class="description">
-            <% if @page.description.length > 200 %>
-              <%= @page.description[0, 200].strip + '…' %><br/>
-              <button type="button" class="js-read-more">Read more</button>
-              <div class="full-description js-description">
-                <%= @page.description %>
-              </div>
+            <% if @page.description.length > 250 %>
+              <%= @page.description[0, 250].strip + '…' %>
             <% else %>
               <%= @page.description %>
             <% end %>

--- a/app/views/management/page_steps/title.html.erb
+++ b/app/views/management/page_steps/title.html.erb
@@ -44,17 +44,7 @@
       </div>
     </div>
   </div>
-  <% if @page.dashboard_version > 1 %>
-    <!-- New dashboards will have the content with the new fancy wysiwyg editor -->
-    <%= react_component('EditDashboardPage', {
-      page: @page,
-      widgets: @widgets
-    } ) %>
-    <%= f.hidden_field :content %>
-  <% end %>
-
   <%= render partial: 'management/steps_shared/footer', locals: {f: f} %>
 <% end %>
-
 
 <%= render partial: 'shared/errors', locals: { resource: @page } %>


### PR DESCRIPTION
1. Move RW wysiwyg to preview, instead of under details 
2. Implement new dashboard layout for admin page preview

@santostiago moved the content editor from title to `/page_steps/preview` for new dashboard.
Could you make sure we accept the data on that step when saving ? `site_page[content]`

https://www.pivotaltracker.com/story/show/157696001