### PR TITLE
Improve the styles of the admin's Content step

### DIFF
--- a/app/assets/stylesheets/layouts/admin/l-site-creation.scss
+++ b/app/assets/stylesheets/layouts/admin/l-site-creation.scss
@@ -276,6 +276,8 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: flex-start;
+      max-width: 570px;
+      margin: 0 auto;
 
       div {
         position: relative;
@@ -292,7 +294,7 @@
           position: absolute;
           left: 0;
           width: 100%;
-          height: 170px;
+          height: 200px;
           top: 0;
           text-indent: -10000px;
           cursor: pointer;
@@ -320,7 +322,7 @@
           align-items: center;
           justify-content: center;
           width: 100%;
-          height: 100px;
+          height: 130px;
           border: 1px dashed $accent-color;
 
           &.-high {
@@ -342,7 +344,7 @@
           align-items: center;
           justify-content: center;
           width: 100%;
-          height: 100px;
+          height: 130px;
           border: 1px solid $color-13;
           background-color: $color-2;
           background-position: center center;
@@ -379,7 +381,6 @@
         }
 
         .restrictions {
-          flex-basis: 50%;
           margin-top: 10px;
           font-size: $font-size-small;
 
@@ -403,17 +404,12 @@
       }
 
       > .logo {
-        flex-basis: calc(25% - 15px);
-        margin-right: 20px;
+        flex-basis: calc(50% - 15px);
+        margin-right: 30px;
       }
 
       > .icon {
-        flex-basis: calc(25% - 15px);
-        margin-right: 20px;
-      }
-
-      > .flag-colors {
-        flex-basis: calc(50% - 10px);
+        flex-basis: calc(50% - 15px);
       }
 
       > hr {
@@ -422,8 +418,8 @@
       }
 
       .homepage-cover-container {
+        margin-top: 50px;
         flex-basis: 100%;
-        margin-bottom: 10px;
 
         > .homepage-cover {
           display: flex;
@@ -442,18 +438,14 @@
           }
 
           > div {
-            flex-basis: calc(50% - 10px);
-            margin-right: 20px;
+            flex-basis: 100%;
             margin-bottom: 20px;
-
-            &:nth-of-type(2n) {
-              margin-right: 0;
-            }
           }
         }
       }
 
       .content-cover-container {
+        margin-top: 50px;
         flex-basis: 100%;
         display: flex;
         justify-content: flex-start;
@@ -461,7 +453,7 @@
         flex-wrap: wrap;
 
         > .content-cover {
-          flex-basis: calc(50% - 10px);
+          flex-basis: 100%;
         }
       }
 

--- a/app/assets/stylesheets/layouts/admin/l-site-creation.scss
+++ b/app/assets/stylesheets/layouts/admin/l-site-creation.scss
@@ -381,6 +381,7 @@
         }
 
         .restrictions {
+          flex-grow: 1;
           margin-top: 10px;
           font-size: $font-size-small;
 
@@ -461,7 +462,7 @@
       .cover-attribution {
         display: flex;
         flex-direction: column;
-        margin: 10px;
+        margin-top: 10px;
         flex-basis: 50%;
 
         input {

--- a/app/javascript/containers/AdminCarousel.js
+++ b/app/javascript/containers/AdminCarousel.js
@@ -186,7 +186,7 @@ class AdminCarousel extends React.Component {
       <div className="homepage-cover-container">
         <div className="homepage-cover">
           <h3>Homepage cover image</h3>
-          <p>You can select multiple images to make an carusel</p>
+          <p>If you'd like, you can select multiple images to create a carousel.</p>
           {main_images.map((image, i) => this.renderInputs(image, i))}
         </div>
       </div>


### PR DESCRIPTION
This PR improves the styles of the admin's Content tab following the removal of the flag colours setting.

Specifically, the styles make sure the whole preview of the images is clickable.

<p align="center">
<img width="607" alt="Example of settings for the Content tab" src="https://user-images.githubusercontent.com/6073968/68233197-9f3b1d80-fff6-11e9-8437-f158f083f59e.png">
</p>

## Testing instructions

1. Go to the admin section
2. Edit your local site
3. Click the «Content» tab
4. Add one image for each setting

Make sure the page's layout is centred, and that each image if fully clickable.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/168495611)
