### PR TITLE
Fix a bug preventing the user from downloading filtered datasets in Chrome

### DIFF
--- a/app/javascript/helpers/api.js
+++ b/app/javascript/helpers/api.js
@@ -272,7 +272,7 @@ export const getDatasetDownloadUrls = (datasetId, datasetProvider, sqlQuery) => 
   const canDownloadCSV = ['rasdaman', 'nexgddp', 'loca', 'gee'].indexOf(datasetProvider) === -1;
   const canDownloadJSON = ['rasdaman', 'nexgddp', 'loca'].indexOf(datasetProvider) === -1;
 
-  const query = `${ENV.API_URL}/download/${datasetId}?sql=${sqlQuery}`;
+  const query = `${ENV.API_URL}/download/${datasetId}?sql=${encodeURIComponent(sqlQuery)}`;
   return {
     ...(canDownloadCSV ? { csv: `${query}&format=csv` } : {}),
     ...(canDownloadJSON ? { json: `${query}&format=json` } : {})


### PR DESCRIPTION
**⚠️ This PR depends on #381. You might not be able to test it without the fix provided by #381.**

This PR fixes an issue where the user wouldn't be able to download the data associated with a dashboard in Chrome.

<p align="center">
<img width="767" alt="Widget displayed in a dashboard with info and CSV download buttons below it" src="https://user-images.githubusercontent.com/6073968/69956683-8db33b80-14f8-11ea-9bc3-0daf164fd8cb.png">
</p>

This would happen if the user would filter the dashboard using a numeric column. The reason being that the download URL would contain a “<” sign and [Chrome blocks URLs that contain it](https://www.chromestatus.com/feature/5735596811091968).

## Testing instructions

**Using Chrome:**
1. Create a dashboard based on a dataset that contains at least one numeric column (optional)
2. Open the public dashboard
3. Add a filter based on a numeric column, and move the left-side handle toward the centre

<p align="center">
<img width="803" alt="Interface to add filters: a numeric column has been selected and the lower bound of values has been lifted, as instructed" src="https://user-images.githubusercontent.com/6073968/69956931-55f8c380-14f9-11ea-99be-4eaf5c3fff34.png">
</p>

4. Click «Apply filters»
5. Below the widget, click the button to download the data as CSV

If the file is successfully downloaded, then this PR has fixed the issue.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/169922929).
