### PR TITLE
Fix bug with removes session data between steps

### DIFF
--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -321,11 +321,7 @@ class Management::PageStepsController < ManagementController
     # Verify if the manager is editing a page or creating a new one
     @page = params[:site_page_id] ? SitePage.find(params[:site_page_id]) : (SitePage.new site_id: @site.id)
 
-    @page_id = if @page&.persisted?
-                 params[:dataset_id] || @page.id.to_s
-               else
-                 :new
-               end
+    @page_id = @page&.persisted? ? @page.id.to_s : :new
   end
 
   # Builds the current page state based on the database, session and params


### PR DESCRIPTION
Fix the bug on `Management::PageStepsController` to ensure that it uses information of the session between the different steps.

## Testing instructions

1. Edit an existing page (map page for example)
2. Change the position of the page and click continue.
3. Change details of the page and click continue.
4. Make new changes and save

The information of the previous steps (position and details) should be saved.

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/168644708](https://www.pivotaltracker.com/story/show/168644708)