### PR TITLE
Prevent the advanced editor from crashing when editing specific widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "vega": "^3.1.0",
     "vega-lib": "4.4.0",
     "vizz-wysiwyg": "^2.1.2",
-    "widget-editor": "^1.4.4",
+    "widget-editor": "^1.4.6",
     "wri-json-api-serializer": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,10 +738,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@esri/arcgis-to-geojson-utils@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.3.0.tgz#79ab65bf3e40c039dbdebceff4b3b0ec088b189c"
-
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"
@@ -4658,14 +4654,6 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-esri-leaflet@^2.1.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-2.2.3.tgz#858d9b84641d121d9115753db45aeffb67ad72e8"
-  dependencies:
-    "@esri/arcgis-to-geojson-utils" "^1.3.0"
-    leaflet-virtual-grid "^1.0.7"
-    tiny-binary-search "^1.0.3"
-
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
@@ -6988,16 +6976,6 @@ lcid@^2.0.0:
 lcov-parse@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-
-leaflet-virtual-grid@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/leaflet-virtual-grid/-/leaflet-virtual-grid-1.0.7.tgz#0dbb0dacd506b6e6d291314da5022d348729f8ad"
-  dependencies:
-    leaflet "^1.0.0"
-
-leaflet@^1.0.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.4.tgz#7f006ea5832603b53d7269ef5c595fd773060a40"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -12029,10 +12007,6 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-binary-search@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
-
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -13343,17 +13317,16 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-widget-editor@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.4.4.tgz#28d9751eef6ccfc6f4a85662ed1f8ff39bb417d0"
-  integrity sha512-1wpDqWVSGFo0neVXnQnQ+FAYVHdXn40I+146OMBZxDdMgDvTiDkkfjEh3DeCY+N5Y8kra1BGsyP+3uyNj/a0Rw==
+widget-editor@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.4.6.tgz#e7a31d72482f382080d12db71501a5b59a1d5ad0"
+  integrity sha512-smkpRmh2FN7W6XzxZ8tqMpCFtrk5ev+Vua9oT224gxAwumTYwGmtiDQhsKfbEfRCA4TZk8fWyTlMtW8wO5bTMw==
   dependencies:
     autobind-decorator "^2.1.0"
     babel-runtime "^6.26.0"
     classnames "^2.2.5"
     d3-format "^1.2.1"
     d3-time-format "^2.1.1"
-    esri-leaflet "^2.1.1"
     lodash "^4.17.4"
     peer-deps-externals-webpack-plugin "^1.0.2"
     rc-slider "^8.4.0"


### PR DESCRIPTION
The advanced editor would crash when editing specific widgets because the `VegaChart` component of the [widget-editor](github.com/resource-watch/widget-editor) would crash itself. This PR addresses the issue by updating the widget-editor to its latest version, which [fixes the bug](https://github.com/resource-watch/widget-editor/blob/develop/CHANGELOG.md#v146---23012020).

## Testing instructions

1. Open `/management/sites/base-site/widget_steps/c1f84743-9373-4a64-96d3-0e72c7ef184a/edit`
2. Click the “Continue” button

The app must not crash and you must be able to see the widget.

## Pivotal Tracker

No tracked.
