### PR TITLE
Feature/admin site settings improvements

### DIFF
--- a/app/assets/javascripts/helpers/notifications.js
+++ b/app/assets/javascripts/helpers/notifications.js
@@ -12,6 +12,11 @@
         type: 'warning',
         content: 'You can\'t unselect a context set as default!',
         additionalContent: 'Set another one as default before trying to unselect it.'
+      },
+      defaultLanguage: {
+        type: 'error',
+        content: 'The site is configured with a default language that is not available.',
+        additionalContent: 'Please enable this language by ticking its checkbox.'
       }
     },
 

--- a/app/assets/javascripts/routers/admin/SiteCreationRouter.js
+++ b/app/assets/javascripts/routers/admin/SiteCreationRouter.js
@@ -63,6 +63,41 @@
       });
     },
 
+    initSettingsStep() {
+      var checkboxes = document.querySelectorAll('.js-checkboxes input[type="checkbox"]');
+      var select = document.querySelector('.js-default-lang');
+      var form = document.querySelector('.js-form');
+
+      var getDefaultLang = function () {
+        return select.selectedOptions[0].textContent.trim().toLowerCase();
+      };
+
+      var getCheckboxForLang = function (lang) {
+        return  Array.prototype.slice.call(checkboxes).find(function (checkbox) {
+          return checkbox.id === 'translate_' + lang;
+        });
+      };
+
+      // When the user picks a default language for the site, we also ticks the checkbox
+      // corresponding to this language to make it available as one of the target languages
+      select.addEventListener('change', function (e) {
+        var checkbox = getCheckboxForLang(getDefaultLang());
+        if (checkbox) {
+          checkbox.checked = true;
+        }
+      });
+
+      // When the user submits the form, we make sure the site's default language has been enabled
+      // If not, we display an error message
+      form.addEventListener('submit', function (e) {
+        var checkbox = getCheckboxForLang(getDefaultLang());
+        if (!checkbox.checked) {
+          e.preventDefault();
+          App.notifications.broadcast(App.Helper.Notifications.site.defaultLanguage);
+        }
+      });
+    },
+
     initTemplateStep: function () {
       var themeColorContainer = document.querySelector('.js-theme-color');
       var input = themeColorContainer.querySelector('input');

--- a/app/assets/javascripts/routers/admin/SiteEditionRouter.js
+++ b/app/assets/javascripts/routers/admin/SiteEditionRouter.js
@@ -64,6 +64,41 @@
       });
     },
 
+    initSettingsStep() {
+      var checkboxes = document.querySelectorAll('.js-checkboxes input[type="checkbox"]');
+      var select = document.querySelector('.js-default-lang');
+      var form = document.querySelector('.js-form');
+
+      var getDefaultLang = function () {
+        return select.selectedOptions[0].textContent.trim().toLowerCase();
+      };
+
+      var getCheckboxForLang = function (lang) {
+        return  Array.prototype.slice.call(checkboxes).find(function (checkbox) {
+          return checkbox.id === 'translate_' + lang;
+        });
+      };
+
+      // When the user picks a default language for the site, we also ticks the checkbox
+      // corresponding to this language to make it available as one of the target languages
+      select.addEventListener('change', function (e) {
+        var checkbox = getCheckboxForLang(getDefaultLang());
+        if (checkbox) {
+          checkbox.checked = true;
+        }
+      });
+
+      // When the user submits the form, we make sure the site's default language has been enabled
+      // If not, we display an error message
+      form.addEventListener('submit', function (e) {
+        var checkbox = getCheckboxForLang(getDefaultLang());
+        if (!checkbox.checked) {
+          e.preventDefault();
+          App.notifications.broadcast(App.Helper.Notifications.site.defaultLanguage);
+        }
+      });
+    },
+
     initTemplateStep: function () {
       var themeColorContainer = document.querySelector('.js-theme-color');
       var input = themeColorContainer.querySelector('input');

--- a/app/assets/stylesheets/components/shared/c-select.scss
+++ b/app/assets/stylesheets/components/shared/c-select.scss
@@ -81,11 +81,4 @@
       line-height: 24px;
     }
   }
