### PR TITLE
Fix the translations not working when navigating

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require backbone
-//= require turbolinks
 //= require fitvids
 //= require d3
 //= require vega

--- a/app/assets/javascripts/dispatchers/frontDispatcher.js
+++ b/app/assets/javascripts/dispatchers/frontDispatcher.js
@@ -53,5 +53,5 @@
   };
 
   // We need for the DOM to be ready
-  document.addEventListener('turbolinks:load', init);
+  window.addEventListener('DOMContentLoaded', init);
 }).call(this, this.App);

--- a/app/assets/javascripts/views/front/languageSelectorView.js
+++ b/app/assets/javascripts/views/front/languageSelectorView.js
@@ -38,6 +38,12 @@
           }, 0)
         }
 
+        // We update the url
+        if (!/\?(.*)?l=[a-z]{2}/.test(location.search)) {
+          var url = (!location.search.length ? '?' : '&') + 'l=' + this.options.currentLanguage;
+          history.replaceState(null, '', url);
+        }
+
         this.render();
       }.bind(this));
     },
@@ -63,6 +69,13 @@
       this.trigger('state:change', {
         currentLanguage: _.findWhere(this.options.languages, { code: languageCode })
       });
+
+      // We update the URL with the new choice
+      var search = location.search.replace(/l=[a-z]{2}/, 'l=' + languageCode);
+      history.replaceState(null, '', search);
+
+      // We also update the localStorage
+      localStorage.setItem('language', languageCode);
     },
 
     /**

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,9 @@
       api_key: '<%= @site_page.site.site_settings.transifex_api_key(@site_page.site_id).value || '' %>',
       detectlang: function () {
         var match = location.search.match(/\?(?:.*)?l=([a-z]{2})/);
-        return (match && match.length) > 1 ? match[1]: '<%= @site_page.site.site_settings.default_site_language(@site_page.site_id).value || 'fr' %>';
+        var urlLanguage =  (match && match.length) > 1 ? match[1] : null;
+        var storageLanguage = localStorage.getItem('language') || null;
+        return urlLanguage || storageLanguage || '<%= @site_page.site.site_settings.default_site_language(@site_page.site_id).value || 'fr' %>';
       }
     };
   </script>


### PR DESCRIPTION
This PR fixes an issue where the translations are not working when navigating from one page to another.

This PR contains two parts:
1. Saving/restoring the language from the `localStorage`/url
2. Addressing the issue of the page being only partially translated when navigating

For the first point, the current language is stored in two places:
- in the `localStorage`: this is how we save the user's selection from page to page
- in the URL (the parameter `l`): this is how someone can share a page in a specific language

For the second point, it seems the issue is related to Turbolinks. Disabling it fixes the issue.

@tomasmoose I'd appreciate if you could have a look and eventually find a way we can make this work with Turbolinks. I tried everything I knew but couldn't manage to find a solution. If you want to try, just revert the changes in:
- `app/assets/javascripts/application.js`
- `app/assets/javascripts/dispatchers/frontDispatcher.js`