### PR TITLE
Unify footer buttons on open_content and dashboard/link pages

### DIFF
--- a/app/controllers/management/page_steps_controller.rb
+++ b/app/controllers/management/page_steps_controller.rb
@@ -22,6 +22,7 @@ class Management::PageStepsController < ManagementController
   CONTINUE = 'CONTINUE'.freeze
   SAVE = 'SAVE'.freeze
   PUBLISH = 'PUBLISH'.freeze
+  UNPUBLISH = 'UNPUBLISH'.freeze
 
 
   # TODO : create a session for incorrect state and last step visited (?)
@@ -512,7 +513,8 @@ class Management::PageStepsController < ManagementController
   # Returns true if the button pressed was publish
   def publish_button?
     return false unless params[:button]
-    return params[:button].upcase == PUBLISH.upcase
+
+    [PUBLISH, UNPUBLISH].include? params[:button].upcase
   end
 
   # Saves the current state and goes to the next step

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -1,0 +1,13 @@
+module FooterHelper
+  def save_button?(object_id, always_save, never_save)
+    object_id || (always_save && never_save != true)
+  end
+
+  def continue_button_type(object_id, always_save, never_save, publish)
+    if save_button?(object_id, always_save, never_save) || publish
+      'button'
+    else
+      'submit'
+    end
+  end
+end

--- a/app/views/management/page_steps/open_content_v2.html.erb
+++ b/app/views/management/page_steps/open_content_v2.html.erb
@@ -26,6 +26,6 @@
 
   </div>
 
-  <%= render partial: 'management/steps_shared/footer', locals: {f: f, no_continue: true, always_save: true, publish: !@page.enabled} %>
+  <%= render partial: 'management/steps_shared/footer', locals: {f: f} %>
   <%= render partial: 'shared/errors', locals: { resource: @page } %>
 <% end %>

--- a/app/views/management/page_steps/open_content_v2_preview.html.erb
+++ b/app/views/management/page_steps/open_content_v2_preview.html.erb
@@ -14,5 +14,6 @@
 
 <%= Gon::Base.render_data(camel_case: true, camel_depth: 3) %>
 <%= form_for @page, url: wizard_path, method: :put do |f| %>
+  <%= f.hidden_field :content %>
   <%= render partial: 'management/steps_shared/finish_footer', locals: {f: f} %>
 <% end %>

--- a/app/views/management/page_steps/preview.html.erb
+++ b/app/views/management/page_steps/preview.html.erb
@@ -30,7 +30,7 @@
     }) %>
   </div>
 
-  <%= render partial: 'management/steps_shared/footer', locals: {f: f, always_save: true, no_continue: true, wide: true } %>
+  <%= render partial: 'management/steps_shared/footer', locals: {f: f, always_save: true, no_continue: true, publish: true, wide: true } %>
 <% end %>
 <%= render partial: 'shared/errors', locals: { resource: @page} %>
 

--- a/app/views/management/steps_shared/_finish_footer.html.erb
+++ b/app/views/management/steps_shared/_finish_footer.html.erb
@@ -2,8 +2,15 @@
   <div class="wrapper">
     <%= link_to 'Cancel', management_site_site_pages_path(@site.slug), class: 'c-button -outline -dark-text' %>
     <div>
-      <%= f.button (@page.enabled ? 'Unpublish' : 'Publish'), value: Management::PageStepsController::PUBLISH, type: 'submit', class: 'c-button js-submit' %>
-      <%= link_to 'Go to live page', @page.site.routes.first.host_with_scheme + @page.url, target: '_blank', class: 'c-button' if @page.enabled  %>
+      <%= f.button Management::PageStepsController::SAVE, value: Management::PageStepsController::SAVE, type: 'submit', class: 'c-button js-submit' %>
+
+      <% if @page.persisted? %>
+        <% if @page.enabled %>
+          <%= f.button Management::PageStepsController::UNPUBLISH, value: Management::PageStepsController::UNPUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
+        <% else %>
+          <%= f.button Management::PageStepsController::PUBLISH, value: Management::PageStepsController::PUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/management/steps_shared/_finish_footer.html.erb
+++ b/app/views/management/steps_shared/_finish_footer.html.erb
@@ -2,14 +2,21 @@
   <div class="wrapper">
     <%= link_to 'Cancel', management_site_site_pages_path(@site.slug), class: 'c-button -outline -dark-text' %>
     <div>
