### PR TITLE
Remove Continue button on tag searching tab

### DIFF
--- a/app/views/management/page_steps/tag_searching.erb
+++ b/app/views/management/page_steps/tag_searching.erb
@@ -28,5 +28,5 @@
       </div>
     </div>
   </div>
-  <%= render partial: 'management/steps_shared/footer', locals: {f: f, always_save: true, publish: true} %>
+  <%= render partial: 'management/steps_shared/footer', locals: {f: f, no_continue: true, always_save: true, publish: true} %>
 <% end %>


### PR DESCRIPTION
This PR fixes the bug which shows the Continue button when creating a tag searching page.

## Testing instructions

1. Create a new page
2. Fill the position tab
3. Fill the details tab
4. Select tag searching page

You will see the tag searching page without Continue button

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/169900686](https://www.pivotaltracker.com/story/show/169900686)