### PR TITLE
Fix bug that remove site settings from settings tabs

### DIFF
--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -164,7 +164,7 @@ class Admin::SiteStepsController < AdminController
 
       when 'settings'
         settings = site_params.to_h
-        @site = params[:site_slug] ? Site.find_by(slug: params[:site_slug]) : Site.new(session[:site][@site_id])
+        @site = current_site
 
         begin
           # If the user is editing
@@ -384,7 +384,7 @@ class Admin::SiteStepsController < AdminController
       # Merge site settings with the existing ones
       session[:site][@site_id]['site_settings_attributes'] ||= {}
       if site_params.to_h['site_settings_attributes']
-        max_key = site_params.to_h['site_settings_attributes'].keys.map(&:to_i).max
+        max_key = session[:site][@site_id]['site_settings_attributes'].keys.size
         site_params.to_h['site_settings_attributes'].values.each_with_index do |site_setting, index|
           existing_site_setting = session[:site][@site_id]['site_settings_attributes'].values.find do |ss|
             if ss['name'] == 'main_image'


### PR DESCRIPTION
This PR fixes an error which produces missing site settings on the site creation

## Testing instructions

1. Go to /admin/sites and click on the button to create a new site
2. Continue with the entire process of creation of a site
3. Go to the datasets of the new site and try to create a new one. All works now because the site has `site_language` site setting.
