### PR TITLE
Fix bug with layerPanel and analysisModules on map site pages

### DIFF
--- a/app/helpers/site_pages_helper.rb
+++ b/app/helpers/site_pages_helper.rb
@@ -1,5 +1,4 @@
 module SitePagesHelper
-
   def nested_page_links(parent)
     content_tag(:ul, class: (parent.parent.nil? ? 'sitemap' : '')) do
       if parent.parent.nil? # add homepage
@@ -13,9 +12,16 @@ module SitePagesHelper
           else
             link_to(page.name, page.url)
           end
-        end)    
+        end)
       end
     end
   end
 
+  def parse_map_field(field)
+    field = field.is_a?(Hash) ? field.to_json : JSON.parse(field).to_json
+    field = field.blank? ? '{}' : field
+    field.squish.gsub("'", "\\\\'").html_safe
+  rescue
+    '{}'
+  end
 end

--- a/app/services/site_creator.rb
+++ b/app/services/site_creator.rb
@@ -19,10 +19,27 @@ class SiteCreator
                   page.content
                 end
 
+      if page.name == 'Map'
+        content = JSON.parse page.content['settings']
+
+        default_map = MapVersion.order(:position).first.default_settings
+        default_map_hash = JSON.parse default_map['settings']
+
+        if default_map_hash['layerPanel']
+          content['layerPanel'] = default_map_hash['layerPanel'].to_json
+        end
+
+        if default_map_hash['analysisModules']
+          content['analysisModules'] = default_map_hash['analysisModules'].to_json
+        end
+
+        page.content['settings'] = content.to_json
+      end
+
       new_page = SitePage.create!(
         name: page.name,
         description: page.description,
-        content: content,
+        content: page.content,
         uri: page.uri,
         site: site,
         show_on_menu: page.show_on_menu,

--- a/app/views/management/site_pages/map/_analysis.html.erb
+++ b/app/views/management/site_pages/map/_analysis.html.erb
@@ -23,12 +23,8 @@
           } catch (e) {}
         }
       });
-      var analysisModulesValue;
-      try {
-        analysisModulesValue = JSON.parse('<%= settings.object.analysisModules.squish.gsub("'", "\\\\'").squish.html_safe %>');
-      } catch (err) {
-        analysisModulesValue = JSON.parse('{}');
-      }
+
+      var analysisModulesValue = JSON.parse('<%= parse_map_field(settings.object.analysisModules) %>');
 
       analysisModulesContainer.editor = analysisModulesEditor;
       analysisModulesContainer.input = analysisModulesInput;

--- a/app/views/management/site_pages/map/_analysis.html.erb
+++ b/app/views/management/site_pages/map/_analysis.html.erb
@@ -25,7 +25,7 @@
       });
       var analysisModulesValue;
       try {
-        analysisModulesValue = JSON.parse('<%= settings.object.analysisModules.gsub("'", "\\\\'").squish.html_safe rescue {} %>');
+        analysisModulesValue = JSON.parse('<%= settings.object.analysisModules.squish.gsub("'", "\\\\'").squish.html_safe %>');
       } catch (err) {
         analysisModulesValue = JSON.parse('{}');
       }

--- a/app/views/management/site_pages/map/_layer_panel.html.erb
+++ b/app/views/management/site_pages/map/_layer_panel.html.erb
@@ -22,13 +22,8 @@
           } catch (e) {}
         }
       });
-      var layerPanelValue;
-      try {
-        layerPanelValue = JSON.parse('<%= settings.object.layerPanel.squish.gsub("'", "\\\\'").html_safe rescue {} %>');
-      } catch (err) {
-        console.log(err);
-        layerPanelValue = JSON.parse('{}');
-      }
+
+      var layerPanelValue = JSON.parse('<%= parse_map_field(settings.object.layerPanel) %>');
 
       layerPanelContainer.editor = layerPanelEditor;
       layerPanelContainer.input = layerPanelInput;

--- a/app/views/management/site_pages/map/_others_panel.html.erb
+++ b/app/views/management/site_pages/map/_others_panel.html.erb
@@ -23,12 +23,8 @@
           } catch (e) {}
         }
       });
-      var otherFieldsModulesValue;
-      try {
-        otherFieldsModulesValue = JSON.parse('<%= settings.object.otherFieldsModules.gsub("'", "\\\\'").squish.html_safe rescue {} %>');
-      } catch (err) {
-        otherFieldsModulesValue = JSON.parse('{}');
-      }
+
+      var otherFieldsModulesValue = JSON.parse('<%= parse_map_field(settings.object.otherFieldsModules) %>');
 
       otherFieldsModulesContainer.editor = otherFieldsModulesEditor;
       otherFieldsModulesContainer.input = otherFieldsModulesInput;


### PR DESCRIPTION
Fix bug with the default map site page created when we create a new site. The `layerPanel` and `analysisModules` fields appeared with an empty json.

## Testing instructions

1. Create a new site of the Map type
2. Access to the map site page of the new site
3. Check that the `layerPanel` and `analysisModules` appears with the default information

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/164712996](https://www.pivotaltracker.com/story/show/164712996)