### PR TITLE
fix quotation styles for open content and home pages

### DIFF
--- a/app/assets/stylesheets/components/shared/c-content.scss
+++ b/app/assets/stylesheets/components/shared/c-content.scss
@@ -137,10 +137,12 @@
   }
 
   blockquote {
-    margin: 30px auto;
-    font-size: $font-size-x-normal;
+    margin: 40px auto!important;
+    padding: 0 10px!important;
+    font-size: $font-size-big!important;
     font-weight: $font-weight-light;
     font-style: italic;
+    border-left: none!important;
 
     &::before {
       content: '“';

--- a/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
+++ b/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
@@ -88,6 +88,54 @@
     }
   }
 
+  blockquote {
+    margin: 40px auto!important;
+    padding: 0 10px!important;
+    font-size: $font-size-big!important;
+    font-weight: $font-weight-light;
+    font-style: italic;
+    border-left: none!important;
+
+    &::before {
+      content: '“';
+    }
+
+    &::after {
+      content: '”';
+    }
+
+    @media #{$mq-mobile} {
+      margin: 60px auto;
+      font-size: $font-size-medium;
+    }
+
+    @if $theme == 3 {
+      color: $color-4;
+      line-height: 1.5;
+
+      @media #{$mq-mobile} {
+        line-height: 1.25;
+      }
+    }
+
+    @if $theme == 2 {
+      color: $color-4;
+      letter-spacing: .2px;
+      line-height: 1.1;
+    }
+
+    @if $theme == 1 {
+      color: $color-1;
+      font-family: $font-family-2;
+      line-height: 1.5;
+
+      @media #{$mq-mobile} {
+        line-height: 1.25;
+      }
+    }
+
+  }
+
   .cw-wysiwyg-list-item {
     &.-image {
       text-align: center;


### PR DESCRIPTION
This pr adds: 

![screen shot 2018-11-15 at 10 45 25](https://user-images.githubusercontent.com/971129/48544307-97eda200-e8c3-11e8-8cc4-5e7759da1b24.png)


New quotation style. Removed the grey border from before and bumped the font size. Also made sure the same style is included for the open content V2 pages.

Also, the blockquote styles from previous versions where never used. we needed to important them :( 