### PR TITLE
Fix a bug where empty pages can't be edited or viewed

### DIFF
--- a/app/javascript/pages/admin/open-content-preview.js
+++ b/app/javascript/pages/admin/open-content-preview.js
@@ -8,11 +8,12 @@ import Wysiwyg from 'components/shared/Wysiwyg';
 class OpenContentPreview extends React.Component {
   render() {
     const { admin } = this.props;
+
     return (
       <div className="vizz-wysiwyg">
         <Wysiwyg
           readOnly
-          items={JSON.parse(admin.page.content) || []}
+          items={admin.page.content ? JSON.parse(admin.page.content) : []}
         />
       </div>
     );

--- a/app/javascript/pages/admin/open-content.js
+++ b/app/javascript/pages/admin/open-content.js
@@ -8,10 +8,11 @@ import Wysiwyg from 'components/shared/Wysiwyg';
 class OpenContent extends React.Component {
   render() {
     const { admin } = this.props;
+
     return (
       <div className="vizz-wysiwyg">
         <Wysiwyg
-          items={JSON.parse(admin.page.content) || []}
+          items={admin.page.content ? JSON.parse(admin.page.content) : []}
           widgets={admin.widgets}
           onChange={(d) => {
             const el = document.getElementById('site_page_content');

--- a/app/javascript/pages/home.js
+++ b/app/javascript/pages/home.js
@@ -12,7 +12,7 @@ const Home = ({ site }) => (
       <div className="vizz-wysiwyg c-content">
         <Wysiwyg
           readOnly
-          items={JSON.parse(site.page.content) || []}
+          items={site.page.content ? JSON.parse(site.page.content) : []}
         />
       </div>
     )}

--- a/app/javascript/pages/static.js
+++ b/app/javascript/pages/static.js
@@ -12,7 +12,7 @@ const StaticPage = ({ site, relatedPages }) => (
     <div className="vizz-wysiwyg">
       <Wysiwyg
         readOnly
-        items={JSON.parse(site.page.content) || []}
+        items={site.page.content ? JSON.parse(site.page.content) : []}
       />
     </div>
 


### PR DESCRIPTION
This PR fixes a bug where empty pages (Open Content and Homepage) couldn't be edited anymore or even viewed.

## Testing instructions

_These are the instructions for the Open Content type of page (which are the ones reported to fail in the task), but the same process can be applied to the Homepage type of page._

1. Open the management section of a local site (using your local DB)
2. Click the «New page» button of the header
3. Click «Continue» at the «Position» step
4. Give a name, a description and a URI of your choosing and click «Continue»
5. Select «Open Content» as the type of page
6. Click «Save» at the «Content» step, without making any change to the page
7. Click «Publish» at the «Preview» step
8. Find the page in the list and click its edit button
9. Go directly to the «Content» step

Make sure the Wysiwyg is displayed and no errors are thrown in the console.

10. Go to the «Preview» step

Make sure there are no errors thrown in the console.

11. Open the page you just created

Make sure there are no errors thrown in the console.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/168644423)