### PR TITLE
Fix logo height for desktop.

### DIFF
--- a/app/assets/stylesheets/components/front/c-header.scss
+++ b/app/assets/stylesheets/components/front/c-header.scss
@@ -464,7 +464,7 @@ $submenu-separator-color: red;
 
       .logo {
         display: inline-block;
-        height: 80px;
+        height: 85px;
         padding: 0;
         pointer-events: all; // We want the logo to receive the events
 


### PR DESCRIPTION
Make the height of the logo 85px. 50px + 5px + 30px (menu + flag + sub-menu).

## Testing instructions

1. Open one of the sites that had this logo height bug.
2. Logo should have correct height now.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169399550)