### PR TITLE
Fix an issue where some parts of the wysiwyg might not be visible

### DIFF
--- a/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
+++ b/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
@@ -1,4 +1,9 @@
 .vizz-wysiwyg {
+  // The margin is needed for the floating menu displayed when selecting some text
+  // Without it, if the user selects the last line of text, the font style dropdown might not be
+  // entirely visible
+  margin-bottom: 80px;
+
   .cw-quill .ql-bubble .ql-tooltip {
     // Must be below .c-action-bar and the modal
     // for the link edition but over .cw-wysiwyg-toolbar


### PR DESCRIPTION
This PR fixes an issue where the font style dropdown menu of the wysiwyg's floating menu might be partially hidden at the bottom.

<p align="center">
<img width="509" alt="Dropdown menu is not hidden anymore" src="https://user-images.githubusercontent.com/6073968/69654024-03885480-106c-11ea-8405-81d70cc435df.png">
</p>

If we would to increase the `z-index` value of the floating menu, it would overlap the action bar that is located at the bottom of the screen, so instead, this PR adds a sufficiently big margin at the bottom of the wysiwyg.

## Testing instructions

1. Follow the first few steps to create a new Open Content page
2. At the «Content» step, add a new text block and paste a few paragraphs of text
3. Select a word of the last line of content
4. Click on the font style dropdown

Make sure you're able to see all the options of the dropdown (scrolling might be required).

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169881213).
