### PR TITLE
Fix a bug where the dashboard could crash

### DIFF
--- a/app/javascript/components/shared/Dashboard/dashboard.helpers.js
+++ b/app/javascript/components/shared/Dashboard/dashboard.helpers.js
@@ -1,6 +1,10 @@
 import get from 'lodash/get';
 
 const isEmptyMetadata = (metadata) => {
+  if (!metadata) {
+    return true;
+  }
+
   const keys = [
     'description',
     'citation',


### PR DESCRIPTION
This PR fixes a bug where the dashboards would crash if no metadata would be available in the user's language.

## Testing instructions

1. Create a dashboard with any dataset (optional)
2. Open the dashboard's public page

Since Transifex is not run locally, the selected language will be `''`. As a consequence, there won't be any metadata corresponding to this empty string.

If the dashboard is correctly displayed, then this PR fixes the issue.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169919468).
