### PR TITLE
Fix bug with additional uri for sites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ services:
 addons:
   postgresql: "9.4"
 before_install:
-  - gem install bundler -v 1.12.5
+  - gem install bundler -v 1.17.3
   - bundle install
   - RAILS_ENV=test bundle exec rake db:create db:schema:load

--- a/app/controllers/admin/site_steps_controller.rb
+++ b/app/controllers/admin/site_steps_controller.rb
@@ -63,7 +63,7 @@ class Admin::SiteStepsController < AdminController
       site_id: @site_id,
       session: session,
       params: params,
-      site_params: site_params
+      site_params: params[:site] ? site_params : {}
     )
 
     @site = result.site if result.success?

--- a/app/interactors/site_steps/update_logic/name_step.rb
+++ b/app/interactors/site_steps/update_logic/name_step.rb
@@ -8,7 +8,12 @@ module SiteSteps
           # If the user pressed the save button
           save_button_logic(context.site_id, context.site, context.session)
         else
-          continue_button_logic(context.site, context.params)
+          continue_button_logic(
+            context.site_id,
+            context.site,
+            context.params,
+            context.session
+          )
         end
       end
 
@@ -25,10 +30,11 @@ module SiteSteps
         end
       end
 
-      def continue_button_logic(site, params)
+      def continue_button_logic(site_id, site, params, session)
         site.form_step = 'name'
         if params.dig('site', 'routes_attributes', '0')
           params['site']['routes_attributes']['0']['main'] = true
+          session[:site][site_id] = params['site']
         end
 
         return if site.valid?


### PR DESCRIPTION
This PR fixes two bugs on the site creation:
- Avoid the 500 HTTP error when a context is not selected
- Mark the first route as the main one when we click on the continue button

## Testing instructions

Two tests should be done:

- No context is selected

1. Create a new site
2. Complete all steps until context and click to Continue without selecting one.

As a result, you can continue with the Settings step

- Multiple URL are specified for the site

1. Create a new site
2. Fill the main URL and another one as an alternative
3. Continue with the following steps
4. Access to the main URL and check that the content is correct
5. Access to the alternative URL and check that it is redirected to the main URL

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/170507258](https://www.pivotaltracker.com/story/show/170507258)