### PR TITLE
Fix save button when submitting in the preview page

### DIFF
--- a/app/views/management/steps_shared/_footer.html.erb
+++ b/app/views/management/steps_shared/_footer.html.erb
@@ -7,6 +7,9 @@
   <% end %>
     <div>
       <% if !local_assigns.key?(:continue) || local_assigns[:continue] %>
+        <% if local_assigns[:publish] %>
+          <input type="hidden" name="button" value=<%= Management::PageStepsController::CONTINUE %> />
+        <% end %>
         <%= f.button Management::PageStepsController::CONTINUE,
           id: 'testing',
           type: continue_button_type(f.object.id, local_assigns[:always_save], local_assigns[:never_save], local_assigns[:publish]),
@@ -16,6 +19,9 @@
       <% end %>
 
       <% if save_button?(f.object.id, local_assigns[:always_save], local_assigns[:never_save]) %>
+        <% if local_assigns[:publish] %>
+          <input type="hidden" name="button" value=<%= Management::PageStepsController::SAVE %> />
+        <% end %>
         <%= f.button Management::PageStepsController::SAVE,
           value: Management::PageStepsController::SAVE,
           type: local_assigns[:publish] ? 'button' : 'submit',


### PR DESCRIPTION
This PR fixes the bug when clicking on the save button of the preview page, saving the page.

## Testing instructions

1. Create a new dashboard page
2. On the preview page, click on save button
3. The new dashboard page is saved

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/169907748](https://www.pivotaltracker.com/story/show/169907748)