### PR TITLE
Change source to copyrightText instead of name for arcgis connector

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -219,10 +219,10 @@ class Dataset
       lang_metadata = {}
       arcgis_metadata = ArcgisService.build_metadata(self.connector_url)
       lang_metadata[:description] = arcgis_metadata['description']
-      lang_metadata[:source] = arcgis_metadata['name']
+      lang_metadata[:source] = arcgis_metadata['copyrightText']
 
       columns = {}
-      arcgis_metadata['fields'].each {|f| columns[f['name']] = { 'alias': f['alias'] } }
+      arcgis_metadata['fields'].each { |f| columns[f['name']] = {'alias': f['alias']} }
       lang_metadata[:columns] = columns
       lang_metadata[:language] = language
 


### PR DESCRIPTION
This PR fixes the bug which loses the ArcGIS metadata information

## Testing instructions

1. Create a new dataset for ArcGIS type
2. Edit the created dataset

The dataset should appear with existing ArcGIS information and `source` as the `copyrightText`

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/169372669