### PR TITLE
Fix bug for using favicon on the widget pages

### DIFF
--- a/app/services/widget_service.rb
+++ b/app/services/widget_service.rb
@@ -41,9 +41,8 @@ class WidgetService < ApiService
       user_email = widget_json.dig('data', 'attributes', 'user', 'email')
       if user_email
         user = User.find_by(email: user_email)
-        widget_json['data']['attributes']['user']['name'] = user.name
+        widget_json['data']['attributes']['user']['name'] = user&.name
       end
-
       widget = Widget.new widget_json['data']
     rescue Exception
       return nil

--- a/app/views/layouts/standalone.html.erb
+++ b/app/views/layouts/standalone.html.erb
@@ -10,8 +10,10 @@
 
   <meta property="og:title" content="<%= @title %>" />
 
-  <link rel="icon" type="image/png" href="<%= @favico %>" />
-  <link rel="apple-touch-icon" href="<%= @favico %>">
+  <% if @favico %>
+    <link rel="icon" type="image/png" href="<%= @favico %>" />
+    <link rel="apple-touch-icon" href="<%= @favico %>">
+  <% end %>
   <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700" rel="stylesheet">
 
   <%= stylesheet_link_tag 'front/application-theme-default', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,6 +14,6 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('tmp', 'compiled_css')
 
 Rails.application.config.assets.precompile += %w( management.js admin.js )
-Rails.application.config.assets.precompile += %w( admin/application.css management/application.css)
+Rails.application.config.assets.precompile += %w( admin/application.css management/application.css front/application-theme-default.css)
 # The precompilation of the front assets is no longer needed
 #Rails.application.config.assets.precompile += %w( admin/application.css management/application.css front/application-theme-fa.css front/application-theme-lsa.css front/application-theme-carpe.css )


### PR DESCRIPTION
This PR fix the but when rendering widgets

## Testing instructions

1. Go the preview of a widget
2. Click on the PNG download
3. Check that the generated picture is right

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/170233894](https://www.pivotaltracker.com/story/show/170233894)