-
-  &.-admin > select {
-    background-color: $color-2;
-    border-radius: 4px;
-    border-color: $color-13;
-    text-transform: capitalize;
-  }
 }

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -12,11 +12,11 @@
 <%= render partial: 'shared/navigation_header', locals: {form_steps: wizard_steps, id: @site.id, current_step: step, step_names: @steps_names} %>
 <%= Gon::Base.render_data %>
 
-<%= form_for @site, url: wizard_path, method: :put do |f| %>
+<%= form_for @site, url: wizard_path, html: { class: 'js-form' }, method: :put do |f| %>
     <div class="l-site-creation -site-settings">
       <div class="wrapper">
         <div class="settings c-inputs-container">
-          <div class="container">
+          <div class="container js-checkboxes">
             <div>Site's languages (select <strong>at least</strong> one option):</div>
             <br />
             <%= f.fields_for :site_settings, \
@@ -68,7 +68,7 @@
                     <%= settings_form.hidden_field :name, value: 'default_site_language' %>
 
                     <%= settings_form.label 'Default site language', for: 'default_site_language' %>
-                    <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es, 'Georgian' => :ka}, {}, id: 'default_site_language' %>
+                    <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es, 'Georgian' => :ka}, {}, id: 'default_site_language', class: 'js-default-lang' %>
                 <% end %>
                 <br /><br />
                 <div>This language must also be checked above.</div>

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -66,9 +66,7 @@
                     <%= settings_form.hidden_field :name, value: 'default_site_language' %>
 
                     <%= settings_form.label 'Default site language', for: 'default_site_language' %>
-                    <div class="c-select -admin">
-                      <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es, 'Georgian' => :ka}, id: 'default_site_language' %>
-                    </div>
+                    <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es, 'Georgian' => :ka}, id: 'default_site_language' %>
                 <% end %>
             <% end %>
           </div>

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -79,7 +79,7 @@
                   <%= settings_form.hidden_field :position, value: '16' %>
                   <%= settings_form.hidden_field :name, value: 'transifex_api_key' %>
 
-                  <div class="container -big">
+                  <div class="container">
                     <%= settings_form.label 'Transifex API key', for: 'transifex_api_key' %>
                     <%= settings_form.text_field :value, id: 'transifex_api_key' %>
                   </div>
@@ -91,7 +91,7 @@
                   <%= settings_form.hidden_field :position, value: '10' %>
                   <%= settings_form.hidden_field :name, value: 'pre_footer' %>
 
-                  <div class="container -big">
+                  <div class="container">
                     <%= settings_form.label 'Pre-footer', for: 'pre_footer' %>
                     <%= settings_form.text_area :value, id: 'pre_footer' %>
                   </div>
@@ -100,7 +100,7 @@
                   <%= settings_form.hidden_field :position, value: '11' %>
                   <%= settings_form.hidden_field :name, value: 'analytics_key' %>
 
-                  <div class="container -big">
+                  <div class="container">
                     <%= settings_form.label 'Analytics key', for: 'analytics_key' %>
                     <%= settings_form.text_field :value, id: 'analytics_key' %>
                   </div>
@@ -109,7 +109,7 @@
                   <%= settings_form.hidden_field :position, value: '12' %>
                   <%= settings_form.hidden_field :name, value: 'keywords' %>
 
-                  <div class="container -big">
+                  <div class="container">
                     <%= settings_form.label 'Keywords', for: 'keywords' %>
                     <%= settings_form.text_area :value, id: 'keywords' %>
                   </div>
@@ -118,7 +118,7 @@
                   <%= settings_form.hidden_field :position, value: '13' %>
                   <%= settings_form.hidden_field :name, value: 'contact_email_address' %>
 
-                  <div class="container -big">
+                  <div class="container">
                     <%= settings_form.label 'Contact email address', for: 'contact_email_address' %>
                     <%= settings_form.text_field :value, id: 'contact_email_address' %>
                   </div>
@@ -127,7 +127,7 @@
                   <%= settings_form.hidden_field :position, value: '14' %>
                   <%= settings_form.hidden_field :name, value: 'hosting_organization' %>
 
