### PR TITLE
Display correct metadata information in dashboards

### DIFF
--- a/app/assets/stylesheets/components/shared/c-dashboard.scss
+++ b/app/assets/stylesheets/components/shared/c-dashboard.scss
@@ -164,8 +164,18 @@
       }
     }
 
-    p {
+    p, ul {
       margin: 15px 0;
+    }
+
+    ul {
+      display: block;
+
+      li {
+        display: list-item;
+        margin-left: 15px;
+        list-style-type: disc;
+      }
     }
   }
 }

--- a/app/controllers/site_page_controller.rb
+++ b/app/controllers/site_page_controller.rb
@@ -15,6 +15,8 @@ class SitePageController < ApplicationController
 
   def load_site_page
     @site_page = SitePage.find(params[:id])
+    @default_language =
+      SiteSetting.default_site_language(@site_page.site_id)&.value
 
     redirect_to not_found_path unless @site_page && @site_page.visible?
   end

--- a/app/javascript/components/shared/Dashboard/dashboard.actions.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.actions.js
@@ -13,7 +13,9 @@ import {
   SET_DATASET_ID,
   SET_WIDGET_ID,
   SET_PAGE_SLUG,
-  SET_DETAILS_VISIBILITY
+  SET_DETAILS_VISIBILITY,
+  SET_DEFAULT_LANGUAGE,
+  SET_SELECTED_LANGUAGE,
 } from 'components/shared/Dashboard/dashboard.reducer';
 
 import {
@@ -150,4 +152,20 @@ export const setWidgetId = widgetId => ({
 export const setDetailsVisibility = visible => ({
   type: SET_DETAILS_VISIBILITY,
   payload: visible
+});
+
+/**
+ * Set the default language of the dashboard
+ */
+export const setDefaultLanguage = defaultLanguage => ({
+  type: SET_DEFAULT_LANGUAGE,
+  payload: defaultLanguage
+});
+
+/**
+ * Set the selected language of the dashboard
+ */
+export const setSelectedLanguage = selectedLanguage => ({
+  type: SET_SELECTED_LANGUAGE,
+  payload: selectedLanguage
 });

--- a/app/javascript/components/shared/Dashboard/dashboard.component.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.component.js
@@ -258,7 +258,8 @@ Dashboard.propTypes = {
   topContent: PropTypes.string,
   bottomContent: PropTypes.string,
   downloadUrls: PropTypes.object.isRequired,
-  hiddenFields: PropTypes.arrayOf(PropTypes.string)
+  hiddenFields: PropTypes.arrayOf(PropTypes.string),
+  defaultLanguage: PropTypes.string
 };
 
 Dashboard.defaultProps = {

--- a/app/javascript/components/shared/Dashboard/dashboard.component.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.component.js
@@ -53,15 +53,8 @@ class Dashboard extends React.PureComponent {
   }
 
   render() {
-    const { downloadUrls } = this.props;
-    const metadata = this.props.datasetMetadata && this.props.datasetMetadata.attributes;
-
-    let downloadLink = null;
-    if (metadata && metadata.info) {
-      downloadLink = metadata.info.data_download_link
-        || metadata.info.data_download_original_link
-        || null;
-    }
+    const { downloadUrls, datasetMetadata } = this.props;
+    const metadata = datasetMetadata ? datasetMetadata.attributes : {};
 
     return (
       <div className="c-dashboard vizz-wysiwyg">
@@ -86,7 +79,7 @@ class Dashboard extends React.PureComponent {
         </div>
         <div className="actions-container">
           <div />
-          {this.props.datasetData && (
+          {!!metadata && (
             <div className="right">
               <button
                 type="button"
@@ -106,12 +99,13 @@ class Dashboard extends React.PureComponent {
                   CSV <Icon name="icon-download" />
                 </a>
               )}
-              {downloadLink && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.download_data && (
                 <a
                   className="download"
                   aria-label="Download original dataset"
-                  href={downloadLink}
-                  {...(metadata.info.data_download_original_link ? { target: '_blank', rel: 'noopener noreferrer' } : { download: true })}
+                  href={metadata.applicationProperties.download_data}
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   Original dataset <Icon name="icon-download" />
                 </a>
@@ -119,131 +113,120 @@ class Dashboard extends React.PureComponent {
             </div>
           )}
         </div>
-        {this.props.datasetData && (
+        {!!metadata && (
           <Modal
             show={this.props.detailsVisible}
             onClose={() => this.props.setDetailsVisibility(false)}
           >
             <div className="details-modal">
-              <h1>{this.props.datasetData.attributes.name}</h1>
-              <p>{(this.props.datasetMetadata && metadata.description) || 'No description'}</p>
+              <h1>{metadata.name}</h1>
+              <p>{metadata.description || 'No description'}</p>
 
-              {metadata && metadata.info && metadata.info.technical_title && (
+              {!!metadata.citation && (
                 <div>
-                  <h2>Formal name</h2>
-                  <p>{metadata.info.technical_title}</p>
+                  <h2>Citation</h2>
+                  <p>{metadata.citation}</p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.cautions && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.cautions && (
                 <div>
                   <h2>Cautions</h2>
-                  <p>{metadata.info.cautions}</p>
+                  <p>{metadata.applicationProperties.cautions}</p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.citation && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.function && (
                 <div>
-                  <h2>Suggested citation</h2>
-                  <p>{metadata.info.citation}</p>
+                  <h2>Function</h2>
+                  <p>{metadata.applicationProperties.function}</p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.citation && (
+              {!!metadata.source && (
                 <div>
-                  <h2>Suggested citation</h2>
-                  <p>{metadata.info.citation}</p>
+                  <h2>Source</h2>
+                  <ul>
+                    {metadata.source.split(',').map(source => (
+                      <li key={source}>
+                        {source.trim()}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               )}
 
-              {this.props.datasetData.attributes.type && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.resolution && (
                 <div>
-                  <h2>Data type</h2>
-                  <p>{this.props.datasetData.attributes.type}</p>
+                  <h2>Resolution</h2>
+                  <p>{metadata.applicationProperties.resolution}</p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.sources && (
-                <div>
-                  <h2>Sources</h2>
-                  {metadata.info.sources.map(source => (
-                    <p key={source['source-name']}>
-                      {source['source-name']}<br />
-                      {source['source-description']}
-                    </p>
-                  ))}
-                </div>
-              )}
 
-              {metadata && metadata.info && metadata.info.geographic_coverage && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.geographic_coverage && (
                 <div>
                   <h2>Geographic coverage</h2>
-                  <p>{metadata.info.geographic_coverage}</p>
+                  <p>{metadata.applicationProperties.geographic_coverage}</p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.spatial_resolution && (
-                <div>
-                  <h2>Spatial resolution</h2>
-                  <p>{metadata.info.spatial_resolution}</p>
-                </div>
-              )}
 
-              {metadata && metadata.info && metadata.info.date_of_content && (
-                <div>
-                  <h2>Date of content</h2>
-                  <p>{metadata.info.date_of_content}</p>
-                </div>
-              )}
-
-              {metadata && metadata.info && metadata.info.frequency_of_updates && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.frequency_of_updates && (
                 <div>
                   <h2>Frequency of updates</h2>
-                  <p>{metadata.info.frequency_of_updates}</p>
+                  <p>{metadata.applicationProperties.frequency_of_updates}</p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.license && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.date_of_content && (
                 <div>
-                  <h2>License</h2>
+                  <h2>Date of content</h2>
+                  <p>{metadata.applicationProperties.date_of_content}</p>
+                </div>
+              )}
+
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.download_data && (
+                <div>
+                  <h2>Download link</h2>
                   <p>
-                    {metadata.info.license_link
-                      ? <a href={metadata.info.license_link} target="_blank" rel="noopener noreferrer">{metadata.info.license}</a>
-                      : metadata.info.license
-                    }
-                  </p>
-                </div>
-              )}
-
-              {metadata && metadata.info && metadata.info.summary_of_license && (
-                <div>
-                  <h2>Summary of license</h2>
-                  <p>{metadata.info.summary_of_license}</p>
-                </div>
-              )}
-
-              {metadata && metadata.info && metadata.info.link_to_license && (
-                <div>
-                  <h2>Link to full license</h2>
-                  <p>
-                    <a href={metadata.info.link_to_license} target="_blank" rel="noopener noreferrer">
-                      {metadata.info.link_to_license}
+                    <a href={metadata.applicationProperties.download_data} target="_blank" rel="noopener noreferrer">
+                      {metadata.applicationProperties.download_data}
                     </a>
                   </p>
                 </div>
               )}
 
-              {metadata && metadata.language && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.amazon_link && (
                 <div>
-                  <h2>Published language</h2>
-                  <p>{metadata.language}</p>
+                  <h2>Amazon link</h2>
+                  <p>
+                    <a href={metadata.applicationProperties.amazon_link} target="_blank" rel="noopener noreferrer">
+                      {metadata.applicationProperties.amazon_link}
+                    </a>
+                  </p>
                 </div>
               )}
 
-              {metadata && metadata.info && metadata.info.language && metadata.info.language.toLowerCase() !== 'en' && (
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.map_service && (
                 <div>
-                  <h2>Translated title</h2>
-                  <p>{metadata.info.translated_title}</p>
+                  <h2>ArcGIS Map Service or Feature Service Link</h2>
+                  <p>
+                    <a href={metadata.applicationProperties.map_service} target="_blank" rel="noopener noreferrer">
+                      {metadata.applicationProperties.map_service}
+                    </a>
+                  </p>
+                </div>
+              )}
+
+              {!!metadata.applicationProperties && !!metadata.applicationProperties.agol_link && (
+                <div>
+                  <h2>ArcGIS Online ItemID Link</h2>
+                  <p>
+                    <a href={metadata.applicationProperties.agol_link} target="_blank" rel="noopener noreferrer">
+                      {metadata.applicationProperties.agol_link}
+                    </a>
+                  </p>
                 </div>
               )}
             </div>

--- a/app/javascript/components/shared/Dashboard/dashboard.component.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.component.js
@@ -15,13 +15,41 @@ import Notification from 'components/Notification';
 
 class Dashboard extends React.PureComponent {
   componentWillMount() {
-    this.props.setPageSlug(this.props.pageSlug);
-    this.props.setDatasetId(this.props.dataset);
-    this.props.setWidgetId(this.props.widget);
-    this.props.fetchFields(this.props.hiddenFields)
-      .then(() => this.props.fetchData());
-    Promise.all([this.props.fetchWidget(), this.props.fetchDataset()])
-      .then(() => this.props.fetchChartData());
+    const {
+      setPageSlug,
+      setDefaultLanguage,
+      setDatasetId,
+      setWidgetId,
+      fetchFields,
+      fetchData,
+      fetchWidget,
+      fetchDataset,
+      fetchChartData,
+      pageSlug,
+      defaultLanguage,
+      dataset,
+      widget,
+      hiddenFields,
+    } = this.props;
+
+    setPageSlug(pageSlug);
+    setDefaultLanguage(defaultLanguage);
+    setDatasetId(dataset);
+    setWidgetId(widget);
+    fetchFields(hiddenFields).then(() => fetchData());
+    Promise.all([fetchWidget(), fetchDataset()]).then(() => fetchChartData());
+  }
+
+  componentDidMount() {
+    const { setSelectedLanguage } = this.props;
+
+    if (window.Transifex) {
+      // We set the selected language anyway because the user might not change the current
+      // language of the page
+      setSelectedLanguage(Transifex.live.getSelectedLanguageCode());
+
+      Transifex.live.onTranslatePage(selectedLanguage => setSelectedLanguage(selectedLanguage));
+    }
   }
 
   render() {
@@ -252,6 +280,8 @@ Dashboard.propTypes = {
   setWidgetId: PropTypes.func.isRequired,
   fetchWidget: PropTypes.func.isRequired,
   setDetailsVisibility: PropTypes.func.isRequired,
+  setDefaultLanguage: PropTypes.func.isRequired,
+  setSelectedLanguage: PropTypes.func.isRequired,
   preview: PropTypes.bool,
   dataset: PropTypes.string,
   widget: PropTypes.string,
@@ -259,7 +289,7 @@ Dashboard.propTypes = {
   bottomContent: PropTypes.string,
   downloadUrls: PropTypes.object.isRequired,
   hiddenFields: PropTypes.arrayOf(PropTypes.string),
-  defaultLanguage: PropTypes.string
+  defaultLanguage: PropTypes.string,
 };
 
 Dashboard.defaultProps = {
@@ -268,7 +298,8 @@ Dashboard.defaultProps = {
   widget: null,
   topContent: null,
   bottomContent: null,
-  hiddenFields: []
+  hiddenFields: [],
+  defaultLanguage: null,
 };
 
 export default Dashboard;

--- a/app/javascript/components/shared/Dashboard/dashboard.reducer.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.reducer.js
@@ -13,6 +13,8 @@ export const SET_WIDGET_ERROR = 'DASHBOARD/SET_WIDGET_ERROR';
 export const SET_WIDGET_DATA = 'DASHBOARD/SET_WIDGET_DATA';
 export const SET_PAGE_SLUG = 'DASHBOARD/SET_PAGE_SLUG';
 export const SET_DETAILS_VISIBILITY = 'DASHBOARD/SET_DETAILS_VISIBILITY';
+export const SET_DEFAULT_LANGUAGE = 'DASHBOARD/SET_DEFAULT_LANGUAGE';
+export const SET_SELECTED_LANGUAGE = 'DASHBOARD/SET_SELECTED_LANGUAGE';
 
 const initialState = {
   tabs: [
@@ -38,7 +40,9 @@ const initialState = {
     loading: false,
     error: false,
     data: null
-  }
+  },
+  defaultLanguage: null,
+  selectedLanguage: null,
 };
 
 export default (state = initialState, action) => {
@@ -105,6 +109,12 @@ export default (state = initialState, action) => {
 
     case SET_DETAILS_VISIBILITY:
       return Object.assign({}, state, { detailsVisible: action.payload });
+
+    case SET_DEFAULT_LANGUAGE:
+      return Object.assign({}, state, { defaultLanguage: action.payload });
+
+    case SET_SELECTED_LANGUAGE:
+      return Object.assign({}, state, { selectedLanguage: action.payload });
 
     default:
       return state;

--- a/app/javascript/components/shared/Dashboard/dashboard.selectors.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.selectors.js
@@ -5,6 +5,8 @@ export const getDataset = state => state.dashboard.dataset.data;
 const getFieldsSelector = state => state.dashboard.fields.data;
 const getWidget = state => state.dashboard.widget.data;
 const getPageSlugSelector = state => state.dashboard.pageSlug;
+const getDefaultLanguage = state => state.dashboard.defaultLanguage;
+const getSelectedLanguage = state => state.dashboard.selectedLanguage;
 
 /**
  * Return the data without the columns that are not
@@ -44,14 +46,16 @@ export const getPageSlug = createSelector(
  * Return the metadata of the dataset
  */
 export const getDatasetMetadata = createSelector(
-  [getDataset],
-  (dataset) => {
+  [getDataset, getDefaultLanguage, getSelectedLanguage],
+  (dataset, defaultLanguage, selectedLanguage) => {
     if (dataset && dataset.attributes.metadata && dataset.attributes.metadata.length) {
-      const FAMetadata = dataset.attributes.metadata.find(m => m.attributes.application === 'forest-atlas');
-      const enMetadata = dataset.attributes.metadata.find(m => m.attributes.language === 'en');
+      const FAMetadata = dataset.attributes.metadata.filter(m => m.attributes.application === ENV.API_APPLICATIONS);
 
-      // We return, in priority, the metadata for forest-atlas or the one in English
-      return FAMetadata || enMetadata || dataset.attributes.metadata[0];
+      const selectedLangMetadata = FAMetadata.find(m => m.attributes.language === selectedLanguage);
+      const defaultLangMetadata = FAMetadata.find(m => m.attributes.language === defaultLanguage);
+      const randomMetadata = FAMetadata[0];
+
+      return selectedLangMetadata || defaultLangMetadata || randomMetadata;
     }
 
     return null;

--- a/app/javascript/components/shared/Dashboard/index.js
+++ b/app/javascript/components/shared/Dashboard/index.js
@@ -2,7 +2,18 @@ import { connect } from 'react-redux';
 
 import DashboardComponent from 'components/shared/Dashboard/dashboard.component';
 
-import { setSelectedTab, fetchFields, fetchDataset, fetchWidget, setPageSlug, setDatasetId, setWidgetId, setDetailsVisibility } from 'components/shared/Dashboard/dashboard.actions';
+import {
+  setSelectedTab,
+  fetchFields,
+  fetchDataset,
+  fetchWidget,
+  setPageSlug,
+  setDatasetId,
+  setWidgetId,
+  setDetailsVisibility,
+  setDefaultLanguage,
+  setSelectedLanguage,
+} from 'components/shared/Dashboard/dashboard.actions';
 import { fetchData } from 'components/shared/DashboardTableView/dashboard-table-view.actions';
 import { fetchVegaWidgetData } from 'components/shared/DashboardChartView/dashboard-chart-view.actions';
 import { getDatasetMetadata } from 'components/shared/Dashboard/dashboard.selectors';
@@ -27,7 +38,9 @@ const mapDispatchToProps = dispatch => ({
   setPageSlug: pageSlug => dispatch(setPageSlug(pageSlug)),
   setDatasetId: datasetId => dispatch(setDatasetId(datasetId)),
   setWidgetId: widgetId => dispatch(setWidgetId(widgetId)),
-  setDetailsVisibility: visible => dispatch(setDetailsVisibility(visible))
+  setDetailsVisibility: visible => dispatch(setDetailsVisibility(visible)),
+  setDefaultLanguage: defaultLanguage => dispatch(setDefaultLanguage(defaultLanguage)),
+  setSelectedLanguage: selectedLanguage => dispatch(setSelectedLanguage(selectedLanguage)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DashboardComponent);

--- a/app/views/site_page/dashboard_v2.html.erb
+++ b/app/views/site_page/dashboard_v2.html.erb
@@ -16,7 +16,8 @@
     widget: @site_page.dashboard_setting.widget_id,
     topContent: @site_page.dashboard_setting.content_top,
     bottomContent: @site_page.dashboard_setting.content_bottom,
-    hiddenFields: @site_page.dashboard_setting.columns.blank? ? [] : @site_page.dashboard_setting.columns.split(',')
+    hiddenFields: @site_page.dashboard_setting.columns.blank? ? [] : @site_page.dashboard_setting.columns.split(','),
+    defaultLanguage: @default_language
   }) %>
 </div>
 


### PR DESCRIPTION
This PR updates which metadata in shown in the public dashboards and in which language.

By default, it tries to display the metadata in the language selected by the user (Transifex), but can default to the site's default language if none is available. As a last attempt, the metadata of any another language is picked (again, if any).

## Testing instructions

Two flows must be tested:
1. The correct language is picked
2. All the metadata is displayed

### Correct language is picked

1. Create a site with any default language, for example «en», and allow translations in an other, for example «es».
2. Create a dataset and edit its metadata by adding a value for each field, in each language.
3. Create a widget for that dataset.
4. Create a dashboard based on that dataset and widget.
5. Open the dashboard locally and click on the info button below the chart.

<p align="center">
<img width="1304" alt="The info button of the dashboard is located below the chart" src="https://user-images.githubusercontent.com/6073968/65683872-4d49c400-e056-11e9-84a0-e3d7156da9e8.png">
</p>

At this point, make sure the metadata is displayed in the site's default language.

6. To simulate the user changing the language, you can either use a [Redux extension](http://extension.remotedev.io/) and dispatch this:
```json
{
  "type": "DASHBOARD/SET_SELECTED_LANGUAGE",
  "payload": "es"
}
```
(«es» being the second language of the metadata) or you can edit [these lines](https://github.com/Vizzuality/forest-atlas-landscape-cms/blob/2792280d91a34ea41e3d581b2816c443c781f60d/app/javascript/components/shared/Dashboard/dashboard.component.js#L46-L52) of the code and replacing them temporarily by:
```js
    if (window.Transifex) {
      // We set the selected language anyway because the user might not change the current
      // language of the page
      setSelectedLanguage('es');

      // Transifex.live.onTranslatePage(selectedLanguage => setSelectedLanguage(selectedLanguage));
    }
```
7. Reload the page

At this point, make sure the metadata is displayed in the other language.

### All metadata is displayed

1. Go back to point 5. of the previous test.

Make sure all the content you see is the same you have in the metadata form of the dataset.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/167726562)