### PR TITLE
add correct sourcemap and env settings to webpacker

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,3 +1,6 @@
 const environment = require('./environment')
 
+environment.mode = 'production';
+environment.devtool = 'source-map';
+
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
we are running out of memory on our staging servers, I think one of the reasons is that we are inlining our source maps. This causes the heap to explode! and as its all cashed and store in memory we are killing the server at this point.