### PR TITLE
Fix(#169193081): Remove double arrow from map version select.

### DIFF
--- a/app/views/management/page_steps/map.html.erb
+++ b/app/views/management/page_steps/map.html.erb
@@ -22,9 +22,7 @@
           <div class="c-inputs-container -large">
             <div class="container">
               <label for="version">Version</label>
-              <div class="c-select -small">
-                <%= ff.select 'version', MapVersion.order(:position).pluck(:version), {}, class: 'js-version' %>
-              </div>
+              <%= ff.select 'version', MapVersion.order(:position).pluck(:version), {}, class: 'js-version' %>
             </div>
           </div>
 


### PR DESCRIPTION
This PR removes the second arrow from map version select.

## Testing instructions

1. Open a site with pages of type map or create a new map page.
2. Go to the map tab/step
3. Map version select should only display one arrow.

## Screenshot

![image](https://user-images.githubusercontent.com/268405/67703204-f9126680-f9aa-11e9-9bb6-75a5324f47bb.png)

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169193081)