### PR TITLE
Add a description for the site customization settings

### DIFF
--- a/app/assets/stylesheets/layouts/admin/l-site-creation.scss
+++ b/app/assets/stylesheets/layouts/admin/l-site-creation.scss
@@ -208,7 +208,7 @@
       }
 
       label {
-        flex-basis: 180px;
+        flex-basis: 200px;
         flex-shrink: 0;
         margin: 0 10px 0 0;
         font-size: $font-size-s-normal;

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -228,6 +228,7 @@ class SiteSetting < ApplicationRecord
       site.site_settings.find_or_initialize_by(name: 'color') do |c|
         c.value = '#97bd3d'
         c.position = 1
+        c.description = 'Patata'
       end
       site.site_settings.find_or_initialize_by(name: 'content_width', value: '1280px', position: 20)
       site.site_settings.find_or_initialize_by(name: 'content_font', value: '\'Merriweather Sans\'', position: 21)
@@ -250,6 +251,12 @@ class SiteSetting < ApplicationRecord
     unless site.site_settings.exists?(name: 'header-country-colours')
       site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: '#000000', position: 28)
     end
+  end
+
+  def self.field_descriptions
+    {
+      'color': 'Select the color to use for links and other visual elements in your site. Make sure you pick a color which contrasts with the white site background.'
+    }
   end
 
   private

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -228,7 +228,6 @@ class SiteSetting < ApplicationRecord
       site.site_settings.find_or_initialize_by(name: 'color') do |c|
         c.value = '#97bd3d'
         c.position = 1
-        c.description = 'Patata'
       end
       site.site_settings.find_or_initialize_by(name: 'content_width', value: '1280px', position: 20)
       site.site_settings.find_or_initialize_by(name: 'content_font', value: '\'Merriweather Sans\'', position: 21)
@@ -251,12 +250,6 @@ class SiteSetting < ApplicationRecord
     unless site.site_settings.exists?(name: 'header-country-colours')
       site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: '#000000', position: 28)
     end
-  end
-
-  def self.field_descriptions
-    {
-      'color': 'Select the color to use for links and other visual elements in your site. Make sure you pick a color which contrasts with the white site background.'
-    }
   end
 
   private

--- a/app/views/admin/site_steps/style.html.erb
+++ b/app/views/admin/site_steps/style.html.erb
@@ -21,12 +21,12 @@
             <input type="hidden" id="accent-color_name" name="site[site_settings_attributes][0][name]" value="color">
             <input type="hidden" id="accent-color_position" name="site[site_settings_attributes][0][position]" value="1">
 
-            <label for="accent-color_id">
-              Accent color
-              <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-              <% end %>
-            </label>
+            <%= render partial: 'shared/info_template', locals: {
+              form: settings_form,
+              message: 'Accent color',
+              label_for: 'accent-color_id',
+              info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+            } %>
             <div class="color-selector js-color-selector">
               <input type="text" id="accent-color_id" name="site[site_settings_attributes][0][value]" value="<%= settings_form.object.value %>" required pattern="#[0-9a-fA-F]{6}">
               <input type="color" value="<%= settings_form.object.value %>">
@@ -45,12 +45,12 @@
               <%= settings_form.hidden_field :position, value: '20' %>
               <%= settings_form.hidden_field :name, value: 'content_width' %>
 
-              <%= settings_form.label for: 'content_width' do %>
-                Content width
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Content width',
+                label_for: 'content_width',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Narrow (960px)' => '960px', 'Standard (1280px)' => '1280px', 'Fullscreen (100%)' => '100%'}, {}, id: 'content_width' %>
             </div>
 
@@ -59,12 +59,12 @@
               <%= settings_form.hidden_field :position, value: '21' %>
               <%= settings_form.hidden_field :name, value: 'content_font' %>
 
-              <%= settings_form.label for: 'content_font' do %>
-                Content font
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Content font',
+                label_for: 'content_font',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Acumin Pro Condensed' => '\'Acumin Pro Condensed\'', 'Fira Sans' => '\'Fira Sans\'', 'Georgia' => '\'Georgia\'', 'Merriweather' => '\'Merriweather\'', 'Merriweather Sans' => '\'Merriweather Sans\'', 'Roboto Condensed' => '\'Roboto Condensed\''}, {}, id: 'content_font' %>
             </div>
 
@@ -73,12 +73,12 @@
               <%= settings_form.hidden_field :position, value: '22' %>
               <%= settings_form.hidden_field :name, value: 'heading_font' %>
 
