### PR TITLE
Allow the user to customise the height of the widgets in the Open Content pages

### DIFF
--- a/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
+++ b/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
@@ -111,6 +111,41 @@
         }
       }
     }
+    
+    .fa-wysiwyg-configuration {
+      display: flex;
+      align-items: stretch;
+      border: 1px solid $color-6;
+
+      header {
+        position: relative;
+        flex-basis: 40px;
+        flex-shrink: 0;
+        flex-grow: 0;
+        background-color: $color-6;
+        
+        span {
+          position: absolute;
+          bottom: 0;
+          display: block;
+          transform: rotate(-90deg) translate(10px, 100%);
+          transform-origin: bottom left;
+          color: $color-3;
+          line-height: 40px;
+          text-transform: uppercase;
+          font-weight: $font-weight-bold;
+        }
+      }
+
+      main {
+        flex-grow: 1;
+        padding: 10px 15px;
+
+        > .no-margin-bottom {
+          margin-bottom: 0;
+        }
+      }
+    }
   }
 
   blockquote {

--- a/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
+++ b/app/assets/stylesheets/components/shared/c-vizz-wysiwyg.scss
@@ -111,8 +111,16 @@
         }
       }
     }
+
+    &.-widget {
+      .fa-wysiwyg-configuration {
+        margin-top: 10px;
+      }
+    }
     
     .fa-wysiwyg-configuration {
+      width: 100%;
+      min-height: 130px; // Needed for the header
       display: flex;
       align-items: stretch;
       border: 1px solid $color-6;
@@ -143,6 +151,30 @@
 
         > .no-margin-bottom {
           margin-bottom: 0;
+        }
+
+        label {
+          display: block;
+        }
+
+        input {
+          display: block;
+          padding: 10px;
+          margin-top: 5px;
+          font-size: $font-size-small;
+          border: 1px solid $color-9;
+          color: $color-4;
+        }
+
+        textarea {
+          display: block;
+          width: 100%;
+          min-height: 30px;
+          padding: 10px;
+          margin-top: 5px;
+          font-size: $font-size-small;
+          border: 1px solid $color-9;
+          color: $color-4;
         }
       }
     }
@@ -441,11 +473,29 @@
       }
     }
   }
-
-  .c-we-chart,
-  .c-we-chart .chart {
-    min-height: 250px;
+  
+  // Here we use flex boxes instead of just setting the height to 100% because the top container
+  // (.c-we-chart-container) has a min-height defined in JS
+  // Because of that, the children can't use height: 100%;
+  .c-we-chart-container {
+    display: flex;
+    flex-direction: column;
     width: 100%;
+    min-height: 250px;
+
+    .c-we-chart {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      flex-basis: 100%;
+      flex-grow: 1;
+
+      .chart {
+        width: 100%;
+        flex-basis: 100%;
+        flex-grow: 1;
+      }
+    }
   }
 
   .c-we-chart-title {
@@ -520,31 +570,6 @@
 
       border: 1px solid transparent;
       cursor: pointer;
-    }
-  }
-
-  &__preview {
-    &--caption {
-      display: block;
-      font-size: $font-size-small;
-      padding: 5px;
-      color: $color-4;
-    }
-
-    &--captionInput {
-      display: block;
-
-      width: 100%;
-      min-height: 30px;
-
-      padding: 10px;
-      margin: 20px 0 0 0;
-
-      font-size: $font-size-small;
-      border: 1px solid $color-9;
-      color: $color-4;
-
-      resize: none;
     }
   }
 }

