### PR TITLE
Map editor: allow the user to edit the HTML of the wysiwygs

### DIFF
--- a/app/assets/javascripts/routers/management/MapStepRouter.js
+++ b/app/assets/javascripts/routers/management/MapStepRouter.js
@@ -45,6 +45,7 @@
           ['style', ['bold', 'italic', 'underline', 'clear']],
           ['font', ['strikethrough', 'superscript', 'subscript']],
           ['para', ['ul', 'ol', 'paragraph']],
+          ['view', ['codeview']],
         ]
       });
     },


### PR DESCRIPTION
This PR allows the user to edit the HTML of the wysiwygs of the “Narrative” and “Alternative narrative” fields of the map configurations.

<p align="center">
<img width="532" alt="Wysiwyg with the code edition on" src="https://user-images.githubusercontent.com/6073968/73752932-b1de0380-4759-11ea-97c9-cf061fec5703.png">
</p>

## Testing instructions

1. Go to the management section of any site
2. Edit the map page
3. Click the “Map” tab
4. Go to the “Narrative” field and type some content
5. Click the last icon of the toolbar (the “Code view” one)

The content of the wysiwyg should be displayed as HTML.

6. Repeat the step 4-5 for the “Alternative narrative” field

The content of the wysiwyg should be displayed as HTML.

## Pivotal Tracker

[Task](https://www.pivotaltracker.com/story/show/168500479).
