### PR TITLE
Fix(#169265873): Show quick links dropdown on management.

### DIFF
--- a/app/assets/javascripts/dispatchers/managementDispatcher.js
+++ b/app/assets/javascripts/dispatchers/managementDispatcher.js
@@ -53,7 +53,7 @@
       quickLinksParams.activeLink = 'management';
     } else {
       const match = location.pathname.match(/management\/sites\/(([A-z]|-)+)/);
-      if (match.length > 1) {
+      if (match && match.length > 1) {
         quickLinksParams.activeLink = match[1];
       } else {
         quickLinksParams.activeLink = 'management';


### PR DESCRIPTION
This PR fix the bug of not having **Quick Links** dropdown on `/management`.

## Testing instructions

Open the `/management` route:
1. Quick Links dropdown should be displayed.

## Screenshot

![image](https://user-images.githubusercontent.com/268405/67700817-9a4aee00-f9a6-11e9-9ee8-ff0984a9c2cb.png)

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169265873)