### PR TITLE
Widget creation/edition: remove an error from the console

### DIFF
--- a/app/javascript/pages/management/widgets/EditWidgetPage.js
+++ b/app/javascript/pages/management/widgets/EditWidgetPage.js
@@ -237,15 +237,17 @@ class EditWidgetPage extends React.Component {
                 </div>
                 <div className="preview">
                   { previewLoading && <div className="c-loading-spinner -bg" /> }
-                  <VegaChart
-                    data={widgetConfig}
-                    theme={widgetConfig.config || this.state.theme}
-                    theme={getVegaTheme()}
-                    showLegend
-                    reloadOnResize
-                    toggleLoading={loading => this.setState({ previewLoading: loading })}
-                    getForceUpdate={(func) => { this.forceChartUpdate = func; }}
-                  />
+                  {widgetConfig && widgetConfig.data && (
+                    <VegaChart
+                      data={widgetConfig}
+                      theme={widgetConfig.config || this.state.theme}
+                      theme={getVegaTheme()}
+                      showLegend
+                      reloadOnResize
+                      toggleLoading={loading => this.setState({ previewLoading: loading })}
+                      getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+                    />
+                  )}
                 </div>
               </div>
             )}

--- a/app/javascript/pages/management/widgets/NewWidgetPage.js
+++ b/app/javascript/pages/management/widgets/NewWidgetPage.js
@@ -284,14 +284,16 @@ class NewWidgetPage extends React.Component {
                   </div>
                   <div className="preview">
                     { previewLoading && <div className="c-loading-spinner -bg" /> }
-                    <VegaChart
-                      data={widgetConfig}
-                      theme={widgetConfig.config || this.state.theme}
-                      showLegend
-                      reloadOnResize
-                      toggleLoading={loading => this.setState({ previewLoading: loading })}
-                      getForceUpdate={(func) => { this.forceChartUpdate = func; }}
-                    />
+                    {widgetConfig && widgetConfig.data && (
+                      <VegaChart
+                        data={widgetConfig}
+                        theme={widgetConfig.config || this.state.theme}
+                        showLegend
+                        reloadOnResize
+                        toggleLoading={loading => this.setState({ previewLoading: loading })}
+                        getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+                      />
+                    )}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
When the textarea of the advanced mode is empty, the preview fails and displays an error in the console. To prevent this, the preview is only shown if the widget config contains a "data" object.

To test this PR, go to http://localhost:3000/management/sites/base-site/widget_steps/new, select a dataset and choose the advanced mode. You shouldn't see any error in the console.