### PR TITLE
Update the styles of the map report for the new MapBuilder version

### DIFF
--- a/app/assets/stylesheets/layouts/front/map-builder-specifics.scss
+++ b/app/assets/stylesheets/layouts/front/map-builder-specifics.scss
@@ -28,3 +28,11 @@
 .documents-table__link a {
   padding: 0px;
 }
+
+.report-header__logo-container {
+  display: none;
+}
+
+.report-header__title-container .report-header__title {
+  margin-left: 1.25rem;
+}


### PR DESCRIPTION
This PR changes the styles of the map report for the new MapBuilder version.

## Testing instructions

1. Go to [this page](https://cod.forest-atlas.org/map/report.html?title=Forest%20Atlas%20of%20DRC&subtitle=&logoUrl=https%3A%2F%2Fcod.forest-atlas.org%2Fsystem%2Fsite_settings%2Fimages%2F000%2F000%2F034%2Foriginal%2Fdrc1.png%3F1487331314&logoLinkUrl=https%3A%2F%2Fcod.forest-atlas.org&activeSlopeClass=undefined&webmap=f9699bbb3324448fb9cc1085c918fa25&idvalue=1cd9bae392eaf53254f798dfb877a7f3&tcd=30&lang=en&activeLayers=USER_FEATURES%2CAffectation_des_terres_en_9757_38%2CAffectation_des_terres_en_9757_48%2CAffectation_des_terres_en_9757_32%2CAffectation_des_terres_en_9757_120%2CAffectation_des_terres_en_9757_112%2CAffectation_des_terres_en_9757_123%2CAffectation_des_terres_en_9757_101%2CAffectation_des_terres_en_9757_115%2CAffectation_des_terres_en_9757_114%2CAffectation_des_terres_en_9757_40&tcLossFrom=0&tcLossTo=17&gladFrom=2015-01-01T05%3A00%3A00.000Z&gladTo=2019-10-11T17%3A53%3A12.558Z&terraIFrom=2004-01-01&terraITo=2016-07-12&viirsStartDate=2019-10-10%2013%3A53%3A12&viirsEndDate=2019-10-11%2013%3A53%3A12&modisStartDate=2019-10-10%2013%3A53%3A12&modisEndDate=2019-10-11%2013%3A53%3A12&customFeatureTitle=Custom%20Feature%20%231&selectedFeatureTitles=&sharinghost=https%3A%2F%2Fwww.arcgis.com&activeFilters=&activeVersions=&IFL=16&GLOB_MANGROVE=0&Affectation_des_terres_en_9757=121%2C36%2C100%2C40%2C114%2C117%2C118%2C115%2C101%2C102%2C123%2C112%2C120%2C32%2C48%2C38&MODIS_ACTIVE_FIRES=21&VIIRS_ACTIVE_FIRES=21&cache=1.4&origin=https%3A%2F%2Fcod.forest-atlas.org)
2. Paste the CSS changes of this PR

The logo should be hidden of the report.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169099491)