### PR TITLE
Remove widgets list message when there are no widgets

### DIFF
--- a/app/javascript/containers/DatasetsPage.js
+++ b/app/javascript/containers/DatasetsPage.js
@@ -68,7 +68,7 @@ class DatasetsPage extends React.Component {
           >
             <div className="details-modal">
               <h1>Are you sure you want to delete this dataset?</h1>
-              {selectedRow.widgets.value && (
+              {selectedRow.widgets.value.length !== 0 && (
                 <div>
                   <p>
                     The deletion {'can\'t'} be reversed and the following widgets will be


### PR DESCRIPTION
This PR removes the message on the delete modal when there are no widgets

## Testing instructions

1. Access to the list of datasets
2. Click on a delete button of a datasets not associated with any widgets
3. Check that there is no list of widgets message

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/171626065](https://www.pivotaltracker.com/story/show/171626065)