### PR TITLE
Fix bug when there is no aliases for a dataset

### DIFF
--- a/app/javascript/containers/ManagementDatasetAliases.js
+++ b/app/javascript/containers/ManagementDatasetAliases.js
@@ -3,37 +3,53 @@ import PropTypes from 'prop-types';
 
 import ManagementContainer from 'containers/shared/ManagementContainer';
 
+const renderAliasesColumn = (column, index, defaultLanguage) => (
+  <div key={column.name} className="row">
+    <div className="column column-3">
+      <label htmlFor={`dataset-metadata-name-${index}`}>
+        Column name
+      </label>
+      <input type="text" id={`dataset-metadata-name-${index}`} name={`dataset[metadata][${defaultLanguage}][columns][${column.name}][name]`} defaultValue={column.name || ''} disabled />
+    </div>
+    <div className="column column-3">
+      <label htmlFor={`dataset-metadata-alias-${index}`}>
+        Alias
+      </label>
+      <input type="text" id={`dataset-metadata-alias-${index}`} name={`dataset[metadata][${defaultLanguage}][columns][${column.name}][alias]`} defaultValue={column.alias || ''} placeholder="No alias" />
+    </div>
+    <div className="column column-3">
+      <label htmlFor={`dataset-metadata-description-${index}`}>
+        Description
+      </label>
+      <textarea id={`dataset-metadata-description-${index}`} name={`dataset[metadata][${defaultLanguage}][columns][${column.name}][description]`} defaultValue={column.description || ''} placeholder="Empty description" />
+    </div>
+  </div>
+);
+
+const renderAliases = (metadataId, defaultLanguage, columns) => {
+  if (columns.length === 0) {
+    return (
+      <div className="intro">
+        <p>There are no columns for the dataset</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="c-inputs-container -large">
+      <div className="container -flex">
+        <input type="hidden" id="dataset-metadata-id" name={`dataset[metadata][${defaultLanguage}][id]`} defaultValue={metadataId} />
+        {columns.map((column, index) => renderAliasesColumn(column, index, defaultLanguage))}
+      </div>
+    </div>
+  );
+}
+
 const ManagementDatasetAliases = ({ metadataId, defaultLanguage, columns }) => (
   <ManagementContainer>
     <div className="l-dataset-creation -aliases">
       <div className="wrapper">
-        <div className="c-inputs-container -large">
-          <div className="container -flex">
-            <input type="hidden" id="dataset-metadata-id" name={`dataset[metadata][${defaultLanguage}][id]`} defaultValue={metadataId} />
-            {columns.map((column, index) => (
-              <div key={column.name} className="row">
-                <div className="column column-3">
-                  <label htmlFor={`dataset-metadata-name-${index}`}>
-                    Column name
-                  </label>
-                  <input type="text" id={`dataset-metadata-name-${index}`} name={`dataset[metadata][${defaultLanguage}][columns][${column.name}][name]`} defaultValue={column.name || ''} disabled />
-                </div>
-                <div className="column column-3">
-                  <label htmlFor={`dataset-metadata-alias-${index}`}>
-                    Alias
-                  </label>
-                  <input type="text" id={`dataset-metadata-alias-${index}`} name={`dataset[metadata][${defaultLanguage}][columns][${column.name}][alias]`} defaultValue={column.alias || ''} placeholder="No alias" />
-                </div>
-                <div className="column column-3">
-                  <label htmlFor={`dataset-metadata-description-${index}`}>
-                    Description
-                  </label>
-                  <textarea id={`dataset-metadata-description-${index}`} name={`dataset[metadata][${defaultLanguage}][columns][${column.name}][description]`} defaultValue={column.description || ''} placeholder="Empty description" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+        {renderAliases(metadataId, defaultLanguage, columns)}
       </div>
     </div>
   </ManagementContainer>

--- a/app/services/dataset_service.rb
+++ b/app/services/dataset_service.rb
@@ -41,15 +41,19 @@ class DatasetService < ApiService
   # Params
   # +dataset_id+:: The id of the dataset
   # +api_table_name+:: The name of the database's table
-  def self.get_fields(dataset_id, api_table_name)
-    fields_request = @conn.get "/fields/#{dataset_id}"
+  def self.get_fields(dataset_id, api_table_name, token = nil)
+    fields_request = @conn.get do |req|
+      req.url "/fields/#{dataset_id}"
+      req.headers['Authorization'] = "Bearer #{token}" if token
+    end
+
     fields_json = JSON.parse fields_request.body
 
     return {} if fields_json.empty? || !fields_request.success?
 
     fields = []
 
-    fields_json['fields'].each do |data|
+    fields_json&.dig('fields')&.each do |data|
       if DatasetFieldsHelper.is_valid? data.last['type']
         fields << {name: data.first, type: data.last['type']}
       end


### PR DESCRIPTION
This PR fixes the bug on the Alises section of datasets when there are no options.

## Testing instructions

1. Create or access to a datasets which don't have any aliases.
2. Check that the page is not blank and it contains a new message.

![Screenshot 2020-03-30 at 12 34 01](https://user-images.githubusercontent.com/44865682/77903212-c84c9b00-7282-11ea-9631-fcd403602c35.png)

## Pivotal Tracker

[https://www.pivotaltracker.com/story/show/170086353](https://www.pivotaltracker.com/story/show/170086353)