### PR TITLE
Change the template preview flow to prevent the popup permission request

### DIFF
--- a/app/assets/javascripts/views/shared/colorSelectorView.js
+++ b/app/assets/javascripts/views/shared/colorSelectorView.js
@@ -17,7 +17,9 @@
       var colorInput = this.el.querySelector('input[type="color"]');
 
       textInput.value = color;
+      textInput.dispatchEvent(new Event('change'));
       colorInput.value = color;
+      colorInput.dispatchEvent(new Event('change'));
     }
   });
 })(this.App);

--- a/app/assets/javascripts/views/shared/colorSelectorView.js
+++ b/app/assets/javascripts/views/shared/colorSelectorView.js
@@ -3,6 +3,7 @@
 
   App.View.ColorSelectorView = Backbone.View.extend({
     events: {
+      'change input[type="text"]': '_updateColor',
       'change input[type="color"]': '_updateColor'
     },
 
@@ -13,8 +14,10 @@
     _updateColor: function (e) {
       var color = e.currentTarget.value;
       var textInput = this.el.querySelector('input[type="text"]');
+      var colorInput = this.el.querySelector('input[type="color"]');
 
       textInput.value = color;
+      colorInput.value = color;
     }
   });
 })(this.App);

--- a/app/assets/stylesheets/components/admin/c-admin-preview-button.scss
+++ b/app/assets/stylesheets/components/admin/c-admin-preview-button.scss
@@ -1,0 +1,16 @@
+.c-admin-preview-button {
+  display: inline-block;
+
+  & + .c-button {
+    margin-left: 15px;
+  }
+
+  > .c-button {
+    display: inline-block;
+
+    &.-loading {
+      padding-top: 4px;
+      padding-bottom: 4px;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/shared/c-action-bar.scss
+++ b/app/assets/stylesheets/components/shared/c-action-bar.scss
@@ -12,14 +12,8 @@
     transform: translateX(-50%);
   }
 
-  .c-button + .c-button,
-  .c-button + .button-wrapper,
-  .button-wrapper + .c-button {
+  .c-button + .c-button {
     margin-left: 15px;
-  }
-
-  .button-wrapper {
-    display: inline-block;
   }
 
   &.-wide {
@@ -37,6 +31,10 @@
     align-items: center;
     justify-content: space-between;
     height: 100%;
+
+    > .flex {
+      display: flex;
+    }
   }
 
   &.-embed {

--- a/app/assets/stylesheets/components/shared/c-action-bar.scss
+++ b/app/assets/stylesheets/components/shared/c-action-bar.scss
@@ -15,8 +15,11 @@
   .c-button + .c-button,
   .c-button + .button-wrapper,
   .button-wrapper + .c-button {
-    display: inline-block; // Needed for .button-wrapper
     margin-left: 15px;
+  }
+
+  .button-wrapper {
+    display: inline-block;
   }
 
   &.-wide {

--- a/app/javascript/containers/AdminPreviewButton.js
+++ b/app/javascript/containers/AdminPreviewButton.js
@@ -3,98 +3,174 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import queryString from 'query-string';
 
-const consumer = window.ActionCable.createConsumer();
+const CONSUMER = window.ActionCable.createConsumer();
 
-// Not really React way but nothing can be done while the form is not in a component.
-function getSiteSettings() {
-  // We could use just the selector if naming followed a regular rule.
-  const fields = [
-    { name: 'color', selector: '#accent-color_id' },
-    { name: 'content_width', selector: '#content_width' },
-    { name: 'content_font', selector: '#content_font' },
-    { name: 'heading_font', selector: '#heading_font' },
-    { name: 'cover_size', selector: '#cover_size' },
-    { name: 'cover_text_alignment', selector: '#cover_text_alignment' },
-    { name: 'header_separators', selector: '#header_separators' },
-    { name: 'header_background', selector: '#header_background' },
-    { name: 'header_transparency', selector: '#header_transparency' },
-    { name: 'header_login_enabled', selector: '#header_login_enabled' },
-    { name: 'footer_background', selector: '#footer_background' },
-    { name: 'footer_text_color', selector: '#footer_text_color' },
-    { name: 'footer_links_color', selector: '#footer-links-color' }
-  ];
+const SETTINGS_DICT = {
+  color: { selector: '#accent-color_id', multiple: false },
+  content_width: { selector: '#content_width', multiple: false },
+  content_font: { selector: '#content_font', multiple: false },
+  heading_font: { selector: '#heading_font', multiple: false },
+  cover_size: { selector: '#cover_size', multiple: false },
+  cover_text_alignment: { selector: '#cover_text_alignment', multiple: false },
+  header_separators: { selector: '#header_separators', multiple: false },
+  header_background: { selector: '#header_background', multiple: false },
+  header_transparency: { selector: '#header_transparency', multiple: false },
+  header_login_enabled: { selector: '#header_login_enabled', multiple: false },
+  'header-country-colours': {
+    selector: '.country-colors-container input[type="color"]',
+    multiple: true
+  },
+  footer_background: { selector: '#footer_background', multiple: false },
+  footer_text_color: { selector: '#footer_text_color', multiple: false },
+  footer_links_color: { selector: '#footer-links-color', multiple: false }
+};
 
-  const values = fields.reduce((acc, field) => ({
-    ...acc,
-    [field.name]: document.querySelector(field.selector).value
-  }), {});
+const getSettingsValue = () => {
+  return Object.keys(SETTINGS_DICT).reduce((res, setting) => {
+    const element = SETTINGS_DICT[setting].multiple
+      ? document.querySelectorAll(SETTINGS_DICT[setting].selector)
+      : document.querySelector(SETTINGS_DICT[setting].selector);
 
-  const headerCountryColors = Array.from(document.querySelectorAll('.country-colors-container input[type="color"]'))
-    .map(countryColor => countryColor.value).join(' ');
+    if (!element) {
+      return res;
+    }
 
-  return { ...values, 'header-country-colours': headerCountryColors };
-}
+    return {
+      ...res,
+      [setting]: SETTINGS_DICT[setting].multiple
+        ? [...element].map(({ value }) => value).join(' ')
+        : element.value
+    };
+  }, {});
+};
 
-export default function AdminPreviewButton({ className, text, slug }) {
-  const [isLoading, setIsLoading] = useState(false);
+const setSettingsListener = listener => {
+  Object.keys(SETTINGS_DICT).forEach(setting => {
+    const selector = SETTINGS_DICT[setting].selector;
+    const isMulti = SETTINGS_DICT[setting].multiple;
 
+    if (!isMulti) {
+      const element = document.querySelector(selector);
+      element.addEventListener('change', listener);
+    } else {
+      const elements = document.querySelectorAll(selector);
+      elements.forEach(element => {
+        element.addEventListener('change', listener);
+      });
+    }
+  });
+};
+
+const removeSettingsListener = listener => {
+  Object.keys(SETTINGS_DICT).forEach(setting => {
+    const selector = SETTINGS_DICT[setting].selector;
+    const isMulti = SETTINGS_DICT[setting].multiple;
+
+    if (!isMulti) {
+      const element = document.querySelector(selector);
+      element.removeEventListener('change', listener);
+    } else {
+      const elements = document.querySelectorAll(selector);
+      elements.forEach(element => {
+        element.removeEventListener('change', listener);
+      });
+    }
+  });
+};
+
+export default function AdminPreviewButton({ className, slug }) {
+  // State machine without constrained transitions
+  // - dirty: the stylesheet needs to be re-generated
+  // - loading: the stylesheet is being generated
+  // - finished: the stylesheet has been generated
+  const [state, setState] = useState('dirty');
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const setDirtyState = useCallback(() => {
+    setState('dirty');
+    setPreviewUrl(null);
+  }, [setState, setPreviewUrl]);
+  const setLoadingState = useCallback(() => setState('loading'), [setState]);
+  const setFinishedState = useCallback(
+    url => {
+      setState('finished');
+      setPreviewUrl(url);
+    },
+    [setState, setPreviewUrl]
+  );
+
+  const onReceiveData = data => {
+    const siteSettings = JSON.parse(data.site_settings);
+    const host = `${window.location.origin}/admin/sites/${slug}/preview`;
+    const queryParams = {
+      'header-country-colours': siteSettings['header-country-colours'].split(
+        ' '
+      ),
+      header_login_enabled: siteSettings.header_login_enabled
+    };
+    const url = `${host}?${queryString.stringify(queryParams, {
+      arrayFormat: 'bracket'
+    })}`;
+
+    setFinishedState(url);
+  };
+
+  const onClickButton = useCallback(() => {
+    $.get(
+      `${window.location.origin}/admin/sites/${slug}/preview/compile`,
+      { site_settings: getSettingsValue() },
+      () => setLoadingState()
+    );
+  }, [setLoadingState]);
+
+  // Set the listeners to switch to the dirty state
   useEffect(() => {
-    consumer.subscriptions.create('PreviewChannel', {
+    setSettingsListener(setDirtyState);
+
+    return () => {
+      removeSettingsListener(setDirtyState);
+    };
+  }, [setDirtyState]);
+
+  // Create the websocket connection
+  useEffect(() => {
+    CONSUMER.subscriptions.create('PreviewChannel', {
       connected: () => {},
       disconnected: () => {},
-      received: (data) => {
-        const siteSettings = JSON.parse(data.site_settings);
-        const host = `${window.location.origin}/admin/sites/${slug}/preview`;
-        const queryParams = {
-          'header-country-colours': siteSettings['header-country-colours'].split(' '),
-          header_login_enabled: siteSettings.header_login_enabled
-        };
-        const url = `${host}?${queryString.stringify(queryParams, {arrayFormat: 'bracket'})}`;
-
-        setIsLoading(false);
-
-        // Open preview page
-        window.open(url, '_blank');
-      }
+      received: onReceiveData
     });
 
     return () => {};
   }, []);
 
-  const compileStyleSheet = () => {
-    $.get(
-      `${window.location.origin}/admin/sites/${slug}/preview/compile`,
-      { site_settings: getSiteSettings() },
-      () => setIsLoading(true),
+  if (state === 'finished') {
+    return (
+      <a href={previewUrl} target="_blank" className={classnames(className)}>
+        See preview
+      </a>
     );
-  };
-
-  const onClickButton = useCallback(() => {
-    if (!isLoading) {
-      compileStyleSheet();
-    }
-  }, [isLoading]);
+  }
 
   return (
     <button
       type="button"
       className={classnames(className)}
       onClick={onClickButton}
-      disabled={isLoading}
+      disabled={state === 'loading'}
     >
-      {isLoading ? <div className="c-loading-spinner -inline -small" /> : text}
+      {state === 'dirty' && 'Update preview'}
+      {state === 'loading' && (
+        <div className="c-loading-spinner -inline -small" />
+      )}
     </button>
   );
 }
 
 AdminPreviewButton.propTypes = {
-  text: PropTypes.string,
   className: PropTypes.string,
   slug: PropTypes.string
 };
 
 AdminPreviewButton.defaultProps = {
-  text: '',
   className: '',
   slug: null
 };

--- a/app/javascript/containers/AdminPreviewButton.js
+++ b/app/javascript/containers/AdminPreviewButton.js
@@ -16,14 +16,21 @@ const SETTINGS_DICT = {
   header_background: { selector: '#header_background', multiple: false },
   header_transparency: { selector: '#header_transparency', multiple: false },
   header_login_enabled: { selector: '#header_login_enabled', multiple: false },
+  // NOTE: the country colors inputs are re-rendered every time there's a change (whether it's a
+  // change of value, inputs are added or inputs are removed) by a Backbone view.
+  // That means that the "change" event listeners we'll attach to the inputs won't ever be fired.
+  // Nevertheless, we still need this object to be defined so the values can be serialised and sent
+  // to the back-end.
   'header-country-colours': {
-    selector: '.country-colors-container input[type="color"]',
+    selector: '.js-header-country-colours input[type="text"]',
     multiple: true
   },
   footer_background: { selector: '#footer_background', multiple: false },
   footer_text_color: { selector: '#footer_text_color', multiple: false },
   footer_links_color: { selector: '#footer-links-color', multiple: false }
 };
+
+const COUNTRY_COLORS_CONTAINER_SELECTOR = '.js-header-country-colours';
 
 const getSettingsValue = () => {
   return Object.keys(SETTINGS_DICT).reduce((res, setting) => {
@@ -128,6 +135,25 @@ export default function AdminPreviewButton({ className, slug }) {
 
     return () => {
       removeSettingsListener(setDirtyState);
+    };
+  }, [setDirtyState]);
+
+  // NOTE: the country colors inputs are re-rendered every time there's a change (whether it's a
+  // change of value, inputs are added or inputs are removed) by a Backbone view.
+  // Since React can't re-attach the event listeners to the inputs, we listen to DOM tree changes
+  // instead.
+  useEffect(() => {
+    const observer = new MutationObserver(setDirtyState);
+    observer.observe(
+      document.querySelector(COUNTRY_COLORS_CONTAINER_SELECTOR),
+      {
+        childList: true,
+        subtree: true
+      }
+    );
+
+    return () => {
+      observer.disconnect();
     };
   }, [setDirtyState]);
 

--- a/app/javascript/containers/AdminPreviewButton.js
+++ b/app/javascript/containers/AdminPreviewButton.js
@@ -153,7 +153,7 @@ export default function AdminPreviewButton({ className, slug }) {
   return (
     <button
       type="button"
-      className={classnames(className)}
+      className={classnames(className, { '-loading': state === 'loading' })}
       onClick={onClickButton}
       disabled={state === 'loading'}
     >

--- a/app/views/admin/site_steps/_footer.html.erb
+++ b/app/views/admin/site_steps/_footer.html.erb
@@ -5,17 +5,16 @@
     <%= link_to 'Cancel', admin_sites_path, class: 'c-button -outline -dark-text' %>
     <div>
       <% if @site.id %>
-        <% unless local_assigns[:no_continue] %>
-          <%= f.button Admin::SiteStepsController::CONTINUE, value: Admin::SiteStepsController::CONTINUE, type: 'submit', method: :put, class: 'c-button -outline -dark-text' %>
-        <% end %>
         <% if step == 'style' %>
           <%= react_component('AdminPreviewButton', {
-            text: Admin::SiteStepsController::PREVIEW,
             className: 'c-button -outline -dark-text',
             slug: @site.slug
           }, {
             class: 'button-wrapper'
           }) %>
+        <% end %>
+        <% unless local_assigns[:no_continue] %>
+          <%= f.button Admin::SiteStepsController::CONTINUE, value: Admin::SiteStepsController::CONTINUE, type: 'submit', method: :put, class: 'c-button -outline -dark-text' %>
         <% end %>
         <%= f.button Admin::SiteStepsController::SAVE, value: Admin::SiteStepsController::SAVE, type: 'submit', method: :put, class: 'c-button' %>
       <% else %>

--- a/app/views/admin/site_steps/_footer.html.erb
+++ b/app/views/admin/site_steps/_footer.html.erb
@@ -3,14 +3,14 @@
 <div class="c-action-bar">
   <div class="wrapper">
     <%= link_to 'Cancel', admin_sites_path, class: 'c-button -outline -dark-text' %>
-    <div>
+    <div class="flex">
       <% if @site.id %>
         <% if step == 'style' %>
           <%= react_component('AdminPreviewButton', {
             className: 'c-button -outline -dark-text',
             slug: @site.slug
           }, {
-            class: 'button-wrapper'
+            class: 'c-admin-preview-button'
           }) %>
         <% end %>
         <% unless local_assigns[:no_continue] %>


### PR DESCRIPTION
This PR changes how the preview of the template is opened to prevent requesting the popup permission to the user.

The new flow works like this:
1. The user makes changes to the template
2. They click the “Update preview” button
3. The button is disabled and display a spinner while the stylesheet is being generated
4. The button now displays “See preview”
5. The user clicks the button to open the preview in a new tab/window

Each time the user makes a change to one of the settings, the button returns to its original state.

<p align="center">
<img width="926" alt="The button in the action bar displays “Update preview”" src="https://user-images.githubusercontent.com/6073968/70738214-3426ea00-1d0c-11ea-92e6-12c8cd1eb988.png">
</p>

The key change is that the preview tab is not opened programmatically anymore. When the user clicks the button the last time, it is actually a link.

## Testing instructions

1. Go to the “Style” step of a site
2. Click the “Update preview” button

Make sure the button displays a spinner.

3. Click the “See preview” button when it appears

Make sure a new tab/window opens with the preview.

4. Make any change to the template

Make sure the button displays “Update preview” again.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/170081231).
