### PR TITLE
Add login enabled field to header settings.

### DIFF
--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -31,6 +31,7 @@ class Admin::SiteStepsController < AdminController
 
   # This action cleans the session
   def edit
+
     reset_session_key(:site, @site_id, {})
     redirect_to admin_site_site_step_path(site_slug: params[:site_slug], id: :name)
   end

--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -177,7 +177,7 @@ class SitePage < Page
   end
 
   def header_login_enabled?
-    flag = site.site_settings.try(:header_login_enabled, site_id).try(:value)
+    flag = SiteSetting.header_login_enabled(site_id)&.value
     !flag || flag == 'true'
   end
 

--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -176,6 +176,11 @@ class SitePage < Page
     attrs
   end
 
+  def header_login_enabled?
+    flag = site.site_settings.try(:header_login_enabled, site_id).try(:value)
+    !flag || flag == 'true'
+  end
+
   private
   def construct_url
     if self.content['url']

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -244,7 +244,7 @@ class SiteSetting < ApplicationRecord
     end
 
     unless site.site_settings.exists?(name: 'header_login_enabled')
-      site.site_settings.find_or_initialize_by(name: 'header_login_enabled', value: 'false', position: 32)
+      site.site_settings.find_or_initialize_by(name: 'header_login_enabled', value: 'true', position: 32)
     end
 
     unless site.site_settings.exists?(name: 'header-country-colours')

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -32,7 +32,7 @@ class SiteSetting < ApplicationRecord
     pre_footer analytics_key keywords contact_email_address
     hosting_organization transifex_api_key content_width content_font
     heading_font cover_size cover_text_alignment header_separators
-    header_background header_transparency header-country-colours
+    header_background header_transparency header_login_enabled header-country-colours
     footer_background footer_text_color footer-links-color
   ].freeze
   MAX_COLORS = 5
@@ -116,6 +116,10 @@ class SiteSetting < ApplicationRecord
 
   def self.header_transparency(site_id)
     SiteSetting.find_by(name: 'header_transparency', site_id: site_id)
+  end
+
+  def self.header_login_enabled(site_id)
+    SiteSetting.find_by(name: 'header_login_enabled', site_id: site_id)
   end
 
   def self.footer_background(site_id)
@@ -237,6 +241,10 @@ class SiteSetting < ApplicationRecord
       site.site_settings.find_or_initialize_by(name: 'footer_background', value: '\'accent-color\'', position: 29)
       site.site_settings.find_or_initialize_by(name: 'footer_text_color', value: '\'white\'', position: 30)
       site.site_settings.find_or_initialize_by(name: 'footer-links-color', value: '\'white\'', position: 31)
+    end
+
+    unless site.site_settings.exists?(name: 'header_login_enabled')
+      site.site_settings.find_or_initialize_by(name: 'header_login_enabled', value: 'false', position: 32)
     end
 
     unless site.site_settings.exists?(name: 'header-country-colours')

--- a/app/views/admin/site_steps/style.html.erb
+++ b/app/views/admin/site_steps/style.html.erb
@@ -87,7 +87,7 @@
       <fieldset class="c-inputs-container">
         <legend><span>Header</span></legend>
         <%= f.fields_for :site_settings, \
-          (f.object.site_settings.collect.select { |ss| %w[header_separators header_background header_transparency header-country-colours].include?(ss.name) }.sort_by { |ss| ss.position }) do |settings_form| %>
+          (f.object.site_settings.collect.select { |ss| %w[header_separators header_background header_transparency header-country-colours header_login_enabled].include?(ss.name) }.sort_by { |ss| ss.position }) do |settings_form| %>
           <% setting = settings_form.object %>
           <% case setting.name when 'header_separators' %>
             <div class="container">
@@ -114,6 +114,15 @@
 
               <%= settings_form.label 'Background transparency', for: 'header_transparency' %>
               <%= settings_form.select :value, {'Solid color' => '\'solid\'', 'Transparent sub menu' => '\'semi\'', 'Fully transparent' => '\'transparent\''}, {}, id: 'header_transparency' %>
+            </div>
+
+          <% when 'header_login_enabled' %>
+            <div class="container">
+              <%= settings_form.hidden_field :position, value: setting.position %>
+              <%= settings_form.hidden_field :name, value: 'header_login_enabled' %>
+
+              <%= settings_form.label 'Login enabled', for: 'header_login_enabled' %>
+              <%= settings_form.check_box :value, { id: 'header_login_enabled' }, 'true', 'false' %>
             </div>
 
           <% when 'header-country-colours' %>

--- a/app/views/admin/site_steps/style.html.erb
+++ b/app/views/admin/site_steps/style.html.erb
@@ -121,8 +121,8 @@
               <%= settings_form.hidden_field :position, value: setting.position %>
               <%= settings_form.hidden_field :name, value: 'header_login_enabled' %>
 
-              <%= settings_form.label 'Login enabled', for: 'header_login_enabled' %>
-              <%= settings_form.check_box :value, { id: 'header_login_enabled' }, 'true', 'false' %>
+              <%= settings_form.label 'Login', for: 'header_login_enabled' %>
+              <%= settings_form.select :value, {'Display login' => true, 'Hide login' => false}, {}, id: 'header_login_enabled' %>
             </div>
 
           <% when 'header-country-colours' %>

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -153,7 +153,7 @@
         <ul>
           <li class="notranslate js-language-selector"></li>
         </ul>
-        <% if @site_page.site_template.name != 'INDIA' && @site_page.site.site_settings.header_login_enabled(@site_page.site_id).value == 'true' %>
+        <% if @site_page.site_template.name != 'INDIA' && @site_page.header_login_enabled? %>
           <%= render 'front/user'%>
         <% end %>
       </div>

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -153,7 +153,7 @@
         <ul>
           <li class="notranslate js-language-selector"></li>
         </ul>
-        <% if @site_page.site_template.name != 'INDIA' %>
+        <% if @site_page.site_template.name != 'INDIA' && @site_page.site.site_settings.header_login_enabled(@site_page.site_id).value == 'true' %>
           <%= render 'front/user'%>
         <% end %>
       </div>


### PR DESCRIPTION
This PR creates a admin -> style -> header option for display or hide login.

## Testing instructions

1. For a local site go to Admin -> Style -> Header
2. You should see a new **Login** option.
3. You can choose show or hide and save.
4. The site should display or omit the login item accordingly.

![image](https://user-images.githubusercontent.com/268405/68284952-4d39dc80-0076-11ea-9909-a78cb93825a5.png)

![image](https://user-images.githubusercontent.com/268405/68285069-7fe3d500-0076-11ea-9a6c-2a16138662fd.png)

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/168435693)