### PR TITLE
Improvements to the widget creation/edition

### DIFF
--- a/app/assets/stylesheets/components/shared/c-loading-spinner.scss
+++ b/app/assets/stylesheets/components/shared/c-loading-spinner.scss
@@ -17,6 +17,11 @@ $spinner-velocity: 0.6s;
     height: 100%;
   }
 
+  &.-inline {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
   &.-bg {
     width: 100%;
     height: 100%;
@@ -61,6 +66,11 @@ $spinner-velocity: 0.6s;
 
   &.-big::after {
     border-width: $spinner-width * 2;
+  }
+
+  &.-small::after {
+    width: $spinner-size / 1.5;
+    height: $spinner-size / 1.5;
   }
 
   &.-btn {

--- a/app/assets/stylesheets/components/shared/c-loading-spinner.scss
+++ b/app/assets/stylesheets/components/shared/c-loading-spinner.scss
@@ -23,6 +23,7 @@ $spinner-velocity: 0.6s;
   }
 
   &.-bg {
+    position: absolute;
     width: 100%;
     height: 100%;
 
@@ -37,14 +38,15 @@ $spinner-velocity: 0.6s;
       background-color: rgba($spinner-bg-color, 0.2);
     }
 
+    &::after {
+      z-index: 2;
+    }
+
     &.-blank {
       &::before {
         border: 1px solid $color-13;
         border-radius: 4px;
         background-color: $color-3;
-      }
-      &::after {
-        z-index: 2;
       }
     }
   }

--- a/app/assets/stylesheets/components/shared/c-toggle-switcher.scss
+++ b/app/assets/stylesheets/components/shared/c-toggle-switcher.scss
@@ -1,0 +1,32 @@
+.c-toggle-switcher {
+  display: flex;
+  justify-content: center;
+
+  > ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border: 1px solid rgba($color-1, .3);
+    border-radius: 40px;
+  }
+
+  button {
+    display: block;
+    padding: 5px 25px;
+    color: $color-1;
+    line-height: 27px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 40px;
+    appearance: none;
+    font-family: $font-family-1;
+    font-size: $font-size-normal;
+    cursor: pointer;
+
+    &.-active {
+      background: $color-1;
+      color: $color-3;
+      pointer-events: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/layouts/management/l-widget-creation.scss
+++ b/app/assets/stylesheets/layouts/management/l-widget-creation.scss
@@ -26,22 +26,28 @@
       align-items: center;
       justify-content: start;
 
-      > .c-inputs-container {
+      > .widget-container {
+        position: relative;
+        width: 100%;
+        margin-top: 70px;
+      }
+
+      .c-inputs-container {
         min-height: auto;
       }
 
-      > .c-we-widget-editor {
+      .c-we-widget-editor {
         width: 100%;
-        margin-top: 70px;
+        margin-top: 40px;
         z-index: 1;
       }
 
-      > .advanced-editor {
+      .advanced-editor {
         display: flex;
         justify-content: space-between;
         align-items: stretch;
         width: 100%;
-        margin-top: 70px;
+        margin-top: 20px;
 
         > * {
           flex-basis: 50%;

--- a/app/javascript/components/shared/ToggleSwitcher/index.js
+++ b/app/javascript/components/shared/ToggleSwitcher/index.js
@@ -1,0 +1,3 @@
+import ToggleSwitcher from 'components/shared/ToggleSwitcher/toggle-switcher.component';
+
+export default ToggleSwitcher;

--- a/app/javascript/components/shared/ToggleSwitcher/toggle-switcher.component.js
+++ b/app/javascript/components/shared/ToggleSwitcher/toggle-switcher.component.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+function ToggleSwitcher(props) {
+  return (
+    <div className="c-toggle-switcher">
+      <ul>
+        {props.elements.map(el => (
+          <li key={el}>
+            <button
+              className={classnames({ '-active': el === props.selected })}
+              tabIndex="0"
+              onClick={() => props.onChange(el)}
+            >
+              {el}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+ToggleSwitcher.propTypes = {
+  elements: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selected: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired
+};
+
+export default ToggleSwitcher;

--- a/app/javascript/pages/management/widgets/EditWidgetPage.js
+++ b/app/javascript/pages/management/widgets/EditWidgetPage.js
@@ -7,6 +7,7 @@ import ExtendedHeader from 'components/ExtendedHeader';
 import StepsBar from 'components/StepsBar';
 import Notification from 'components/Notification';
 import ThemeSelector from 'components/ThemeSelector';
+import ToggleSwitcher from 'components/shared/ToggleSwitcher';
 
 import { setStep, setWidgetCreationTitle, setWidgetCreationDescription, setWidgetCreationCaption } from 'redactions/management';
 
@@ -38,6 +39,12 @@ class EditWidgetPage extends React.Component {
       // Whether we're using the advanced editor
       advancedEditor: !props.widget.widget_config
         || !props.widget.widget_config.paramsConfig,
+      // Whether the user has dismissed the warning when switching to
+      // the advanced editor
+      advancedEditorWarningAccepted: !props.widget.widget_config
+        || !props.widget.widget_config.paramsConfig,
+      // Whether we're loading the advanced editor
+      advancedEditorLoading: false,
       // State of the advanced editor
       widgetConfig: props.widget.widget_config || {},
       // Whether the preview of the avanced editor is loading
@@ -76,6 +83,62 @@ class EditWidgetPage extends React.Component {
         }
       });
     }
+  }
+
+  componentDidUpdate(_, prevState) {
+    if (!prevState.advancedEditor && this.state.advancedEditor && this.advancedEditor) {
+      this.codeMirror = CodeMirror.fromTextArea(this.advancedEditor, {
+        mode: 'javascript',
+        autoCloseTags: true,
+        lineWrapping: true,
+        lineNumbers: true
+      });
+
+      this.codeMirror.on('change', () => {
+        try {
+          const widgetConfig = JSON.parse(this.codeMirror.getValue());
+          this.setState({ widgetConfig });
+        } catch (e) {
+          // If there's an error in the JSON, we reset the widgetConfig
+          // so the user sees the preview is empty
+          this.setState({ widgetConfig: {} });
+        }
+      });
+    }
+  }
+
+  /**
+   * Event handler executed when the user toggles between
+   * the "normal" and avanced editor
+   */
+  onToggleAdvancedEditor() {
+    const toggleAdvancedEditor = () => {
+      this.setState({
+        advancedEditor: !this.state.advancedEditor,
+        advancedEditorWarningAccepted: false
+      });
+    };
+
+    if (this.state.advancedEditor) {
+      return toggleAdvancedEditor();
+    }
+
+    return new Promise(resolve => this.setState({ advancedEditorLoading: true }, resolve))
+      .then(() => this.getWidgetConfig())
+      .then((res) => {
+        const widgetConfig = Object.assign({}, res);
+        delete widgetConfig.paramsConfig;
+        delete widgetConfig.config;
+        return new Promise(resolve => this.setState({
+          widgetConfig,
+          advancedEditorLoading: false
+        }, resolve));
+      })
+      .catch(() => new Promise(resolve => this.setState({
+        widgetConfig: {},
+        advancedEditorLoading: false
+      }, resolve)))
+      .then(() => toggleAdvancedEditor());
   }
 
   /**
@@ -186,8 +249,11 @@ class EditWidgetPage extends React.Component {
     const { currentStep, setStep, setTitle, setDescription, setCaption,
       title, description, caption, widget } = this.props;
 
-    const { widgetConfigError, advancedEditor,
-      widgetConfig, previewLoading, saveError, theme } = this.state;
+    const { widgetConfigError, advancedEditor, advancedEditorWarningAccepted,
+      advancedEditorLoading, widgetConfig, previewLoading, saveError, theme } = this.state;
+
+    const createdWithAdvancedMode = !this.props.widget.widget_config
+      || !this.props.widget.widget_config.paramsConfig;
 
     const content = (
       <div>
@@ -214,6 +280,19 @@ class EditWidgetPage extends React.Component {
               </div>
             </div>
             <div className="widget-container">
+              { advancedEditorLoading && <div className="c-loading-spinner -bg" /> }
+              { !createdWithAdvancedMode && (
+                <ToggleSwitcher
+                  elements={['Widget editor', 'Advanced editor']}
+                  selected={advancedEditor ? 'Advanced editor' : 'Widget editor'}
+                  onChange={(newSelected) => {
+                    const selected = advancedEditor ? 'Advanced editor' : 'Widget editor';
+                    if (selected !== newSelected) {
+                      this.onToggleAdvancedEditor();
+                    }
+                  }}
+                />
+              )}
               { !advancedEditor && (
                 <WidgetEditor
                   datasetId={widget.dataset}
@@ -242,7 +321,6 @@ class EditWidgetPage extends React.Component {
                       <VegaChart
                         data={widgetConfig}
                         theme={widgetConfig.config || this.state.theme}
-                        theme={getVegaTheme()}
                         showLegend
                         reloadOnResize
                         toggleLoading={loading => this.setState({ previewLoading: loading })}
@@ -282,6 +360,18 @@ class EditWidgetPage extends React.Component {
             content="Unable to update the widget"
             additionalContent="Please try again later."
             onClose={() => this.setState({ saveError: false })}
+          />
+        )}
+
+        {advancedEditor && !advancedEditorWarningAccepted && (
+          <Notification
+            type="warning"
+            content="Once you've updated the widget with the advanced editor, you won't be able to use the simple interface anymore."
+            dialogButtons
+            closeable={false}
+            onCancel={() => this.setState({ advancedEditor: false })}
+            onContinue={() => this.setState({ advancedEditorWarningAccepted: true })}
+            onClose={() => this.setState({ advancedEditor: false })}
           />
         )}
 

--- a/app/javascript/pages/management/widgets/EditWidgetPage.js
+++ b/app/javascript/pages/management/widgets/EditWidgetPage.js
@@ -213,44 +213,46 @@ class EditWidgetPage extends React.Component {
                 />
               </div>
             </div>
-            { !advancedEditor && (
-              <WidgetEditor
-                datasetId={widget.dataset}
-                {...(widget ? { widgetId: widget.id } : {})}
-                widgetTitle={title}
-                widgetCaption={caption}
-                theme={this.state.theme}
-                saveButtonMode="never"
-                embedButtonMode="never"
-                onChangeWidgetTitle={t => setTitle(t)}
-                onChangeWidgetCaption={c => setCaption(c)}
-                provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
-              />
-            )}
-            { advancedEditor && (
-              <div className="advanced-editor">
-                <div>
-                  <textarea
-                    ref={(el) => { this.advancedEditor = el; }}
-                    defaultValue={JSON.stringify(widgetConfig)}
-                  />
-                </div>
-                <div className="preview">
-                  { previewLoading && <div className="c-loading-spinner -bg" /> }
-                  {widgetConfig && widgetConfig.data && (
-                    <VegaChart
-                      data={widgetConfig}
-                      theme={widgetConfig.config || this.state.theme}
-                      theme={getVegaTheme()}
-                      showLegend
-                      reloadOnResize
-                      toggleLoading={loading => this.setState({ previewLoading: loading })}
-                      getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+            <div className="widget-container">
+              { !advancedEditor && (
+                <WidgetEditor
+                  datasetId={widget.dataset}
+                  {...(widget ? { widgetId: widget.id } : {})}
+                  widgetTitle={title}
+                  widgetCaption={caption}
+                  theme={this.state.theme}
+                  saveButtonMode="never"
+                  embedButtonMode="never"
+                  onChangeWidgetTitle={t => setTitle(t)}
+                  onChangeWidgetCaption={c => setCaption(c)}
+                  provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
+                />
+              )}
+              { advancedEditor && (
+                <div className="advanced-editor">
+                  <div>
+                    <textarea
+                      ref={(el) => { this.advancedEditor = el; }}
+                      defaultValue={JSON.stringify(widgetConfig, null, 2)}
                     />
-                  )}
+                  </div>
+                  <div className="preview">
+                    { previewLoading && <div className="c-loading-spinner -bg" /> }
+                    {widgetConfig && widgetConfig.data && (
+                      <VegaChart
+                        data={widgetConfig}
+                        theme={widgetConfig.config || this.state.theme}
+                        theme={getVegaTheme()}
+                        showLegend
+                        reloadOnResize
+                        toggleLoading={loading => this.setState({ previewLoading: loading })}
+                        getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+                      />
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/app/javascript/pages/management/widgets/EditWidgetPage.js
+++ b/app/javascript/pages/management/widgets/EditWidgetPage.js
@@ -148,6 +148,13 @@ class EditWidgetPage extends React.Component {
   onClickUpdate() {
     new Promise((resolve, reject) => { // eslint-disable-line no-new
       if (this.state.advancedEditor) {
+        // If the user hasn't defined any theme in the wysiwyg and if one
+        // has been selected in the theme selector, then we had it before
+        // creating the widget
+        if (this.state.widgetConfig && !this.state.widgetConfig.config && this.state.theme) {
+          resolve(Object.assign({}, this.state.widgetConfig, { config: this.state.theme }));
+        }
+
         resolve(this.state.widgetConfig);
       } else {
         this.getWidgetConfig()

--- a/app/javascript/pages/management/widgets/NewWidgetPage.js
+++ b/app/javascript/pages/management/widgets/NewWidgetPage.js
@@ -87,6 +87,13 @@ class NewWidgetPage extends React.Component {
   onClickCreate() {
     new Promise((resolve, reject) => { // eslint-disable-line no-new
       if (this.state.advancedEditor) {
+        // If the user hasn't defined any theme in the wysiwyg and if one
+        // has been selected in the theme selector, then we had it before
+        // creating the widget
+        if (this.state.widgetConfig && !this.state.widgetConfig.config && this.state.theme) {
+          resolve(Object.assign({}, this.state.widgetConfig, { config: this.state.theme }));
+        }
+
         resolve(this.state.widgetConfig);
       } else {
         this.getWidgetConfig()

--- a/app/javascript/pages/management/widgets/NewWidgetPage.js
+++ b/app/javascript/pages/management/widgets/NewWidgetPage.js
@@ -366,7 +366,7 @@ class NewWidgetPage extends React.Component {
         {advancedEditor && !advancedEditorWarningAccepted && (
           <Notification
             type="warning"
-            content="Onced you've created the widget with the advanced editor, you won't be able to use the simple interface."
+            content="Once you've created the widget with the advanced editor, you won't be able to use the simple interface."
             dialogButtons
             closeable={false}
             onCancel={() => this.setState({ advancedEditor: false })}

--- a/app/javascript/pages/management/widgets/NewWidgetPage.js
+++ b/app/javascript/pages/management/widgets/NewWidgetPage.js
@@ -7,6 +7,7 @@ import ExtendedHeader from 'components/ExtendedHeader';
 import StepsBar from 'components/StepsBar';
 import Notification from 'components/Notification';
 import ThemeSelector from 'components/ThemeSelector';
+import ToggleSwitcher from 'components/shared/ToggleSwitcher';
 
 import { setStep, setWidgetCreationDataset, setWidgetCreationTitle, setWidgetCreationDescription, setWidgetCreationCaption } from 'redactions/management';
 
@@ -277,54 +278,58 @@ class NewWidgetPage extends React.Component {
                     onChange={theme => this.onChangeTheme(theme)}
                   />
                 </div>
-                <footer>
-                  <div className="c-checkbox">
-                    <input type="checkbox" id="advanced-editor" name="advanced-editor" checked={advancedEditor} onClick={() => this.onToggleAdvancedEditor()} />
-                    <label htmlFor="advanced-editor">
-                      { advancedEditorLoading && <div className="c-loading-spinner -inline -small" /> }
-                      &nbsp;Use the advanced editor to create the widget manually
-                    </label>
-                  </div>
-                </footer>
               </div>
-              { !advancedEditor && (
-                <WidgetEditor
-                  datasetId={dataset}
-                  widgetTitle={title}
-                  widgetCaption={caption}
-                  theme={this.state.theme}
-                  saveButtonMode="never"
-                  embedButtonMode="never"
-                  useLayerEditor
-                  onChangeWidgetTitle={t => setTitle(t)}
-                  onChangeWidgetCaption={c => setCaption(c)}
-                  provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
-                  provideLayer={(func) => { this.getLayer = func; }}
+              <div className="widget-container">
+                { advancedEditorLoading && <div className="c-loading-spinner -bg" /> }
+                <ToggleSwitcher
+                  elements={['Widget editor', 'Advanced editor']}
+                  selected={advancedEditor ? 'Advanced editor' : 'Widget editor'}
+                  onChange={(newSelected) => {
+                    const selected = advancedEditor ? 'Advanced editor' : 'Widget editor';
+                    if (selected !== newSelected) {
+                      this.onToggleAdvancedEditor();
+                    }
+                  }}
                 />
-              )}
-              { advancedEditor && (
-                <div className="advanced-editor">
-                  <div>
-                    <textarea
-                      ref={(el) => { this.advancedEditor = el; }}
-                      defaultValue={JSON.stringify(widgetConfig, null, 2)}
-                    />
-                  </div>
-                  <div className="preview">
-                    { previewLoading && <div className="c-loading-spinner -bg" /> }
-                    {widgetConfig && widgetConfig.data && (
-                      <VegaChart
-                        data={widgetConfig}
-                        theme={widgetConfig.config || this.state.theme}
-                        showLegend
-                        reloadOnResize
-                        toggleLoading={loading => this.setState({ previewLoading: loading })}
-                        getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+                { !advancedEditor && (
+                  <WidgetEditor
+                    datasetId={dataset}
+                    widgetTitle={title}
+                    widgetCaption={caption}
+                    theme={this.state.theme}
+                    saveButtonMode="never"
+                    embedButtonMode="never"
+                    useLayerEditor
+                    onChangeWidgetTitle={t => setTitle(t)}
+                    onChangeWidgetCaption={c => setCaption(c)}
+                    provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
+                    provideLayer={(func) => { this.getLayer = func; }}
+                  />
+                )}
+                { advancedEditor && (
+                  <div className="advanced-editor">
+                    <div>
+                      <textarea
+                        ref={(el) => { this.advancedEditor = el; }}
+                        defaultValue={JSON.stringify(widgetConfig, null, 2)}
                       />
-                    )}
+                    </div>
+                    <div className="preview">
+                      { previewLoading && <div className="c-loading-spinner -bg" /> }
+                      {widgetConfig && widgetConfig.data && (
+                        <VegaChart
+                          data={widgetConfig}
+                          theme={widgetConfig.config || this.state.theme}
+                          showLegend
+                          reloadOnResize
+                          toggleLoading={loading => this.setState({ previewLoading: loading })}
+                          getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+                        />
+                      )}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Overview

This PR brings several enhancements to the widget creation/edition:
1. The button to switch between the "standard" and advanced mode has been redesigned and put closer to the widget-editor.
<img align="center" width="1092" alt="Toggle button between the two modes" src="https://user-images.githubusercontent.com/6073968/42457953-af2ab4f0-8390-11e8-9907-065051608cbb.png">

2. When the user switches between the "standard" and advanced mode, the wysiwyg gets pre-populated with the widget of the editor.

3. When editing a "standard" widget, the user has the possibility to convert it with advanced mode (no going back).

## Testing instructions

Create or edit "standard"/advanced widgets.

## Pivotal task

1. [Pivotal task #1](https://www.pivotaltracker.com/story/show/158860215)
2. [Pivotal task #2](https://www.pivotaltracker.com/story/show/158860139)
3. [Pivotal task #3](https://www.pivotaltracker.com/story/show/158860075)