### PR TITLE
Release blockers

### DIFF
--- a/app/views/site_page/map.html.erb
+++ b/app/views/site_page/map.html.erb
@@ -214,15 +214,9 @@
   <script id="library-load" src="http://alpha.blueraster.io/gfw-mapbuilder/external-subscriptions/1.2.0.js"></script>
     <script>
         var mapDatabaseConfig = JSON.parse('<%= @site_page.content.nil? ? '{}' : @site_page.content['settings'].squish.gsub("'", %q(\\\')).html_safe %>')
+
         var mapConfig = Object.assign(mapDatabaseConfig, {
-          language: 'en',
-          title: '<%= @site_page.site.name %>',
-          labels: {
-            en: {
-              title: '<%= @site_page.site.name %>',
-              subtitle: '<%= @site_page.description %>'
-            }
-          }
+          title: '<%= @site_page.site.name %>'
         });
 
 


### PR DESCRIPTION
map builder not translating if the language is not English default. At least I think this was the issue, as we were overwriting the configuration in BO.
https://www.pivotaltracker.com/story/show/158859851