### PR TITLE
Fix/arcgis

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -213,13 +213,20 @@ class Dataset
   # It connects to the feature service and extracts the description,
   # name, and fields
   def build_arcgis_metadata
-    arcgis_metadata = ArcgisService.build_metadata(self.connector_url)
-    metadata[:description] = arcgis_metadata['description']
-    metadata[:source] = arcgis_metadata['name']
+    @metadata = []
+    get_languages.each do |language, _value|
+      lang_metadata = {}
+      arcgis_metadata = ArcgisService.build_metadata(self.connector_url)
+      lang_metadata[:description] = arcgis_metadata['description']
+      lang_metadata[:source] = arcgis_metadata['name']
 
-    columns = {}
-    arcgis_metadata['fields'].each {|f| columns[f['name']] = { 'alias': f['alias'] } }
-    metadata[:columns] = columns
+      columns = {}
+      arcgis_metadata['fields'].each {|f| columns[f['name']] = { 'alias': f['alias'] } }
+      lang_metadata[:columns] = columns
+      lang_metadata[:language] = language
+
+      @metadata.push lang_metadata
+    end
   end
 
   # TODO: have a feeling this does not return the metadata object

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -237,7 +237,6 @@ class SiteSetting < ApplicationRecord
       site.site_settings.find_or_initialize_by(name: 'header_separators', value: 'false', position: 25)
       site.site_settings.find_or_initialize_by(name: 'header_background', value: '\'white\'', position: 26)
       site.site_settings.find_or_initialize_by(name: 'header_transparency', value: '\'semi\'', position: 27)
-      site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: '#000000', position: 28)
       site.site_settings.find_or_initialize_by(name: 'footer_background', value: '\'accent-color\'', position: 29)
       site.site_settings.find_or_initialize_by(name: 'footer_text_color', value: '\'white\'', position: 30)
       site.site_settings.find_or_initialize_by(name: 'footer-links-color', value: '\'white\'', position: 31)
@@ -248,7 +247,7 @@ class SiteSetting < ApplicationRecord
     end
 
     unless site.site_settings.exists?(name: 'header-country-colours')
-      site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: '#000000', position: 28)
+      site.site_settings.find_or_initialize_by(name: 'header-country-colours', value: nil, position: 28)
     end
   end
 

--- a/lib/tasks/update_sites.rake
+++ b/lib/tasks/update_sites.rake
@@ -53,8 +53,6 @@ def convert_existing_site_settings(site)
       value: nil,
       position: max_position + 1
     )
-  elsif country_site_setting.value.blank?
-    country_site_setting.update_attributes!(value: '#000000')
   end
 end
 


### PR DESCRIPTION
This PR fixes the bug which loses the ArcGIS metadata information

## Testing instructions

1. Create a new dataset for ArcGIS type
2. Edit the created dataset

The dataset should appear with existing ArcGIS information 

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/169372669](https://www.pivotaltracker.com/story/show/169372669)