--- a/app/javascript/components/shared/Wysiwyg/blocks/ImagePreview.js
+++ b/app/javascript/components/shared/Wysiwyg/blocks/ImagePreview.js
@@ -24,7 +24,6 @@ class ImagePreview extends PureComponent {
               <label>
                 Caption
                 <textarea
-                  className="fa-wysiwyg-file__preview--captionInput"
                   placeholder="Add caption"
                   defaultValue={caption}
                   onChange={e =>
@@ -41,7 +40,6 @@ class ImagePreview extends PureComponent {
               <label className="no-margin-bottom">
                 Alternative text
                 <textarea
-                  className="fa-wysiwyg-file__preview--captionInput"
                   placeholder="Add alternative text"
                   defaultValue={alternativeText}
                   onChange={e =>

--- a/app/javascript/components/shared/Wysiwyg/blocks/ImagePreview.js
+++ b/app/javascript/components/shared/Wysiwyg/blocks/ImagePreview.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 
 class ImagePreview extends PureComponent {
@@ -16,42 +16,47 @@ class ImagePreview extends PureComponent {
           <span className="fa-wysiwyg-file__preview--caption">{caption}</span>
         )}
         {!readOnly && (
-          <Fragment>
-            <label>
-              Caption
-              <textarea
-                className="fa-wysiwyg-file__preview--captionInput"
-                placeholder="Add caption"
-                defaultValue={caption}
-                onChange={e =>
-                  onChange({
-                    content: {
-                      alternativeText,
-                      caption: e.target.value,
-                      image
-                    }
-                  })
-                }
-              />
-            </label>
-            <label>
-              Alternative text
-              <textarea
-                className="fa-wysiwyg-file__preview--captionInput"
-                placeholder="Add alternative text"
-                defaultValue={alternativeText}
-                onChange={e =>
-                  onChange({
-                    content: {
-                      alternativeText: e.target.value,
-                      caption,
-                      image
-                    }
-                  })
-                }
-              />
-            </label>
-          </Fragment>
+          <div className="fa-wysiwyg-configuration">
+            <header>
+              <span>Configuration</span>  
+            </header>
+            <main>
+              <label>
+                Caption
+                <textarea
+                  className="fa-wysiwyg-file__preview--captionInput"
+                  placeholder="Add caption"
+                  defaultValue={caption}
+                  onChange={e =>
+                    onChange({
+                      content: {
+                        alternativeText,
+                        caption: e.target.value,
+                        image
+                      }
+                    })
+                  }
+                />
+              </label>
+              <label className="no-margin-bottom">
+                Alternative text
+                <textarea
+                  className="fa-wysiwyg-file__preview--captionInput"
+                  placeholder="Add alternative text"
+                  defaultValue={alternativeText}
+                  onChange={e =>
+                    onChange({
+                      content: {
+                        alternativeText: e.target.value,
+                        caption,
+                        image
+                      }
+                    })
+                  }
+                />
+              </label>
+            </main>
+          </div>
         )}
       </div>
     );

--- a/app/javascript/components/shared/Wysiwyg/blocks/WidgetBlock.js
+++ b/app/javascript/components/shared/Wysiwyg/blocks/WidgetBlock.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { VegaChart } from 'widget-editor';
 import { Promise } from 'es6-promise';
 
-import { isVegaWidget, getVegaWidgetQueryParams, getDatasetDownloadUrls, getSqlFilters } from 'helpers/api';
+import {
+  isVegaWidget,
+  getVegaWidgetQueryParams,
+  getDatasetDownloadUrls,
+  getSqlFilters
+} from 'helpers/api';
 import Icon from 'components/icon';
 
 // /widget_data.json?widget_id=
@@ -15,7 +20,11 @@ class WidgetBlock extends React.Component {
   static async getDatasetProvider(datasetId) {
     const query = `${ENV.API_URL}/dataset/${datasetId}`;
     const data = await fetch(query).then(res => res.json());
-    const { data: { attributes: { provider } } } = data;
+    const {
+      data: {
+        attributes: { provider }
+      }
+    } = data;
     return provider;
   }
 
@@ -29,12 +38,18 @@ class WidgetBlock extends React.Component {
       return {};
     }
 
-    const datasetProvider = await WidgetBlock.getDatasetProvider(widget.dataset);
-    const { filters, limit } = getVegaWidgetQueryParams({ widgetConfig: widget.visualization });
+    const datasetProvider = await WidgetBlock.getDatasetProvider(
+      widget.dataset
+    );
+    const { filters, limit } = getVegaWidgetQueryParams({
+      widgetConfig: widget.visualization
+    });
 
     const serializedFilters = getSqlFilters(filters, datasetProvider);
 
-    const sqlQuery = `SELECT * FROM data ${serializedFilters.length ? `WHERE ${serializedFilters}` : ''}`;
+    const sqlQuery = `SELECT * FROM data ${
+      serializedFilters.length ? `WHERE ${serializedFilters}` : ''
+    }`;
 
     return getDatasetDownloadUrls(widget.dataset, datasetProvider, sqlQuery);
   }
@@ -51,50 +66,88 @@ class WidgetBlock extends React.Component {
 
   componentWillMount() {
     const { item } = this.props;
-    this.getChart(item.content.widgetId)
-      .then(async () => {
-        this.setState({ downloadUrls: await WidgetBlock.getDownloadUrls(this.state.widget) });
+    this.getChart(item.content.widgetId).then(async () => {
+      this.setState({
+        downloadUrls: await WidgetBlock.getDownloadUrls(this.state.widget)
       });
+    });
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     // This fixes a bug where the widgets would reload when hovering them
-    return this.state !== nextState
-      || this.props.item.content.widgetId !== nextProps.item.content.widgetId;
+    return (
+      this.state !== nextState ||
+      this.props.item.content.widgetId !== nextProps.item.content.widgetId ||
+      this.props.item.content.height !== nextProps.item.content.height
+    );
   }
 
   getChart(widgetId) {
-    return fetch(`${window.location.origin}/widget_data.json?widget_id=${widgetId}`).then((res) => {
-      return res.json();
-    }).then((w) => new Promise((resolve) => {
-      const widget = w;
-      if (widget.visualization && widget.visualization.width !== undefined) delete widget.visualization.width;
-      if (widget.visualization && widget.visualization.height !== undefined) delete widget.visualization.height;
+    return fetch(
+      `${window.location.origin}/widget_data.json?widget_id=${widgetId}`
+    )
+      .then(res => {
+        return res.json();
+      })
+      .then(
+        w =>
+          new Promise(resolve => {
+            const widget = w;
+            if (
+              widget.visualization &&
+              widget.visualization.width !== undefined
+            )
+              delete widget.visualization.width;
+            if (
+              widget.visualization &&
+              widget.visualization.height !== undefined
+            )
+              delete widget.visualization.height;
 
-      this.setState({
-        loading: false,
-        widget
-      }, resolve);
-    }));
+            this.setState(
+              {
+                loading: false,
+                widget
+              },
+              resolve
+            );
+          })
+      );
   }
 
   render() {
+    const { readOnly, item, onChange } = this.props;
+    const { height } = item.content;
     const { loading, widget, downloadUrls } = this.state;
 
-    if (loading || !widget.visualization) { return null; }
+    if (loading || !widget.visualization) {
+      return null;
+    }
 
     return (
       <Fragment>
         <div className="c-we-chart-title">{widget.name}</div>
-        <VegaChart
-          data={widget.visualization}
-          reloadOnResize
-        />
-        {widget.metadata && !!widget.metadata.length && widget.metadata[0].attributes.info && (
-          <div className="c-we-chart-caption">
-            {widget.metadata[0].attributes.info.caption}
-          </div>
-        )}
+        <div
+          className="c-we-chart-container"
+          // We choose min-height instead of height because custom widget might define a higher
+          // height
+          // Anyway, we don't want widget shorter than 250px
+          style={{ 'min-height': `${Math.max(height, 250) || 250}px` }}
+        >
+          <VegaChart
+            // The key here is used to make sure the widget is rerendered when its height is changed
+            key={height}
+            data={widget.visualization}
+            reloadOnResize
+          />
+        </div>
+        {widget.metadata &&
+          !!widget.metadata.length &&
+          widget.metadata[0].attributes.info && (
+            <div className="c-we-chart-caption">
+              {widget.metadata[0].attributes.info.caption}
+            </div>
+          )}
         <div className="c-we-chart-download">
           {downloadUrls.csv && (
             <a
@@ -107,6 +160,39 @@ class WidgetBlock extends React.Component {
             </a>
           )}
         </div>
+        {!readOnly && (
+          <div className="fa-wysiwyg-configuration">
+            <header>
+              <span>Configuration</span>
+            </header>
+            <main>
+              <label>
+                Height (250px minimum)
+                <input
+                  type="number"
+                  className="fa-wysiwyg-file__preview--captionInput"
+                  placeholder="Height in pixels"
+                  defaultValue={height || 250}
+                  min={250}
+                  onChange={e =>
+                    onChange({
+                      content: {
+                        ...item.content,
+                        height: Number.isInteger(+e.target.value)
+                          ? Math.max(+e.target.value, 250) // Minimum height should stay 250px
+                          : height
+                      }
+                    })
+                  }
+                />
+              </label>
+              <small>
+                Please note that if a custom widget has its height defined in
+                the Vega specification, it won't be overwritten.
+              </small>
+            </main>
+          </div>
+        )}
       </Fragment>
     );
   }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -308,7 +308,8 @@ class Site < ApplicationRecord
   end
 
   def apply_settings
-    system "rake site:apply_settings[#{self.id}] &"
+    #system "rake site:apply_settings[#{self.id}] &"
+    compile_css
   end
 
   ###################################################

--- a/app/services/widget_service.rb
+++ b/app/services/widget_service.rb
@@ -7,7 +7,6 @@ class WidgetService < ApiService
                                 'page[number]': '1', 'page[size]': '10000',
                                 'status': status,
                                 'application': ENV.fetch('API_APPLICATIONS'),
-                                'env': ENV.fetch('API_ENV'),
                                 '_': Time.now.to_s
 
     widgets_json = JSON.parse widgets_request.body
@@ -142,7 +141,6 @@ end
                                 'page[number]': '1', 'page[size]': '10000',
                                 'status': status,
                                 'application': ENV.fetch('API_APPLICATIONS'),
-                                'env': ENV.fetch('API_ENV'),
                                 '_': Time.now.to_s
 
     widgets_json = JSON.parse widgets_request.body

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,7 +44,7 @@ namespace :deploy do
           with rails_env: fetch(:rails_env) do
             with node_env: 'production' do
               execute("cd #{release_path}")
-              execute("bash node -v")
+              execute("node -v")
               execute("yarn")
               # execute(:rake, 'webpacker:compile')
             end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,7 +44,7 @@ namespace :deploy do
           with rails_env: fetch(:rails_env) do
             with node_env: 'production' do
               execute("cd #{release_path}")
-              execute("node -v")
+              execute("bash node -v")
               execute("yarn")
               # execute(:rake, 'webpacker:compile')
             end


### PR DESCRIPTION
This PR lets the user customise the height of the widgets in the Open Content pages.

The user is free to set any height, though the minimum is 250px. Custom widgets that include a height in their Vega specification ignore the height set by the user.

<p align="center">
<img width="1039" alt="Below the widget is a “configuration” box where the user has set its height to 800 pixels. There's also a note regarding the custom widgets." src="https://user-images.githubusercontent.com/6073968/72255775-85721400-35ff-11ea-83cd-b29709b9bb18.png">
</p>

In addition, this PR adds some new styles for the configuration of the blocks in the wysiwyg (widget and image blocks).

## Testing instructions

1. Edit any Open Content page
2. If it doesn't include any widget, add one
3. Below the widget, change its height in the “Configuration” box
4. Set the height to something lower than 250px

Make sure the height is still 250px.

5. Set the height to something bigger than 250px

Make sure the widget is updated and taller.

6. Write anything else in the input (like some text)

Make sure the widget is reset to a 250px height.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/170233309).