-              <%= settings_form.label for: 'heading_font' do %>
-                Heading font
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Heading font',
+                label_for: 'heading_font',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Acumin Pro Condensed' => '\'Acumin Pro Condensed\'', 'Fira Sans' => '\'Fira Sans\'', 'Georgia' => '\'Georgia\'', 'Merriweather' => '\'Merriweather\'', 'Merriweather Sans' => '\'Merriweather Sans\'', 'Roboto Condensed' => '\'Roboto Condensed\''}, {}, id: 'heading_font' %>
             </div>
 
@@ -87,12 +87,12 @@
               <%= settings_form.hidden_field :position, value: '23' %>
               <%= settings_form.hidden_field :name, value: 'cover_size' %>
 
-              <%= settings_form.label for: 'cover_size' do %>
-                Cover size
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Cover size',
+                label_for: 'cover_size',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Small (130px)' => '130px', 'Standard (170px)' => '170px', 'Big (250px)' => '250px', }, {}, id: 'cover_size' %>
             </div>
 
@@ -101,12 +101,12 @@
               <%= settings_form.hidden_field :position, value: '24' %>
               <%= settings_form.hidden_field :name, value: 'cover_text_alignment' %>
 
-              <%= settings_form.label for: 'cover_text_alignment' do %>
-                Cover text alignment
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Cover text alignment',
+                label_for: 'cover_text_alignment',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Left' => 'left', 'Center' => 'center'}, {}, id: 'cover_text_alignment' %>
             </div>
 
@@ -124,13 +124,12 @@
               <%= settings_form.hidden_field :position, value: '25' %>
               <%= settings_form.hidden_field :name, value: 'header_separators' %>
 
-              <%= settings_form.label for: 'header_separators' do %>
-                Menu items separator
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
-
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Menu items separator',
+                label_for: 'header_separators',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Display separators' => true, 'No separator' => false}, {}, id: 'header_separators' %>
             </div>
 
@@ -139,12 +138,12 @@
               <%= settings_form.hidden_field :position, value: '26' %>
               <%= settings_form.hidden_field :name, value: 'header_background' %>
 
-              <%= settings_form.label for: 'header_background' do %>
-                Background color
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Background color',
+                label_for: 'header_background',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Dark' => '\'dark\'', 'Light grey' => '\'grey\'', 'White' => '\'white\''}, {}, id: 'header_background' %>
             </div>
 
@@ -153,12 +152,12 @@
               <%= settings_form.hidden_field :position, value: '27' %>
               <%= settings_form.hidden_field :name, value: 'header_transparency' %>
 
-              <%= settings_form.label for: 'header_transparency' do %>
-                Background transparency
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Background transparency',
+                label_for: 'header_transparency',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Solid color' => '\'solid\'', 'Transparent sub menu' => '\'semi\'', 'Fully transparent' => '\'transparent\''}, {}, id: 'header_transparency' %>
             </div>
 
@@ -167,24 +166,24 @@
               <%= settings_form.hidden_field :position, value: setting.position %>
               <%= settings_form.hidden_field :name, value: 'header_login_enabled' %>
 
-              <%= settings_form.label for: 'header_login_enabled' do %>
-                Login
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Login',
+                label_for: 'header_login_enabled',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Display login' => true, 'Hide login' => false}, {}, id: 'header_login_enabled' %>
             </div>
 
           <% when 'header-country-colours' %>
             <div class="container country-colors-container">
-              <label>
-                Country colors
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              </label>
-              <div class="js-header-country-colours"
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Country colors',
+                label_for: 'country_colors',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
+             <div class="js-header-country-colours"
                   data-colors="<%= settings_form.object.value %>"
                   data-input-id="<%= settings_form.object_name %>"
                   data-input-name="<%= settings_form.object_name %>">
@@ -204,12 +203,12 @@
               <%= settings_form.hidden_field :position, value: '29' %>
               <%= settings_form.hidden_field :name, value: 'footer_background' %>
 
-              <%= settings_form.label for: 'footer_background' do %>
-                Background color
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Background color',
+                label_for: 'footer_background',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'Dark' => '\'dark\'', 'Light grey' => '\'grey\'', 'Accent color' => '\'accent-color\''}, {}, id: 'footer_background' %>
             </div>
 
@@ -218,12 +217,12 @@
               <%= settings_form.hidden_field :position, value: '30' %>
               <%= settings_form.hidden_field :name, value: 'footer_text_color' %>
 
