### PR TITLE
Update the CSV download button behaviour on Open Content pages

### DIFF
--- a/app/javascript/components/shared/Wysiwyg/blocks/WidgetBlock.js
+++ b/app/javascript/components/shared/Wysiwyg/blocks/WidgetBlock.js
@@ -28,12 +28,17 @@ class WidgetBlock extends React.Component {
    * @param {object} widget
    */
   static async getDownloadUrls(widget) {
+    const allowDownload = !!(widget.metadata
+      && widget.metadata.length
+      && widget.metadata[0].attributes.info
+      && widget.metadata[0].attributes.info.allowDownload);
+
     const dataUrl = (widget.visualization && widget.visualization.data
       && widget.visualization.data.length
       && widget.visualization.data[0].url)
       || '';
 
-    if (!dataUrl.length) {
+    if (!dataUrl.length || !allowDownload) {
       return {};
     }
 


### PR DESCRIPTION
This PR makes two changes to the download feature of the widgets in the Open Content pages:
1. Only widgets that have a specific flag can now be downloaded (`allowDownload` in the metadata, see [this task](https://www.pivotaltracker.com/story/show/170235238))
2. SQL query to download the data has been changed (as a consequence, “advanced” widgets can now be downloaded)

The exact requirements are detailed in the Pivotal task (see below).

## Testing instructions

1. Create a widget with any type of filter and aggregation
2. Create an Open Content page with the widget and make it public
3. Open the Open Content page

You must not be able to download the widget as a CSV.

4. Update the metadata of the widget to include an `allowDownload` key with the value `true` in `metadata.attributes.info`:
```
{
	"language": "en",
	"application": "forest-atlas",
	"info": {
		"allowDownload": true
	}
}
```
5. Reload the Open Content page

A download button must be shown below the widget.

6. Click the CSV download button

The file must be a valid CSV one.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/170234777).
