### PR TITLE
Add a new ENV var to define where to load the MapBuilder from

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ API_URL=https://production-api.globalforestwatch.org/v1
 API_ENV=production,preproduction
 API_APPLICATIONS=forest-atlas,gfw
 CONTROL_TOWER_URL=https://production-api.globalforestwatch.org
+MAP_BUILDER_BASE_URL=https://library.gfw-mapbuilder.org

--- a/app/views/site_page/map.html.erb
+++ b/app/views/site_page/map.html.erb
@@ -8,8 +8,8 @@
 <div class="modal-wrapper hidden" id="share-modal"></div>
 
 <% content_for :external_js do %>
-  <script id="library-load" src="//wri-sites.s3.amazonaws.com/gfw-mapbuilder.org/library.gfw-mapbuilder.org/<%= @site_page.content['version'] || '1.3.3' %>.js"></script>
-  <script type="text/javascript">  
+  <script id="library-load" src="<%= ENV['MAP_BUILDER_BASE_URL'] %>/<%= @site_page.content['version'] || '1.3.3' %>.js"></script>
+  <script type="text/javascript">
     var triggerCustom;
     var mapDatabaseConfig = JSON.parse('<%= @map_content %>');
     var mapConfig = Object.assign(mapDatabaseConfig, {
@@ -19,7 +19,7 @@
     fetch('<%= ENV['FA_PUBLIC_FOLDER']%>/subscriptions', {
       method: 'GET',
       headers: {
-        Authorization: 'Bearer <%= session[:user_token] %>'            
+        Authorization: 'Bearer <%= session[:user_token] %>'
       }
     }).then(function(response) {
       return response.json();

--- a/app/views/site_page/map_report.html.erb
+++ b/app/views/site_page/map_report.html.erb
@@ -21,7 +21,7 @@
 
 
 <% content_for :external_js do %>
-  <script id="report-load" src="//wri-sites.s3.amazonaws.com/gfw-mapbuilder.org/library.gfw-mapbuilder.org/reportLib.<%= @site_page.content['version'] || '1.1.15' %>.js"></script>
+  <script id="report-load" src="<%= ENV['MAP_BUILDER_BASE_URL'] %>/reportLib.<%= @site_page.content['version'] || '1.1.15' %>.js"></script>
   <script>
     var mapDatabaseConfig = JSON.parse('<%= @map_content %>')
 


### PR DESCRIPTION
This PR adds a new ENV variable to the project, `MAP_BUILDER_BASE_URL`, and use it to construct the URL of the MapBuilder (and its companion report library).

## Testing instructions

1. Edit your `.env` and add: `MAP_BUILDER_BASE_URL=https://library.gfw-mapbuilder.org`
2. Reload the server
3. Go to the admin section, click the «Maps» tab and create a «1.4.0» version
4. Go to the management section of your local site, and edit the map
5. Copy the configuration from here: http://richard.teaches-yoga.com/management/sites/richard-teaches-yoga/site_pages/1139/page_steps/map
6. Open the map page

Make sure it is correctly displayed.

7. Append this to the URL: `/report.html?title=Forest Atlas of DRC&subtitle=&logoUrl=https%3A%2F%2Fcod.forest-atlas.org%2Fsystem%2Fsite_settings%2Fimages%2F000%2F000%2F034%2Foriginal%2Fdrc1.png%3F1487331314&logoLinkUrl=https%3A%2F%2Fcod.forest-atlas.org&activeSlopeClass=undefined&webmap=f9699bbb3324448fb9cc1085c918fa25&idvalue=1cd9bae392eaf53254f798dfb877a7f3&tcd=30&lang=en&activeLayers=USER_FEATURES%2CAffectation_des_terres_en_9757_38%2CAffectation_des_terres_en_9757_48%2CAffectation_des_terres_en_9757_32%2CAffectation_des_terres_en_9757_120%2CAffectation_des_terres_en_9757_112%2CAffectation_des_terres_en_9757_123%2CAffectation_des_terres_en_9757_101%2CAffectation_des_terres_en_9757_115%2CAffectation_des_terres_en_9757_114%2CAffectation_des_terres_en_9757_40&tcLossFrom=0&tcLossTo=17&gladFrom=2015-01-01T05%3A00%3A00.000Z&gladTo=2019-10-11T17%3A53%3A12.558Z&terraIFrom=2004-01-01&terraITo=2016-07-12&viirsStartDate=2019-10-10 13%3A53%3A12&viirsEndDate=2019-10-11 13%3A53%3A12&modisStartDate=2019-10-10 13%3A53%3A12&modisEndDate=2019-10-11 13%3A53%3A12&customFeatureTitle=Custom Feature %231&selectedFeatureTitles=&sharinghost=https%3A%2F%2Fwww.arcgis.com&activeFilters=&activeVersions=&IFL=16&GLOB_MANGROVE=0&Affectation_des_terres_en_9757=121%2C36%2C100%2C40%2C114%2C117%2C118%2C115%2C101%2C102%2C123%2C112%2C120%2C32%2C48%2C38&MODIS_ACTIVE_FIRES=21&VIIRS_ACTIVE_FIRES=21&cache=1.4&origin=https%3A%2F%2Fcod.forest-atlas.org`

Make sure a report is showing.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169438715)
