### PR TITLE
Remove the widget's caption field from the UI

### DIFF
--- a/app/assets/stylesheets/layouts/management/l-widget-creation.scss
+++ b/app/assets/stylesheets/layouts/management/l-widget-creation.scss
@@ -44,6 +44,11 @@
 
       .c-we-widget-editor,
       .c-we-chart {
+        // Hack to temporarily hide the widget's caption before v2
+        input[name="widget-caption"] {
+          display: none;
+        }
+
         .c-we-vega-chart-legend {
           // Bootstrap default styles mess up with the
           // chart's legend

--- a/app/javascript/containers/ManagementDatasetMetadata.js
+++ b/app/javascript/containers/ManagementDatasetMetadata.js
@@ -143,7 +143,7 @@ const ManagementDatasetMetadata = ({ languages, defaultLanguage, metadata }) => 
                 Metadata is used to provide users with additional information about your dataset and links which let users access the original source data. Dataset metadata will be visible on dataset dashboard pages and should be entered in the primary language for your site. Metadata can also be translated into multiple languages if your site supports translations into multiple languages.
               </p>
               <p>
-                Please use the widget metadata tools to add metadata (title, caption, and description) for widgets embedded in open content pages.
+                Please use the widget metadata tools to add metadata (title, description and citation) for widgets embedded in open content pages.
               </p>
             </div>
             {languageOptions.map(({ value }) => (

--- a/app/javascript/pages/management/widgets/EditWidgetPage.js
+++ b/app/javascript/pages/management/widgets/EditWidgetPage.js
@@ -23,7 +23,6 @@ import {
   setStep,
   setWidgetCreationTitle,
   setWidgetCreationDescription,
-  setWidgetCreationCaption,
   setWidgetCreationPrivateName,
   setWidgetCreationCitation,
   setWidgetCreationAllowDownload
@@ -101,9 +100,6 @@ class EditWidgetPage extends React.Component {
       if (allowDownload !== undefined && allowDownload !== null) {
         this.props.setAllowDownload(allowDownload);
       }
-
-      const caption = metadata.info && metadata.info.caption;
-      if (caption) this.props.setCaption(caption);
     }
   }
 
@@ -246,7 +242,6 @@ class EditWidgetPage extends React.Component {
             privateName: this.props.privateName,
             citation: this.props.citation,
             allowDownload: this.props.allowDownload,
-            caption: this.props.caption
           }
         };
 
@@ -340,13 +335,11 @@ class EditWidgetPage extends React.Component {
       setDescription,
       setCitation,
       setAllowDownload,
-      setCaption,
       title,
       privateName,
       description,
       citation,
       allowDownload,
-      caption,
       widget
     } = this.props;
 
@@ -494,13 +487,11 @@ class EditWidgetPage extends React.Component {
                     datasetId={widget.dataset}
                     {...(widget ? { widgetId: widget.id } : {})}
                     widgetTitle={title}
-                    widgetCaption={caption}
                     theme={this.state.theme}
                     onChangeTheme={this.onCustomizeTheme}
                     saveButtonMode="never"
                     embedButtonMode="never"
                     onChangeWidgetTitle={t => setTitle(t)}
-                    onChangeWidgetCaption={c => setCaption(c)}
                     provideWidgetConfig={func => {
                       this.getWidgetConfig = func;
                     }}
@@ -509,24 +500,6 @@ class EditWidgetPage extends React.Component {
                 {advancedEditor && (
                   <div className="advanced-editor">
                     <div className="textarea-container">
-                      <div className="caption-container">
-                        <div className="c-inputs-container">
-                          <div className="container">
-                            <label htmlFor="widget-caption">
-                              Widget caption
-                            </label>
-                            <input
-                              type="text"
-                              id="widget-caption"
-                              name="widget-caption"
-                              value={caption}
-                              onChange={({ target }) =>
-                                setCaption(target.value)
-                              }
-                            />
-                          </div>
-                        </div>
-                      </div>
                       <p>{`Make sure you're using a syntax compatible with Vega ${
                         ENV.VEGA_VERSION.split('.')[0]
                       }. Please remove the "$schema" attribute from the specification.`}</p>
@@ -677,14 +650,12 @@ EditWidgetPage.propTypes = {
   description: PropTypes.string.isRequired,
   citation: PropTypes.string.isRequired,
   allowDownload: PropTypes.bool.isRequired,
-  caption: PropTypes.string.isRequired,
   setStep: PropTypes.func.isRequired,
   setTitle: PropTypes.func.isRequired,
   setPrivateName: PropTypes.func.isRequired,
   setDescription: PropTypes.func.isRequired,
   setCitation: PropTypes.func.isRequired,
   setAllowDownload: PropTypes.func.isRequired,
-  setCaption: PropTypes.func.isRequired,
   queryUrl: PropTypes.string.isRequired,
   redirectUrl: PropTypes.string.isRequired,
   defaultLanguage: PropTypes.string
@@ -704,7 +675,6 @@ function mapStateToProps(state) {
     description: state.management.widgetCreation.description,
     citation: state.management.widgetCreation.citation,
     allowDownload: state.management.widgetCreation.allowDownload,
-    caption: state.management.widgetCreation.caption
   };
 }
 
@@ -719,7 +689,6 @@ function mapDispatchToProps(dispatch) {
     setCitation: (...params) => dispatch(setWidgetCreationCitation(...params)),
     setAllowDownload: (...params) =>
       dispatch(setWidgetCreationAllowDownload(...params)),
-    setCaption: (...params) => dispatch(setWidgetCreationCaption(...params))
   };
 }
 

--- a/app/javascript/pages/management/widgets/NewWidgetPage.js
+++ b/app/javascript/pages/management/widgets/NewWidgetPage.js
@@ -22,7 +22,6 @@ import {
   setWidgetCreationDataset,
   setWidgetCreationTitle,
   setWidgetCreationDescription,
-  setWidgetCreationCaption,
   setWidgetCreationPrivateName,
   setWidgetCreationCitation,
   setWidgetCreationAllowDownload
@@ -187,7 +186,6 @@ class NewWidgetPage extends React.Component {
             privateName: this.props.privateName,
             citation: this.props.citation,
             allowDownload: this.props.allowDownload,
-            caption: this.props.caption
           }
         };
 
@@ -341,13 +339,11 @@ class NewWidgetPage extends React.Component {
       setDescription,
       setCitation,
       setAllowDownload,
-      setCaption,
       title,
       privateName,
       description,
       citation,
       allowDownload,
-      caption,
       redirectUrl
     } = this.props;
 
@@ -514,14 +510,12 @@ class NewWidgetPage extends React.Component {
                   <WidgetEditor
                     datasetId={dataset}
                     widgetTitle={title}
-                    widgetCaption={caption}
                     theme={this.state.theme}
                     onChangeTheme={this.onCustomizeTheme}
                     saveButtonMode="never"
                     embedButtonMode="never"
                     useLayerEditor
                     onChangeWidgetTitle={t => setTitle(t)}
-                    onChangeWidgetCaption={c => setCaption(c)}
                     provideWidgetConfig={func => {
                       this.getWidgetConfig = func;
                     }}
@@ -533,24 +527,6 @@ class NewWidgetPage extends React.Component {
                 {advancedEditor && (
                   <div className="advanced-editor">
                     <div className="textarea-container">
-                      <div className="caption-container">
-                        <div className="c-inputs-container">
-                          <div className="container">
-                            <label htmlFor="widget-caption">
-                              Widget caption
-                            </label>
-                            <input
-                              type="text"
-                              id="widget-caption"
-                              name="widget-caption"
-                              value={caption}
-                              onChange={({ target }) =>
-                                setCaption(target.value)
-                              }
-                            />
-                          </div>
-                        </div>
-                      </div>
                       <p>{`Make sure you're using a syntax compatible with Vega ${
                         ENV.VEGA_VERSION.split('.')[0]
                       }. Please remove the "$schema" attribute from the specification.`}</p>
@@ -698,7 +674,6 @@ NewWidgetPage.propTypes = {
   description: PropTypes.string.isRequired,
   citation: PropTypes.string.isRequired,
   allowDownload: PropTypes.bool.isRequired,
-  caption: PropTypes.string.isRequired,
   setStep: PropTypes.func.isRequired,
   setDataset: PropTypes.func.isRequired,
   setTitle: PropTypes.func.isRequired,
@@ -706,7 +681,6 @@ NewWidgetPage.propTypes = {
   setDescription: PropTypes.func.isRequired,
   setCitation: PropTypes.func.isRequired,
   setAllowDownload: PropTypes.func.isRequired,
-  setCaption: PropTypes.func.isRequired,
   queryUrl: PropTypes.string.isRequired,
   redirectUrl: PropTypes.string.isRequired,
   defaultLanguage: PropTypes.string
@@ -726,7 +700,6 @@ function mapStateToProps(state) {
     description: state.management.widgetCreation.description,
     citation: state.management.widgetCreation.citation,
     allowDownload: state.management.widgetCreation.allowDownload,
-    caption: state.management.widgetCreation.caption
   };
 }
 
@@ -742,7 +715,6 @@ function mapDispatchToProps(dispatch) {
     setCitation: (...params) => dispatch(setWidgetCreationCitation(...params)),
     setAllowDownload: (...params) =>
       dispatch(setWidgetCreationAllowDownload(...params)),
-    setCaption: (...params) => dispatch(setWidgetCreationCaption(...params))
   };
 }
 

--- a/app/javascript/redactions/management.js
+++ b/app/javascript/redactions/management.js
@@ -7,7 +7,6 @@ const initialState = {
     description: '',
     citation: '',
     allowDownload: true,
-    caption: ''
   }
 };
 
@@ -18,7 +17,6 @@ export const SET_WIDGET_CREATION_PRIVATE_NAME = '@management/SET_WIDGET_CREATION
 export const SET_WIDGET_CREATION_DESCRIPTION = '@management/SET_WIDGET_CREATION_DESCRIPTION';
 export const SET_WIDGET_CREATION_CITATION = '@management/SET_WIDGET_CREATION_CITATION';
 export const SET_WIDGET_CREATION_ALLOW_DOWNLOAD = '@management/SET_WIDGET_CREATION_ALLOW_DOWNLOAD';
-export const SET_WIDGET_CREATION_CAPTION = '@management/SET_WIDGET_CREATION_CAPTION';
 
 export function setStep(step) {
   return {
@@ -69,13 +67,6 @@ export function setWidgetCreationAllowDownload(allowDownload) {
   };
 }
 
-export function setWidgetCreationCaption(caption) {
-  return {
-    type: SET_WIDGET_CREATION_CAPTION,
-    payload: caption
-  };
-}
-
 export default (state = initialState, action) => {
   switch (action.type) {
     case SET_STEP:
@@ -92,8 +83,6 @@ export default (state = initialState, action) => {
       return { ...state, widgetCreation: { ...state.widgetCreation, citation: action.payload } };
     case SET_WIDGET_CREATION_ALLOW_DOWNLOAD:
       return { ...state, widgetCreation: { ...state.widgetCreation, allowDownload: action.payload } };
-    case SET_WIDGET_CREATION_CAPTION:
-      return { ...state, widgetCreation: { ...state.widgetCreation, caption: action.payload } };
     default:
       return state;
   }


### PR DESCRIPTION
This PR removes the widget's caption field from all the UI.

For the widget-editor, we use a temporal hack to hide it. It will be completely removed in v2.

## Testing instructions

1. Click the button to create a new widget
2. Select a dataset and click “Continue”
3. Give the widget a name and click “Continue”

In the widget-editor, make sure there's no caption field display below the title one.

4. Click the “Advanced editor” tab

Make sure there's no “Caption” field above the JSON editor.

5. Repeat the steps 1-4 with the edit page

## Pivotal Tracker

Comment on [this task](https://www.pivotaltracker.com/story/show/170235238/comments/211121321).
