### PR TITLE
Fix a text alignment issue in the dashboards

### DIFF
--- a/app/javascript/pages/admin/edit-dashboard.js
+++ b/app/javascript/pages/admin/edit-dashboard.js
@@ -16,7 +16,7 @@ class EditDashboard extends React.Component {
 
   render() {
     return (
-      <div className="c-edit-dashboard">
+      <div className="c-edit-dashboard vizz-wysiwyg">
         <input type="hidden" name="site_page[dashboard_setting][content_top]" value={this.state.topContent || ''} />
         <input type="hidden" name="site_page[dashboard_setting][content_bottom]" value={this.state.bottomContent || ''} />
         <Wysiwyg


### PR DESCRIPTION
This PR fixes an issue where the text elements of the dashboards would be narrower in the wysiwyg, affecting their alignment.

## Testing instructions

1. Open or create a dashboard page
2. Go to the Preview step
3. Add a text block with some content (a few lines)
4. Center the text by selecting it and choosing the alignment option from the floating menu

Make sure the text is correctly centred and that it can reach both sides of the layout.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/168355626).
