### PR TITLE
Make sure to always pick most relevant metadata for the dashboards

### DIFF
--- a/app/javascript/components/shared/Dashboard/dashboard.helpers.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.helpers.js
@@ -1,0 +1,26 @@
+import get from 'lodash/get';
+
+const isEmptyMetadata = (metadata) => {
+  const keys = [
+    'description',
+    'citation',
+    'source',
+    'applicationProperties.cautions',
+    'applicationProperties.function',
+    'applicationProperties.resolution',
+    'applicationProperties.geographic_coverage',
+    'applicationProperties.frequency_of_updates',
+    'applicationProperties.date_of_content',
+    'applicationProperties.download_data',
+    'applicationProperties.amazon_link',
+    'applicationProperties.map_service',
+    'applicationProperties.agol_link',
+  ];
+
+  return keys.every((key) => {
+    const value = get(metadata, key);
+    return value === '' || value === undefined || value === null;
+  });
+};
+
+export { isEmptyMetadata };

--- a/app/javascript/components/shared/Dashboard/dashboard.helpers.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.helpers.js
@@ -18,7 +18,7 @@ const isEmptyMetadata = (metadata) => {
   ];
 
   return keys.every((key) => {
-    const value = get(metadata, key);
+    const value = get(metadata.attributes, key);
     return value === '' || value === undefined || value === null;
   });
 };

--- a/app/javascript/components/shared/Dashboard/dashboard.selectors.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.selectors.js
@@ -1,5 +1,7 @@
 import { createSelector } from 'reselect';
 
+import { isEmptyMetadata } from './dashboard.helpers';
+
 const getData = state => state.dashboard.data.data;
 export const getDataset = state => state.dashboard.dataset.data;
 const getFieldsSelector = state => state.dashboard.fields.data;
@@ -55,7 +57,8 @@ export const getDatasetMetadata = createSelector(
       const defaultLangMetadata = FAMetadata.find(m => m.attributes.language === defaultLanguage);
       const randomMetadata = FAMetadata[0];
 
-      return selectedLangMetadata || defaultLangMetadata || randomMetadata;
+      return [selectedLangMetadata, defaultLangMetadata]
+        .find(metadata => !isEmptyMetadata(metadata)) || randomMetadata;
     }
 
     return null;


### PR DESCRIPTION
This PR makes sure the dashboards always display the most relevant metadata available. Instead of just checking if a metadata exists in a specific language, we now also check if it's not empty, in which case we would fallback to a different one.

## Testing instructions

### Setup

In order to test the changes locally, you must make the following temporary change first: in `app/javascript/components/shared/Dashboard/dashboard.component.js`, replace `componentDidMount` by:
```js
  componentDidMount() {
    const { setSelectedLanguage } = this.props;

    setSelectedLanguage('fr');
  }
```

Note that we set «fr» as the language. This means that the metadata of the dashboard will be displayed in French, if it exists and it is not empty.

Then, you need to pick a dataset for which you can add metadata in several languages in the management section. In this example, English and French.

Edit the dataset in the management section, and fill in the fields for the English tab. Save.

After that, we'll delete the French metadata from the API:
```bash
curl --request DELETE \
  --url 'http://api.resourcewatch.org/v1/dataset/DATASET_ID_HERE/metadata?application=forest-atlas&language=fr' \
  --header 'authorization: Bearer XXX' \
  --header 'content-type: application/json'
```

(Make sure to use your user token and to replace `DATASET_ID_HERE` with the ID of your dataset.)

Go back to the page to edit the metadata, and save again. This will create a new French metadata object with empty values.

You're done.

## Test

1. Create a dashboard with the dataset you selected before (you might need to create a widget first)
2. Visit the dashboard
3. Below the widget, click the info button

A modal must be displayed, with the metadata in English. If the PR doesn't work, the French metadata (which is empty) will be displayed instead.


## Pivotal tracker

[Task comment](https://www.pivotaltracker.com/story/show/167726562/comments/207796320).