-              <%= settings_form.label for: 'footer_text_color' do %>
-                Text color
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Text color',
+                label_for: 'footer_text_color',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'White' => '\'white\'', 'Accent color' => '\'accent-color\''}, {}, id: 'footer_text_color' %>
             </div>
 
@@ -232,12 +231,12 @@
               <%= settings_form.hidden_field :position, value: '31' %>
               <%= settings_form.hidden_field :name, value: 'footer-links-color' %>
 
-              <%= settings_form.label for: 'footer-links-color' do %>
-                Links color
-                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
-                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
-                <% end %>
-              <% end %>
+              <%= render partial: 'shared/info_template', locals: {
+                form: settings_form,
+                message: 'Links color',
+                label_for: 'footer-links-color',
+                info_message: t("admin.site_steps.style.#{settings_form.object.name}", :default => false)
+              } %>
               <%= settings_form.select :value, {'White' => '\'white\'', 'Accent color' => '\'accent-color\''}, {}, id: 'footer-links-color' %>
             </div>
 

--- a/app/views/admin/site_steps/style.html.erb
+++ b/app/views/admin/site_steps/style.html.erb
@@ -23,9 +23,9 @@
 
             <label for="accent-color_id">
               Accent color
-              <% #if !value[:description].blank? %>
-                <button type="button" class="info-button" data-tippy="<%= @site.site_settings.field_descriptions[:color] %>" data-tippy-interactive="true">Field information</button>
-              <% #end %>
+              <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+              <% end %>
             </label>
             <div class="color-selector js-color-selector">
               <input type="text" id="accent-color_id" name="site[site_settings_attributes][0][value]" value="<%= settings_form.object.value %>" required pattern="#[0-9a-fA-F]{6}">
@@ -45,7 +45,12 @@
               <%= settings_form.hidden_field :position, value: '20' %>
               <%= settings_form.hidden_field :name, value: 'content_width' %>
 
-              <%= settings_form.label 'Content width', for: 'content_width' %>
+              <%= settings_form.label for: 'content_width' do %>
+                Content width
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Narrow (960px)' => '960px', 'Standard (1280px)' => '1280px', 'Fullscreen (100%)' => '100%'}, {}, id: 'content_width' %>
             </div>
 
@@ -54,7 +59,12 @@
               <%= settings_form.hidden_field :position, value: '21' %>
               <%= settings_form.hidden_field :name, value: 'content_font' %>
 
-              <%= settings_form.label 'Content font', for: 'content_font' %>
+              <%= settings_form.label for: 'content_font' do %>
+                Content font
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Acumin Pro Condensed' => '\'Acumin Pro Condensed\'', 'Fira Sans' => '\'Fira Sans\'', 'Georgia' => '\'Georgia\'', 'Merriweather' => '\'Merriweather\'', 'Merriweather Sans' => '\'Merriweather Sans\'', 'Roboto Condensed' => '\'Roboto Condensed\''}, {}, id: 'content_font' %>
             </div>
 
@@ -63,7 +73,12 @@
               <%= settings_form.hidden_field :position, value: '22' %>
               <%= settings_form.hidden_field :name, value: 'heading_font' %>
 
-              <%= settings_form.label 'Heading font', for: 'heading_font' %>
+              <%= settings_form.label for: 'heading_font' do %>
+                Heading font
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Acumin Pro Condensed' => '\'Acumin Pro Condensed\'', 'Fira Sans' => '\'Fira Sans\'', 'Georgia' => '\'Georgia\'', 'Merriweather' => '\'Merriweather\'', 'Merriweather Sans' => '\'Merriweather Sans\'', 'Roboto Condensed' => '\'Roboto Condensed\''}, {}, id: 'heading_font' %>
             </div>
 
@@ -72,7 +87,12 @@
               <%= settings_form.hidden_field :position, value: '23' %>
               <%= settings_form.hidden_field :name, value: 'cover_size' %>
 
-              <%= settings_form.label 'Cover size', for: 'cover_size' %>
+              <%= settings_form.label for: 'cover_size' do %>
+                Cover size
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Small (130px)' => '130px', 'Standard (170px)' => '170px', 'Big (250px)' => '250px', }, {}, id: 'cover_size' %>
             </div>
 
@@ -81,7 +101,12 @@
               <%= settings_form.hidden_field :position, value: '24' %>
               <%= settings_form.hidden_field :name, value: 'cover_text_alignment' %>
 
