### PR TITLE
Move preview functionality for non admin users

### DIFF
--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,6 +1,8 @@
-class Admin::PreviewController < AdminController
+class PreviewController < ApplicationController
+  include PermissionsHelper
+
   before_action :load_site
-  before_action :ensure_only_admin_user
+  before_action :set_user_gon
 
   def index
     gon.header_login_enabled = params[:header_login_enabled]

--- a/app/javascript/containers/PreviewButton.js
+++ b/app/javascript/containers/PreviewButton.js
@@ -85,7 +85,7 @@ const removeSettingsListener = listener => {
   });
 };
 
-export default function AdminPreviewButton({ className, slug }) {
+export default function PreviewButton({ className, slug }) {
   // State machine without constrained transitions
   // - dirty: the stylesheet needs to be re-generated
   // - loading: the stylesheet is being generated
@@ -107,7 +107,7 @@ export default function AdminPreviewButton({ className, slug }) {
 
   const onReceiveData = data => {
     const siteSettings = JSON.parse(data.site_settings);
-    const host = `${window.location.origin}/admin/sites/${slug}/preview`;
+    const host = `${window.location.origin}/sites/${slug}/preview`;
     const queryParams = {
       'header-country-colours': siteSettings['header-country-colours'].split(
         ' '
@@ -123,7 +123,7 @@ export default function AdminPreviewButton({ className, slug }) {
 
   const onClickButton = useCallback(() => {
     $.get(
-      `${window.location.origin}/admin/sites/${slug}/preview/compile`,
+      `${window.location.origin}/sites/${slug}/preview/compile`,
       { site_settings: getSettingsValue() },
       () => setLoadingState()
     );
@@ -191,12 +191,12 @@ export default function AdminPreviewButton({ className, slug }) {
   );
 }
 
-AdminPreviewButton.propTypes = {
+PreviewButton.propTypes = {
   className: PropTypes.string,
   slug: PropTypes.string
 };
 
-AdminPreviewButton.defaultProps = {
+PreviewButton.defaultProps = {
   className: '',
   slug: null
 };

--- a/app/javascript/containers/PreviewStatic.js
+++ b/app/javascript/containers/PreviewStatic.js
@@ -7,7 +7,7 @@ import Cover from './Cover';
 import HomePage from './HomePage';
 import StaticPage from './StaticPage';
 
-export default function AdminPreviewStatic({ siteSettings, homepage, opencontent }) {
+export default function PreviewStatic({ siteSettings, homepage, opencontent }) {
   const [isHomepage, setIsHomepage] = useState(true);
 
   const onClickHomepage = useCallback(() => setIsHomepage(true), [setIsHomepage]);
@@ -162,7 +162,7 @@ export default function AdminPreviewStatic({ siteSettings, homepage, opencontent
   );
 }
 
-AdminPreviewStatic.propTypes = {
+PreviewStatic.propTypes = {
   siteSettings: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   homepage: PropTypes.shape({}).isRequired,
   opencontent: PropTypes.shape({}).isRequired,

--- a/app/views/admin/site_steps/_footer.html.erb
+++ b/app/views/admin/site_steps/_footer.html.erb
@@ -6,7 +6,7 @@
     <div class="flex">
       <% if @site.id %>
         <% if step == 'style' %>
-          <%= react_component('AdminPreviewButton', {
+          <%= react_component('PreviewButton', {
             className: 'c-button -outline -dark-text',
             slug: @site.slug
           }, {

--- a/app/views/front/_menu.html.erb
+++ b/app/views/front/_menu.html.erb
@@ -1,4 +1,4 @@
-<%# WARN: if you make any change to this template, please update app/javascript/containsers/AdminPreviewStatic.js %>
+<%# WARN: if you make any change to this template, please update app/javascript/containsers/PreviewStatic.js %>
 <header class="c-header js-header">
   <div class="mobile-drawer js-mobile-drawer">
     <div class="wrapper">

--- a/app/views/preview/index.html.erb
+++ b/app/views/preview/index.html.erb
@@ -150,4 +150,4 @@
   }
 } %>
 
-<%= react_component('AdminPreviewStatic', config) %>
+<%= react_component('PreviewStatic', config) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,6 @@ Rails.application.routes.draw do
     resources :temporary_content_images, only: [:create]
     resources :sites, param: :slug do
       resources :site_steps, only: [:show, :update, :edit]
-      resources :preview, only: [:index] do
-        collection do
-          get :compile
-        end
-      end
     end
 
     resources :site_steps, only: [:show, :update, :new]
@@ -100,6 +95,14 @@ Rails.application.routes.draw do
     resources :context_steps, only: [:edit, :show, :update]
   end
   resources :context_steps, only: [:new, :show, :update]
+
+  resources :sites, param: :slug, only: :none do
+    resources :preview, only: [:index] do
+      collection do
+        get :compile
+      end
+    end
+  end
 
   get '/no-permissions', to: 'static_page#no_permissions'
   get '/widget_data', to: 'static_page#widget_data'


### PR DESCRIPTION
This PR ensures that the preview of the sites works for non-admin users.

## Testing instructions

1. Log with a no-admin user which has owned sites
2. Edit one of his/her sites
3. Access to settings tabs and change anything
4. Generate the preview

Now the preview should work fine.

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/170081522](https://www.pivotaltracker.com/story/show/170081522)