-      <%= f.button Management::PageStepsController::SAVE, value: Management::PageStepsController::SAVE, type: 'submit', class: 'c-button js-submit' %>
+      <%= f.button Management::PageStepsController::SAVE,
+        type: 'button',
+        value: Management::PageStepsController::SAVE,
+        class: 'c-button -outline -dark-text' %>
 
-      <% if @page.persisted? %>
-        <% if @page.enabled %>
-          <%= f.button Management::PageStepsController::UNPUBLISH, value: Management::PageStepsController::UNPUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
-        <% else %>
-          <%= f.button Management::PageStepsController::PUBLISH, value: Management::PageStepsController::PUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
-        <% end %>
+      <% if @page.enabled %>
+        <%= f.button Management::PageStepsController::UNPUBLISH,
+          value: Management::PageStepsController::UNPUBLISH,
+          type: 'submit',
+          class: 'c-button js-submit' %>
+      <% else %>
+        <%= f.button Management::PageStepsController::PUBLISH,
+        value: Management::PageStepsController::PUBLISH,
+        type: 'submit',
+        class: 'c-button js-submit' %>
       <% end %>
     </div>
   </div>

--- a/app/views/management/steps_shared/_footer.html.erb
+++ b/app/views/management/steps_shared/_footer.html.erb
@@ -7,16 +7,30 @@
   <% end %>
     <div>
       <% unless local_assigns[:no_continue] %>
-        <%= f.button Management::PageStepsController::CONTINUE, value: Management::PageStepsController::CONTINUE, type: 'submit', class: 'c-button js-submit' + ((f.object.id || local_assigns[:always_save]) ? ' -outline -dark-text' : '') %>
+        <%= f.button Management::PageStepsController::CONTINUE,
+          type: continue_button_type(f.object.id, local_assigns[:always_save], local_assigns[:never_save], local_assigns[:publish]),
+          value: Management::PageStepsController::CONTINUE,
+          class: "c-button #{(f.object.id || local_assigns[:always_save]) ? ' -outline -dark-text' : 'js-submit'}" %>
       <% end %>
-      <% if (f.object.id || local_assigns[:always_save]) && (local_assigns[:never_save] != true) %>
-        <%= f.button Management::PageStepsController::SAVE, value: Management::PageStepsController::SAVE, type: 'submit', class: 'c-button js-submit' %>
+
+      <% if save_button?(f.object.id, local_assigns[:always_save], local_assigns[:never_save]) %>
+        <%= f.button Management::PageStepsController::SAVE,
+          value: Management::PageStepsController::SAVE,
+          type: local_assigns[:publish] ? 'button' : 'submit',
+          class: "c-button #{local_assigns[:publish] ? '-outline -dark-text' : 'js-submit'}" %>
       <% end %>
+
       <% if local_assigns[:publish] %>
         <% if @page.enabled %>
-          <%= f.button Management::PageStepsController::UNPUBLISH, value: Management::PageStepsController::UNPUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
+          <%= f.button Management::PageStepsController::UNPUBLISH,
+            value: Management::PageStepsController::UNPUBLISH,
+            type: 'submit',
+            class: 'c-button js-submit' %>
         <% else %>
-          <%= f.button Management::PageStepsController::PUBLISH, value: Management::PageStepsController::PUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
+          <%= f.button Management::PageStepsController::PUBLISH,
+            value: Management::PageStepsController::PUBLISH,
+            type: 'submit',
+            class: 'c-button js-submit' %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/management/steps_shared/_footer.html.erb
+++ b/app/views/management/steps_shared/_footer.html.erb
@@ -13,8 +13,12 @@
         <%= f.button Management::PageStepsController::SAVE, value: Management::PageStepsController::SAVE, type: 'submit', class: 'c-button js-submit' %>
       <% end %>
       <% if local_assigns[:publish] %>
-        <%= f.button Management::PageStepsController::PUBLISH, value: Management::PageStepsController::PUBLISH, type: 'submit', class: 'c-button' %>
-    <% end %>
+        <% if @page.enabled %>
+          <%= f.button Management::PageStepsController::UNPUBLISH, value: Management::PageStepsController::UNPUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
+        <% else %>
+          <%= f.button Management::PageStepsController::PUBLISH, value: Management::PageStepsController::PUBLISH, type: 'submit', class: 'c-button -outline -dark-text' %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Unify cancel, save and publish/unpublish buttons on the different pages

## Testing instructions

1. Create an open content page
2. Check that only appears Cancel, Save and Publish/Unpublish buttons

---

1. Create a dashboard or link page
2. Check that only appears Cancel, Save and Publish/Unpublish buttons

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/169907748](https://www.pivotaltracker.com/story/show/169907748)
