### PR TITLE
Fix validation for content_type on group site_pages

### DIFF
--- a/app/models/site_page.rb
+++ b/app/models/site_page.rb
@@ -223,8 +223,9 @@ class SitePage < Page
     end
 
     # Validate type
-    if steps_list[:pages].index('type') <= step_index
-      self.errors['content_type'] << 'Please select a valid type' unless self.content_type > 0 && self.content_type <= ContentType.length
+    if steps_list[:pages].index('type') <= step_index &&
+       !ContentType.list.include?(content_type)
+      self.errors['content_type'] << 'Please select a valid type'
     end
 
 


### PR DESCRIPTION
Fix the validation of `content_type` when we are selecting it on site page creation.

## Testing instructions

1. Create a site page and continue until the last step.
2. Select group site pages content type.

You should not receive any errors.

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/169878991](https://www.pivotaltracker.com/story/show/169878991)