### PR TITLE
Fix/metadata session

### DIFF
--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -164,7 +164,7 @@ class Admin::SiteStepsController < AdminController
 
       when 'settings'
         settings = site_params.to_h
-        @site = params[:site_slug] ? Site.find_by(slug: params[:site_slug]) : Site.new(session[:site][@site_id])
+        @site = current_site
 
         begin
           # If the user is editing
@@ -384,7 +384,7 @@ class Admin::SiteStepsController < AdminController
       # Merge site settings with the existing ones
       session[:site][@site_id]['site_settings_attributes'] ||= {}
       if site_params.to_h['site_settings_attributes']
-        max_key = site_params.to_h['site_settings_attributes'].keys.map(&:to_i).max
+        max_key = session[:site][@site_id]['site_settings_attributes'].keys.size
         site_params.to_h['site_settings_attributes'].values.each_with_index do |site_setting, index|
           existing_site_setting = session[:site][@site_id]['site_settings_attributes'].values.find do |ss|
             if ss['name'] == 'main_image'

--- a/app/controllers/management/dataset_steps_controller.rb
+++ b/app/controllers/management/dataset_steps_controller.rb
@@ -202,13 +202,13 @@ class Management::DatasetStepsController < ManagementController
     end
 
     # Update the dataset with the attributes saved on the session
-    @dataset.set_attributes session[:dataset_creation][@dataset_id] if session[:dataset_creation][@dataset_id]
+    @dataset.set_attributes session[:dataset_creation][@dataset_id].symbolize_keys if session[:dataset_creation][@dataset_id]
 
     @dataset.application = (ENV['API_APPLICATIONS'] || 'forest-atlas') unless @dataset.application
 
     process_metadata(ds_params)
 
-    @dataset.assign_attributes ds_params.except(:context_ids)
+    @dataset.assign_attributes ds_params.except(:context_ids, :metadata)
     @dataset.legend = {} unless @dataset.legend
     @dataset.metadata = {} unless @dataset.metadata
   end
@@ -289,7 +289,7 @@ class Management::DatasetStepsController < ManagementController
       formatted_metadata[metadata['attributes']['language']]['id'] =
         metadata['id']
     end
-    @metadata = formatted_metadata
+    @metadata = formatted_metadata.merge(session[:dataset_creation][@dataset_id]["metadata"])
   end
 
   def get_metadata_columns

--- a/app/controllers/management/dataset_steps_controller.rb
+++ b/app/controllers/management/dataset_steps_controller.rb
@@ -239,7 +239,8 @@ class Management::DatasetStepsController < ManagementController
 
   def set_current_dataset_state
     return if action_name == 'show'
-    if action_name != 'show' && session[:dataset_creation][@dataset_id]
+
+    if session[:dataset_creation][@dataset_id]
       session[:dataset_creation][@dataset_id] =
         session[:dataset_creation][@dataset_id].deep_merge(@dataset.attributes)
     else
@@ -295,9 +296,9 @@ class Management::DatasetStepsController < ManagementController
   def get_metadata_columns
     @default_language = SiteSetting.default_site_language(@site.id).value
     dataset = DatasetService.get_metadata(@dataset.id)['data']
-    metadata = dataset['attributes']['metadata'].select do |md|
+    metadata = dataset['attributes']['metadata'].find do |md|
       md['attributes']['language'] == @default_language
-    end.first
+    end
     @metadata_id = metadata&.dig('id')
 
     fields = DatasetService.get_fields @dataset.id, dataset['tableName']

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -186,6 +186,7 @@ class Dataset
     DatasetService.update token, id, connector_url if provider.eql? 'csv'
 
     metadata.each do |language, metadata_info|
+      metadata_info['language'] = language
       metadata_info.symbolize_keys!
       if metadata_info[:id].present?
         update_metadata(token, metadata_info)


### PR DESCRIPTION
The PR fixes the bug that loses data between the different steps of a dataset edition (metadata, aliases).

## Testing instructions

1. Click the button to edit a dataset
2. Make some changes in the inputs of the «Metadata» tab
3. Click continue to go to the «Alias» tab
4. Click the «Metadata» button of the steps bar

When you come back to the tab, the changes continue like before and are persisted when saved.

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/168878879](https://www.pivotaltracker.com/story/show/168878879)