-                  <div class="container -big">
+                  <div class="container">
                     <%= settings_form.label 'Hosting organization', for: 'hosting_organization' %>
                     <%= settings_form.text_field :value, id: 'hosting_organization' %>
                   </div>

--- a/app/views/admin/site_steps/settings.html.erb
+++ b/app/views/admin/site_steps/settings.html.erb
@@ -17,6 +17,8 @@
       <div class="wrapper">
         <div class="settings c-inputs-container">
           <div class="container">
+            <div>Site's languages (select <strong>at least</strong> one option):</div>
+            <br />
             <%= f.fields_for :site_settings, \
             (f.object.site_settings.collect.select {|x| %w[translate_english translate_french translate_spanish translate_georgian].include?(x.name)}.sort_by {|s| s.position}) do |settings_form| %>
                 <% setting = settings_form.object %>
@@ -25,7 +27,7 @@
                     <%= settings_form.hidden_field :name, value: 'translate_english' %>
                     <div class="c-checkbox">
                       <%= settings_form.check_box :value, id: 'translate_english' %>
-                      <%= settings_form.label 'Allow English translations', for: 'translate_english' %>
+                      <%= settings_form.label 'English', for: 'translate_english' %>
                     </div>
 
                 <% when 'translate_french' %>
@@ -34,7 +36,7 @@
 
                     <div class="c-checkbox">
                       <%= settings_form.check_box :value, id: 'translate_french' %>
-                      <%= settings_form.label 'Allow French translations', for: 'translate_french' %>
+                      <%= settings_form.label 'French', for: 'translate_french' %>
                     </div>
 
                 <% when 'translate_spanish' %>
@@ -43,7 +45,7 @@
 
                     <div class="c-checkbox">
                       <%= settings_form.check_box :value, id: 'translate_spanish' %>
-                      <%= settings_form.label 'Allow Spanish translations', for: 'translate_spanish' %>
+                      <%= settings_form.label 'Spanish', for: 'translate_spanish' %>
                     </div>
 
                 <% when 'translate_georgian' %>
@@ -52,7 +54,7 @@
 
                     <div class="c-checkbox">
                       <%= settings_form.check_box :value, id: 'translate_georgian' %>
-                      <%= settings_form.label 'Allow Georgian translations', for: 'translate_georgian' %>
+                      <%= settings_form.label 'Georgian', for: 'translate_georgian' %>
                     </div>
                 <% end %>
             <% end %>
@@ -66,8 +68,10 @@
                     <%= settings_form.hidden_field :name, value: 'default_site_language' %>
 
                     <%= settings_form.label 'Default site language', for: 'default_site_language' %>
-                    <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es, 'Georgian' => :ka}, id: 'default_site_language' %>
+                    <%= settings_form.select :value, {'English' => :en, 'French' => :fr, 'Spanish' => :es, 'Georgian' => :ka}, {}, id: 'default_site_language' %>
                 <% end %>
+                <br /><br />
+                <div>This language must also be checked above.</div>
             <% end %>
           </div>
           <%= f.fields_for :site_settings, \


### PR DESCRIPTION
This PR prevents the user from setting as the default language of a site, a language that is not enabled.

<p align="center">
<img width="766" alt="An error notification is displayed because the user selected as default language, a language that has not been enabled" src="https://user-images.githubusercontent.com/6073968/66763855-8086b280-eea0-11e9-9dfa-0a6ea3d92cd4.png">
</p>

Here are the changes of the PR:
- Explanations has been added to the checkboxes (enabled languages) and the select input (default language)
- When the user selects a language as the default one, its corresponding checkbox is automatically checked
- When the user continues to the next step, if the default language is not enabled, an error notification is shown and the user isn't brought to the next step
- Minor changes to the font size of the inputs and minor accessibility enhancements

## Testing instructions

Repeat these steps for both the site creation flow **and** the site edition flow:
1. Create/edit a site and go to the «Settings» step
2. If any, disable all the checkboxes under the «Site's languages» section
3. Change the default site language to another value

At this point, the language you selected must have been enabled automatically (look at its corresponding checkbox).

4. Untick the checkbox corresponding to the site's default language
5. Click «Continue» or «Save»

You must not be brought to the next step and an error must notify you about the site's default language not being available.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169043523)