-              <%= settings_form.label 'Cover text alignment', for: 'cover_text_alignment' %>
+              <%= settings_form.label for: 'cover_text_alignment' do %>
+                Cover text alignment
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Left' => 'left', 'Center' => 'center'}, {}, id: 'cover_text_alignment' %>
             </div>
 
@@ -99,7 +124,13 @@
               <%= settings_form.hidden_field :position, value: '25' %>
               <%= settings_form.hidden_field :name, value: 'header_separators' %>
 
-              <%= settings_form.label 'Menu items separator', for: 'header_separators' %>
+              <%= settings_form.label for: 'header_separators' do %>
+                Menu items separator
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
+
               <%= settings_form.select :value, {'Display separators' => true, 'No separator' => false}, {}, id: 'header_separators' %>
             </div>
 
@@ -108,7 +139,12 @@
               <%= settings_form.hidden_field :position, value: '26' %>
               <%= settings_form.hidden_field :name, value: 'header_background' %>
 
-              <%= settings_form.label 'Background color', for: 'header_background' %>
+              <%= settings_form.label for: 'header_background' do %>
+                Background color
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Dark' => '\'dark\'', 'Light grey' => '\'grey\'', 'White' => '\'white\''}, {}, id: 'header_background' %>
             </div>
 
@@ -117,7 +153,12 @@
               <%= settings_form.hidden_field :position, value: '27' %>
               <%= settings_form.hidden_field :name, value: 'header_transparency' %>
 
-              <%= settings_form.label 'Background transparency', for: 'header_transparency' %>
+              <%= settings_form.label for: 'header_transparency' do %>
+                Background transparency
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Solid color' => '\'solid\'', 'Transparent sub menu' => '\'semi\'', 'Fully transparent' => '\'transparent\''}, {}, id: 'header_transparency' %>
             </div>
 
@@ -126,13 +167,23 @@
               <%= settings_form.hidden_field :position, value: setting.position %>
               <%= settings_form.hidden_field :name, value: 'header_login_enabled' %>
 
-              <%= settings_form.label 'Login', for: 'header_login_enabled' %>
+              <%= settings_form.label for: 'header_login_enabled' do %>
+                Login
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Display login' => true, 'Hide login' => false}, {}, id: 'header_login_enabled' %>
             </div>
 
           <% when 'header-country-colours' %>
             <div class="container country-colors-container">
-              <label>Country colors</label>
+              <label>
+                Country colors
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              </label>
               <div class="js-header-country-colours"
                   data-colors="<%= settings_form.object.value %>"
                   data-input-id="<%= settings_form.object_name %>"
@@ -153,7 +204,12 @@
               <%= settings_form.hidden_field :position, value: '29' %>
               <%= settings_form.hidden_field :name, value: 'footer_background' %>
 
-              <%= settings_form.label 'Background color', for: 'footer_background' %>
+              <%= settings_form.label for: 'footer_background' do %>
+                Background color
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'Dark' => '\'dark\'', 'Light grey' => '\'grey\'', 'Accent color' => '\'accent-color\''}, {}, id: 'footer_background' %>
             </div>
 
@@ -162,7 +218,12 @@
               <%= settings_form.hidden_field :position, value: '30' %>
               <%= settings_form.hidden_field :name, value: 'footer_text_color' %>
 
-              <%= settings_form.label 'Text color', for: 'footer_text_color' %>
+              <%= settings_form.label for: 'footer_text_color' do %>
+                Text color
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'White' => '\'white\'', 'Accent color' => '\'accent-color\''}, {}, id: 'footer_text_color' %>
             </div>
 
@@ -171,7 +232,12 @@
               <%= settings_form.hidden_field :position, value: '31' %>
               <%= settings_form.hidden_field :name, value: 'footer-links-color' %>
 
-              <%= settings_form.label 'Links color', for: 'footer-links-color' %>
+              <%= settings_form.label for: 'footer-links-color' do %>
+                Links color
+                <% if t("admin.site_steps.style.#{settings_form.object.name}", :default => false) %>
+                  <button type="button" class="info-button" data-tippy="<%= t("admin.site_steps.style.#{settings_form.object.name}") %>" data-tippy-interactive="true">Field information</button>
+                <% end %>
+              <% end %>
               <%= settings_form.select :value, {'White' => '\'white\'', 'Accent color' => '\'accent-color\''}, {}, id: 'footer-links-color' %>
             </div>
 

