### PR TITLE
feat(#169761868): Hide measurement tool for India template.

### DIFF
--- a/app/assets/stylesheets/front/_base-theme-ind.scss
+++ b/app/assets/stylesheets/front/_base-theme-ind.scss
@@ -1135,6 +1135,10 @@ form{
   display: none !important;
 }
 
+.control-panel__measurement{
+  display: none !important;
+}
+
 .atlas_wrapper{
 
   text-align: center;


### PR DESCRIPTION
This PR:

* Hide measurement tool from map for India template

![image](https://user-images.githubusercontent.com/268405/69045405-b0b8f800-09ee-11ea-9168-6873e966ac2f.png)

## Testing instructions

1. Go to a site map with version 1.4.2 and India template selected.
2. Measurement tool should not appear, only zoom in and out.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169761868)