### PR TITLE
Fix bug which produce two country colours on default template

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -237,7 +237,6 @@ class SiteSetting < ApplicationRecord
       site.site_settings.find_or_initialize_by(name: 'header_separators', value: 'false', position: 25)
       site.site_settings.find_or_initialize_by(name: 'header_background', value: '\'white\'', position: 26)
       site.site_settings.find_or_initialize_by(name: 'header_transparency', value: '\'semi\'', position: 27)
-      site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: '#000000', position: 28)
       site.site_settings.find_or_initialize_by(name: 'footer_background', value: '\'accent-color\'', position: 29)
       site.site_settings.find_or_initialize_by(name: 'footer_text_color', value: '\'white\'', position: 30)
       site.site_settings.find_or_initialize_by(name: 'footer-links-color', value: '\'white\'', position: 31)
@@ -248,7 +247,7 @@ class SiteSetting < ApplicationRecord
     end
 
     unless site.site_settings.exists?(name: 'header-country-colours')
-      site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: '#000000', position: 28)
+      site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: nil, position: 28)
     end
   end
 

--- a/lib/tasks/update_sites.rake
+++ b/lib/tasks/update_sites.rake
@@ -53,8 +53,6 @@ def convert_existing_site_settings(site)
       value: nil,
       position: max_position + 1
     )
-  elsif country_site_setting.value.blank?
-    country_site_setting.update_attributes!(value: '#000000')
   end
 end
 


### PR DESCRIPTION
This PR fixes the bug which produces two countries' color selectors when creating a new site.

## Testing instructions

1. Create a new site
2. Select default template

Now one country color selector should appear which no value.

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/169609415](https://www.pivotaltracker.com/story/show/169609415)