### PR TITLE
Fix for delete row bug 

### DIFF
--- a/app/assets/stylesheets/components/shared/c-table.scss
+++ b/app/assets/stylesheets/components/shared/c-table.scss
@@ -196,5 +196,65 @@
     text-align: left;
     cursor: pointer;
   }
-}
 
+  .confirm-delete {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    background: #ffffff;
+    z-index: 9999;
+    width: 390px;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+    box-shadow: 0px 7px 14px 2px #00000040;
+    padding: 10px 10px 30px 10px;
+    text-align: center;
+    border-radius: 5px;
+
+    h2 {
+      display: block;
+    }
+
+    button, a {
+      border: none;
+      height: 40px;
+      background: #adacad;
+      font-size: 14px;
+      text-transform: capitalize;
+      padding: 0;
+      line-height: 40px;
+      margin: 0 20px;
+      color: #3e3e3e;
+      font-weight: 600;
+      width: 130px;
+
+      border-radius: 5px;
+      text-decoration: none;
+      cursor: pointer;
+
+      &:hover {
+        opacity: 0.6;
+      }
+
+    }
+
+    .options {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    button {
+      display: block;
+    }
+
+    a {
+      background: #ff095f;
+      color: #FFF;
+
+      &:hover { text-decoration: none; }
+
+    }
+
+  }
+
+}

--- a/app/javascript/components/table/Confirm.js
+++ b/app/javascript/components/table/Confirm.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Confirm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      confirm: false
+    };
+  }
+
+  onConfirm() {
+    this.setState({ confirm: true });
+  }
+
+  render() {
+    const { msg, link } = this.props;
+    return (
+      <div>
+        <button
+          onClick={() => this.onConfirm()}
+          data-method="delete"
+          className="c-table-action-button -delete"
+          title="Delete"
+        >
+          Delete
+        </button>
+
+        {this.state.confirm &&
+        <div className="confirm-delete">
+          <h2>{msg || 'Are you sure?'}</h2>
+
+          <div className="options">
+            <button onClick={() => this.setState({ confirm: false })}>No</button>
+
+            <a
+              href={link || '#'}
+              data-method="delete"
+              title="Delete"
+            >
+              Yes
+            </a>
+          </div>
+        </div>}
+      </div>);
+  }
+}
+
+Confirm.propTypes = {
+  msg: PropTypes.string.isRequired,
+  link: PropTypes.string.isRequired
+};
+
+export default Confirm;

--- a/app/javascript/components/table/TableActions.js
+++ b/app/javascript/components/table/TableActions.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// Components
+import Confirm from './Confirm';
+
 const TableActions = ({ data, action, onClickAction }) => {
   if (action === 'toggle' && 'enable' in data && 'enabled' in data && data.enable.value !== null) {
     return (
@@ -38,15 +41,10 @@ const TableActions = ({ data, action, onClickAction }) => {
     return (
       <td key={action}>
         <span className="row-content">
-          <a
-            href={window.location.origin + data[action].value}
-            data-method="delete"
-            className="c-table-action-button -delete"
-            title="Delete"
-            onClick={() => onClickAction(action, data)}
-          >
-            Delete
-          </a>
+          <Confirm
+            msg="Are you sure you want to delete this?"
+            link={window.location.origin + data[action].value}
+          />
         </span>
       </td>);
   }

--- a/app/javascript/components/table/index.js
+++ b/app/javascript/components/table/index.js
@@ -369,14 +369,6 @@ Table.defaultProps = {
         window.location.reload();
       });
     }
-
-    if (action === 'delete') {
-      const shouldDelete = window.confirm('are you sure you want to remove this?');
-      if (shouldDelete) {
-        return shouldDelete;
-      }
-      e.preventDefault();
-    }
   }
 };
 


### PR DESCRIPTION
![screen shot 2018-08-13 at 13 29 11](https://user-images.githubusercontent.com/971129/44029280-016caa34-9efd-11e8-86fa-ba30e2ec6934.png)

Created a new modal for our delete table row logic, this is because there is currently a bug that does not prevent the default action on our table deletion links.  (known react issue on regular links) So even if you cancel the action, it still removes the item.

this is a description of the issue: https://medium.com/@ericclemmons/react-event-preventdefault-78c28c950e46


We need to use a _traditional link_ for the action to get triggered by rails. so capsulated the link inside a simple modal window instead.