### PR TITLE
Fix a style issue that prevented the user from seeing and editing all the info of the users of a site

### DIFF
--- a/app/assets/stylesheets/layouts/management/l-user-list.scss
+++ b/app/assets/stylesheets/layouts/management/l-user-list.scss
@@ -1,0 +1,5 @@
+.l-user-list {
+  // We make sure the fixed c-action-bar doesn't cover the content if the
+  // screen has a small height
+  padding: 50px 0 75px;
+}

--- a/app/views/management/sites/associations.html.erb
+++ b/app/views/management/sites/associations.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <%= form_for @site, url: management_site_update_associations_path, method: :put do |f| %>
-  <div class="l-site-creation -users">
+  <div class="l-user-list">
     <div class="wrapper">
       <div class="c-cards-list">
         <%= f.fields_for :user_site_associations, @site.user_site_associations.sort do |ff| %>


### PR DESCRIPTION
This PR fixes a style issue in the users list page of a site (management): the bottom row would be partially hidden by the fixed action bar.

<p align="center">
<img width="1246" alt="Last row of list of users is not hidden by the actions bar anymore" src="https://user-images.githubusercontent.com/6073968/70134611-5cfe0e00-1680-11ea-9af6-d4723eca2130.png">
</p>

## Testing instructions

1. Go to the management section of any site
2. Click the «Users» tab
3. Reduce the height of your browser's window

Make sure that you can see all of the information of the last row of users, including the two «Site admin» and «Publisher» checkboxes.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/170083816).