--- a/app/views/admin/site_steps/style.html.erb
+++ b/app/views/admin/site_steps/style.html.erb
@@ -21,7 +21,12 @@
             <input type="hidden" id="accent-color_name" name="site[site_settings_attributes][0][name]" value="color">
             <input type="hidden" id="accent-color_position" name="site[site_settings_attributes][0][position]" value="1">
 
-            <label for="accent-color_id">Accent color</label>
+            <label for="accent-color_id">
+              Accent color
+              <% #if !value[:description].blank? %>
+                <button type="button" class="info-button" data-tippy="<%= @site.site_settings.field_descriptions[:color] %>" data-tippy-interactive="true">Field information</button>
+              <% #end %>
+            </label>
             <div class="color-selector js-color-selector">
               <input type="text" id="accent-color_id" name="site[site_settings_attributes][0][value]" value="<%= settings_form.object.value %>" required pattern="#[0-9a-fA-F]{6}">
               <input type="color" value="<%= settings_form.object.value %>">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -5,6 +5,7 @@
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag 'admin/application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <script src="https://unpkg.com/tippy.js@3.3.0/dist/tippy.all.min.js" defer></script>
   <%= javascript_include_tag 'admin', 'data-turbolinks-track': 'reload' %>
   <%= favicon_link_tag %>
 </head>

--- a/app/views/shared/_info_template.html.erb
+++ b/app/views/shared/_info_template.html.erb
@@ -1,0 +1,27 @@
+<% if form %>
+  <%= form.label label_for do %>
+    <%= message %>
+    <% if info_message -%>
+      <button
+        type="button"
+        class="info-button"
+        data-tippy="<%= info_message %>"
+        data-tippy-interactive="true">
+        Field information
+      </button>
+    <% end %>
+  <% end %>
+<% else %>
+  <label>
+    <%= message %>
+    <% if info_message %>
+      <button
+        type="button"
+        class="info-button"
+        data-tippy="<% info_message %>"
+        data-tippy-interactive="true">
+        Field information
+      </button>
+    <% end %>
+  </label>
+<% end %>

--- a/app/views/shared/_info_template.html.erb
+++ b/app/views/shared/_info_template.html.erb
@@ -1,5 +1,5 @@
 <% if form %>
-  <%= form.label label_for do %>
+  <%= form.label nil, for: label_for do %>
     <%= message %>
     <% if info_message -%>
       <button

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,20 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  admin:
+    site_steps:
+      style:
+        'color': 'Select the color to use for links and other visual elements in your site. Make sure you pick a color which contrasts with the white site background.'
+        'content_width': 'Select the maximum width for your site («Narrow (960px)», «Standard (1280px)», or «Fullscreen (100%)»).'
+        'content_font': 'Select the font to use for your site text.'
+        'heading_font': 'Select the font to use for all titles and site headings.'
+        'cover_size': 'Select the height for your cover photo in open content pages («Small (130px)», «Standard (170px)» or «Big (250px)».'
+        'cover_text_alignment': 'Select the positioning and alignment of the text inside your site cover photo. Available options are «Left» or «Center».'
+        'header_login_enabled': 'Enable login to allow users to subscribe to areas and receive deforestation and fire alerts from Global Forest Watch.'
+        'header-country-colours': 'Add a border at the bottom of your header with the flag colors for your site. You may select up to 5 colors.'
+        'header_separators': 'Select if you would like to display a vertical separator between the items in your header.'
+        'header_background': 'Select the background color for your site header and sub menu («Dark», «Light grey», or «White»).'
+        'header_transparency': 'Specify if your site header should be transparent. Select «solid color» for a non-transparent header, «transparent sub-menu» for a transparent sub-menu and «fully transparent» for a transparent sub-menu and header.'
+        'footer_background': 'Select the background color for your site’s footer («Dark», «Light grey», or «White»).'
+        'footer_text_color': 'Select the text color for the text in your site’s footer («White» or «Accent color»).'
+        'footer-links-color': 'Select the color for the link buttons in your site’s footer («White» or «Accent color»).'


### PR DESCRIPTION
This PR adds description messages for admin site_steps styles.

## Testing instructions

1. Open the style tabs in the admin settings for a site.
2. It should display an icon for information on each field.
3. It should display a tooltip on hover for all of these icons.

![image](https://user-images.githubusercontent.com/268405/68413018-48178300-0185-11ea-8161-f5fab53153ef.png)

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169580379)
