### PR TITLE
Pass the best available language with alias information to the widget-editor

### DIFF
--- a/app/controllers/management/widget_steps_controller.rb
+++ b/app/controllers/management/widget_steps_controller.rb
@@ -1,6 +1,7 @@
 class Management::WidgetStepsController < ManagementController
 
   before_action :set_site
+  before_action :set_default_language
   before_action :authenticate_user_for_site!
   before_action :ensure_management_user, only: :destroy
 
@@ -104,5 +105,9 @@ class Management::WidgetStepsController < ManagementController
 
   def set_site
     @site = Site.find_by(slug: params[:site_slug])
+  end
+
+  def set_default_language
+    @default_language = SiteSetting.default_site_language(@site.id).value
   end
 end

--- a/app/javascript/containers/WidgetsContainer.js
+++ b/app/javascript/containers/WidgetsContainer.js
@@ -14,6 +14,7 @@ function WidgetsContainer(props) {
           widget={props.widget}
           queryUrl={props.queryUrl}
           redirectUrl={props.redirectUrl}
+          defaultLanguage={props.defaultLanguage}
         />
       </ManagementContainer>
     );
@@ -33,6 +34,7 @@ function WidgetsContainer(props) {
         datasets={props.datasets}
         queryUrl={props.queryUrl}
         redirectUrl={props.redirectUrl}
+        defaultLanguage={props.defaultLanguage}
       />
     </ManagementContainer>
   );
@@ -43,7 +45,12 @@ WidgetsContainer.propTypes = {
   widgets: PropTypes.array, // eslint-disable-line react/require-default-props
   datasets: PropTypes.array, // eslint-disable-line react/require-default-props
   queryUrl: PropTypes.string, // eslint-disable-line react/require-default-props
-  redirectUrl: PropTypes.string // eslint-disable-line react/require-default-props
+  redirectUrl: PropTypes.string, // eslint-disable-line react/require-default-props
+  defaultLanguage: PropTypes.string,
+};
+
+WidgetsContainer.defaultProps = {
+  defaultLanguage: 'en', // We should never pass null as a locale
 };
 
 export default WidgetsContainer;

--- a/app/javascript/pages/management/widgets/helpers.js
+++ b/app/javascript/pages/management/widgets/helpers.js
@@ -1,0 +1,55 @@
+/**
+ * Return a promise with the list of metadatas associated with the dataset
+ * @param {string} datasetId ID of the dataset
+ * @returns {Promise<Object[]>}
+ */
+const getDatasetMetadata = datasetId => fetch(`${ENV.API_URL}/dataset/${datasetId}?includes=metadata&application=${ENV.API_APPLICATIONS}&env=${ENV.API_ENV}`)
+  .then((res) => {
+    if (res.ok) {
+      return res.json();
+    }
+    throw new Error(res.statusText);
+  })
+  .then(({ data }) => data.attributes.metadata);
+
+/**
+ * Return which languages the dataset as alias metadata info for
+ * @param {string} datasetId ID of the dataset
+ * @returns {Promise<string[]>}
+ */
+const getMetadataLanguagesWithAliasInfo = async (datasetId) => {
+  const isRelevant = str => str !== null && str !== undefined && str.length > 0;
+
+  try {
+    const metadatas = await getDatasetMetadata(datasetId);
+    const relevantMetadatas = metadatas.filter((metadata) => {
+      if (!metadata.attributes.columns) {
+        return false;
+      }
+
+      return Object.keys(metadata.attributes.columns)
+        .some(column => isRelevant(metadata.attributes.columns[column].alias)
+          || isRelevant(metadata.attributes.columns[column].description));
+    });
+
+    return relevantMetadatas.map(metadata => metadata.attributes.language);
+  } catch (e) {
+    return [];
+  }
+};
+
+/**
+ * Return the best language to display the (alias) metadata info in
+ * @param {string} datasetId ID of the dataset
+ * @param {string} defaultLanguage Default language to use
+ * @returns {Promise<string>}
+ */
+export const getMostAppropriateMetadataLanguage = (datasetId, defaultLanguage) => getMetadataLanguagesWithAliasInfo(datasetId)
+  .then((languages) => {
+    if (languages.indexOf(defaultLanguage) !== -1) {
+      return defaultLanguage;
+    }
+
+    return languages[0] || defaultLanguage;
+  })
+  .catch(() => defaultLanguage);

--- a/app/views/management/widget_steps/_form.html.erb
+++ b/app/views/management/widget_steps/_form.html.erb
@@ -4,6 +4,7 @@
                     { datasets: @datasets,
                       widget: @widget,
                       queryUrl: @widget.nil? ? management_site_widget_steps_path(@site.slug) : management_site_widget_step_path(@site.slug, @widget.id),
-                      redirectUrl: management_site_widgets_path(@site.slug)}) %>
+                      redirectUrl: management_site_widgets_path(@site.slug),
+                      defaultLanguage: @default_language}) %>
 
 <%= render partial: 'shared/errors', locals: { resource: @widget } %>


### PR DESCRIPTION
This PR makes sure the widget-editor can provide alias and description information to the user by passing it the best appropriate locale.

The locale is determined by the site's default language, or, if not relevant, by any other language that might have alias information.

## Testing instructions

Two cases must be tested:
1. The dataset has alias information for the site's default language
2. It does not

For the first case, provide alias information in the site's default language to a specific dataset. Then, use this dataset to create a widget. When the widget-editor is displayed, check if the alias information is available.

<p align="center">
<img width="920" alt="The alias information is displayed in the widget-editor by hovering the cursor on the name of the columns" src="https://user-images.githubusercontent.com/6073968/65701972-23a29400-e07a-11e9-8668-99a0baccb713.png">
</p>

For the second case, provide alias information *only* for another language. Follow the same steps and check if the alias information is also available.

You could also try creating a widget with a dataset that has no alias information in any language. In this case, you should not see any aliases or descriptions in the widget-editor.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/167726568)