### PR TITLE
Add permissions to create users for site admins

### DIFF
--- a/app/controllers/management/users_controller.rb
+++ b/app/controllers/management/users_controller.rb
@@ -48,7 +48,8 @@ class Management::UsersController < ManagementController
   def create_and_grant_access(role)
     @user = User.new(user_params.except(:site_role))
     if @user.valid?
-      api_response = @user.send_to_api(session[:user_token], management_url)
+      api_response = @user.send_to_api(user_token(@site), management_url)
+
       if api_response[:valid]
         @user.save
         @usa = @user.user_site_associations.build(site: @site, role: role).save


### PR DESCRIPTION
This PR add permissions 

## Testing instructions

1. Login with an site admin user
2. Access to the users list of a site where the user is a Site Admin
3. Create a new user
4. Check that the user has been persisted

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/162107867](https://www.pivotaltracker.com/story/show/162107867)
